### PR TITLE
Send slack notifications to custom channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,7 @@ jobs:
       - name: "Slack Notification"
         uses: "rtCamp/action-slack-notify@v2"
         env:
+          SLACK_CHANNEL:    "team-content"
           SLACK_TITLE:      "Something broke CI for floxenvs"
           SLACK_FOOTER:     "Thank you for caring"
           SLACK_WEBHOOK:    "${{ secrets.MANAGED_SLACK_WEBHOOK }}"


### PR DESCRIPTION
Try if providing a  custom SLACK_CHANNEL is able to override the channel set in the webhook.