### PR TITLE
feat: add mongodb example env

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 | `cassandra` | ✅ | ✅ | ✅ | |
 | `elasticsearch` | ✅ | ✅ | ✅ | |
 | `mysql` | ✅ | ✅ | ✅ | |
+| `mongodb` | ✅ | ✅ | | |
 | **Shell:** |
 | `dotenv` | ✅ | ✅ | ✅ | Load .env environment variables |
 | `mkcert` | ✅ | ✅ | ✅ | A tool to make locally trusted development certificates |

--- a/mongodb/.flox/.gitignore
+++ b/mongodb/.flox/.gitignore
@@ -1,0 +1,4 @@
+run/
+cache/
+lib/
+log/

--- a/mongodb/.flox/env.json
+++ b/mongodb/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "mongodb",
+  "version": 1
+}

--- a/mongodb/.flox/env/manifest.lock
+++ b/mongodb/.flox/env/manifest.lock
@@ -1,0 +1,296 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "version": 1,
+    "install": {
+      "mongodb-ce": {
+        "pkg-path": "mongodb-ce",
+        "version": "7.0.12"
+      },
+      "mongosh": {
+        "pkg-path": "mongosh"
+      }
+    },
+    "vars": {
+      "MONGO_HOST": "127.0.0.1",
+      "MONGO_PORT": "27017"
+    },
+    "hook": {
+      "on-activate": "export MONGO_HOME=\"$FLOX_ENV_CACHE/mongodb\"\nexport MONGO_CONFIG=\"$MONGO_HOME/mongod.conf\"\nif [ ! -d \"$MONGO_HOME\" ]; then\n  mkdir -m 0700 -p \"$MONGO_HOME\"\nfi\nif [ ! -d \"$MONGO_HOME/logs\" ]; then\n  mkdir -m 0700 -p \"$MONGO_HOME/logs\"\nfi\n\ncat >$MONGO_CONFIG <<EOF \nstorage:\n  dbPath: \"$MONGO_HOME\"\nnet:\n  bindIp: $MONGO_HOST, ::1\n  ipv6: true\nreplication:\n  replSetName: dev-rs\nEOF\n"
+    },
+    "profile": {
+      "common": "echo \"\"\necho \"     ╔══════════════════════════════════════════════════════╗\"\necho \"     ║                                                      ║\"\necho \"     ║  Start Mongodb in the background:                    ║\"\necho \"     ║  👉 flox services start                              ║\"\necho \"     ║  👉 flox activate --start-services                   ║\"\necho \"     ║                                                      ║\"\necho \"     ║  Try to connect to MongoDB:                          ║\"\necho \"     ║  👉 mongosh --host $MONGO_HOST --port $MONGO_PORT    ║\"\necho \"     ║                                                      ║\"\necho \"     ╚══════════════════════════════════════════════════════╝\"\necho \"\"\n"
+    },
+    "options": {
+      "systems": [
+        "aarch64-darwin",
+        "aarch64-linux",
+        "x86_64-darwin",
+        "x86_64-linux"
+      ],
+      "allow": {
+        "licenses": []
+      },
+      "semver": {}
+    },
+    "services": {
+      "mongodb": {
+        "command": "mongod --config $MONGO_HOME/mongod.conf",
+        "vars": null,
+        "is-daemon": null,
+        "shutdown": null,
+        "systems": null
+      }
+    }
+  },
+  "packages": [
+    {
+      "attr_path": "mongodb-ce",
+      "broken": false,
+      "derivation": "/nix/store/l3jis161l9fhp6ncvxawzam1cz2bc1d7-mongodb-ce-7.0.12.drv",
+      "description": "MongoDB is a general purpose, document-based, distributed database.",
+      "install_id": "mongodb-ce",
+      "license": "[ Server Side Public License ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "name": "mongodb-ce-7.0.12",
+      "pname": "mongodb-ce",
+      "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "rev_count": 672439,
+      "rev_date": "2024-08-28T04:32:53Z",
+      "scrape_date": "2024-08-30T05:22:14Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "7.0.12",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/hv3yir19hrlah781cf7pxjjjxzpv6lxj-mongodb-ce-7.0.12"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "mongodb-ce",
+      "broken": false,
+      "derivation": "/nix/store/cyaj07z5cph51ypnq4ari3lvr0qbgykr-mongodb-ce-7.0.12.drv",
+      "description": "MongoDB is a general purpose, document-based, distributed database.",
+      "install_id": "mongodb-ce",
+      "license": "[ Server Side Public License ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "name": "mongodb-ce-7.0.12",
+      "pname": "mongodb-ce",
+      "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "rev_count": 672439,
+      "rev_date": "2024-08-28T04:32:53Z",
+      "scrape_date": "2024-08-30T05:22:14Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "7.0.12",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/c4ksf6hp38ayqc0m7agy47nk5bm1syr5-mongodb-ce-7.0.12"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "mongodb-ce",
+      "broken": false,
+      "derivation": "/nix/store/jlpfhsddwk4fg0cpgjmicvmw3v2609zn-mongodb-ce-7.0.12.drv",
+      "description": "MongoDB is a general purpose, document-based, distributed database.",
+      "install_id": "mongodb-ce",
+      "license": "[ Server Side Public License ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "name": "mongodb-ce-7.0.12",
+      "pname": "mongodb-ce",
+      "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "rev_count": 672439,
+      "rev_date": "2024-08-28T04:32:53Z",
+      "scrape_date": "2024-08-30T05:22:14Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "7.0.12",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/fbd13fybfw35yg2nv0v5sws54g570dfi-mongodb-ce-7.0.12"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "mongodb-ce",
+      "broken": false,
+      "derivation": "/nix/store/jr3q5i6fmlw8fwbsmvh2mc80i5vs16i5-mongodb-ce-7.0.12.drv",
+      "description": "MongoDB is a general purpose, document-based, distributed database.",
+      "install_id": "mongodb-ce",
+      "license": "[ Server Side Public License ]",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "name": "mongodb-ce-7.0.12",
+      "pname": "mongodb-ce",
+      "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "rev_count": 672439,
+      "rev_date": "2024-08-28T04:32:53Z",
+      "scrape_date": "2024-08-30T05:22:14Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "7.0.12",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gs07a3wj1vsx433j59yrigq0lbwrczx4-mongodb-ce-7.0.12"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "mongosh",
+      "broken": false,
+      "derivation": "/nix/store/1iskndxb0cchak563090vrqi41pif6y4-mongosh-2.3.0.drv",
+      "description": "MongoDB Shell",
+      "install_id": "mongosh",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "name": "mongosh-2.3.0",
+      "pname": "mongosh",
+      "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "rev_count": 672439,
+      "rev_date": "2024-08-28T04:32:53Z",
+      "scrape_date": "2024-08-30T05:22:14Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.3.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/wvl39r8ayk2fvgahirncxzmfpi5vakk2-mongosh-2.3.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "mongosh",
+      "broken": false,
+      "derivation": "/nix/store/60ha2vv58hzgxkp16cj1n4xcdph4annx-mongosh-2.3.0.drv",
+      "description": "MongoDB Shell",
+      "install_id": "mongosh",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "name": "mongosh-2.3.0",
+      "pname": "mongosh",
+      "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "rev_count": 672439,
+      "rev_date": "2024-08-28T04:32:53Z",
+      "scrape_date": "2024-08-30T05:22:14Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.3.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/cd6r771v02r6hxf47x5zfl30h4bbviwr-mongosh-2.3.0"
+      },
+      "system": "aarch64-linux",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "mongosh",
+      "broken": false,
+      "derivation": "/nix/store/qlaydbv1jzlm1l0bkrnjm58l6xfidby9-mongosh-2.3.0.drv",
+      "description": "MongoDB Shell",
+      "install_id": "mongosh",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "name": "mongosh-2.3.0",
+      "pname": "mongosh",
+      "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "rev_count": 672439,
+      "rev_date": "2024-08-28T04:32:53Z",
+      "scrape_date": "2024-08-30T05:22:14Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.3.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/66prjy5kwvlf7liqdfy2jkgk9580sf8x-mongosh-2.3.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "toplevel",
+      "priority": 5
+    },
+    {
+      "attr_path": "mongosh",
+      "broken": false,
+      "derivation": "/nix/store/yj2j7rj191pcqg0dvv1a12w09db4dhqq-mongosh-2.3.0.drv",
+      "description": "MongoDB Shell",
+      "install_id": "mongosh",
+      "license": "Apache-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "name": "mongosh-2.3.0",
+      "pname": "mongosh",
+      "rev": "71e91c409d1e654808b2621f28a327acfdad8dc2",
+      "rev_count": 672439,
+      "rev_date": "2024-08-28T04:32:53Z",
+      "scrape_date": "2024-08-30T05:22:14Z",
+      "stabilities": [
+        "stable",
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.3.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/0kclrh4x6y44dkdzwbx95i8326p0kg79-mongosh-2.3.0"
+      },
+      "system": "x86_64-linux",
+      "group": "toplevel",
+      "priority": 5
+    }
+  ]
+}

--- a/mongodb/.flox/env/manifest.toml
+++ b/mongodb/.flox/env/manifest.toml
@@ -1,0 +1,56 @@
+version = 1
+
+[install]
+mongodb-ce.pkg-path = "mongodb-ce"
+mongodb-ce.version = "7.0.12"
+mongosh.pkg-path = "mongosh"
+
+[vars]
+
+MONGO_HOST = "127.0.0.1"
+MONGO_PORT = "27017"
+
+[hook]
+on-activate = '''
+export MONGO_HOME="$FLOX_ENV_CACHE/mongodb"
+export MONGO_CONFIG="$MONGO_HOME/mongod.conf"
+if [ ! -d "$MONGO_HOME" ]; then
+  mkdir -m 0700 -p "$MONGO_HOME"
+fi
+
+cat >$MONGO_CONFIG <<EOF 
+storage:
+  dbPath: "$MONGO_HOME"
+net:
+  bindIp: $MONGO_HOST, ::1
+  ipv6: true
+EOF
+'''
+
+
+[profile]
+common = '''
+echo ""
+echo "     ╔══════════════════════════════════════════════════════╗"
+echo "     ║                                                      ║"
+echo "     ║  Start Mongodb in the background:                    ║"
+echo "     ║  👉 flox services start                              ║"
+echo "     ║  👉 flox activate --start-services                   ║"
+echo "     ║                                                      ║"
+echo "     ║  Try to connect to MongoDB:                          ║"
+echo "     ║  👉 mongosh --host $MONGO_HOST --port $MONGO_PORT    ║"
+echo "     ║                                                      ║"
+echo "     ╚══════════════════════════════════════════════════════╝"
+echo ""
+'''
+
+[services]
+mongodb.command = "mongod --config $MONGO_HOME/mongod.conf"
+
+[options]
+systems = [
+  "aarch64-darwin",
+  "aarch64-linux",
+  "x86_64-darwin",
+  "x86_64-linux",
+]

--- a/mongodb/test.sh
+++ b/mongodb/test.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if ! command -v mongod 2>&1 >/dev/null; then
+  echo "Error: 'mongod' command could not be found."
+  exit 1
+fi
+if ! command -v mongosh 2>&1 >/dev/null; then
+  echo "Error: 'mongosh' command could not be found."
+  exit 1
+fi
+
+MAX_ATTEMPTS=20
+echo -n ">>> Waiting for MongoDB to start .."
+while [ $MAX_ATTEMPTS -gt 0 ]; do
+  if mongosh --host $MONGO_HOST --port $MONGO_PORT --eval "db.adminCommand('ping')" >/dev/null 2>&1; then
+    echo -e "\n>>> MongoDB STARTED SUCCESSFULLY\n"
+    break
+  fi
+  echo -n ".."
+  MAX_ATTEMPTS=$((MAX_ATTEMPTS-1))
+  sleep 1
+done
+
+if [ $MAX_ATTEMPTS -eq 0 ]; then
+  echo -e "\nError: Failed to connect to MongoDB after 20 attempts"
+  exit 1
+fi
+
+echo ">>> flox services status"
+flox services status
+
+echo ">>> flox services logs monogodb"
+flox services logs mongodb
+
+MONGO_STATUS=$(mongosh --host $MONGO_HOST --port $MONGO_PORT --eval "db.serverStatus().ok" --quiet)
+if [ "$MONGO_STATUS" != "1" ]; then
+    echo "Error: MongoDB is not responding correctly."
+    exit 1
+fi
+echo ">>> MongoDB server status check ... OK"


### PR DESCRIPTION
Added new example environment for mongodb
- Created test file to verify mongod process started successfully
- Creates mongo config in flox cache
- Starts service with config file created in flox cache

```
~/d/f/mongodb ❯❯❯ flox activate -s                                                                                                                                                          
✅ You are now using the environment 'mongodb'.
To stop using this environment, type 'exit'


     ╔══════════════════════════════════════════════════════╗
     ║                                                      ║
     ║  Start Mongodb in the background:                    ║
     ║  👉 flox services start                              ║
     ║  👉 flox activate --start-services                   ║
     ║                                                      ║
     ║  Try to connect to MongoDB:                          ║
     ║  👉 mongosh --host 127.0.0.1 --port 27017    ║
     ║                                                      ║
     ╚══════════════════════════════════════════════════════╝

flox [mongodb] ~/d/f/mongodb ❯❯❯ ./test.sh                                                                                                                                                      
>>> Waiting for MongoDB to start ..
>>> MongoDB STARTED SUCCESSFULLY

>>> flox services status
NAME       STATUS            PID
mongodb    Running         64690

>>> flox services logs monogodb
{"t":{"$date":"2025-01-24T12:37:43.259-05:00"},"s":"I",  "c":"NETWORK",  "id":22943,   "ctx":"listener","msg":"Connection accepted","attr":{"remote":"127.0.0.1:58290","uuid":{"uuid":{"$uuid":"bd24cfd
f-4e33-4266-b43b-5a947be27ade"}},"connectionId":3,"connectionCount":3}}
{"t":{"$date":"2025-01-24T12:37:43.263-05:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn2","msg":"client metadata","attr":{"remote":"127.0.0.1:58289","client":"conn2","negotiatedCompressors
":[],"doc":{"application":{"name":"mongosh 2.3.0"},"driver":{"name":"nodejs|mongosh","version":"6.8.0|2.3.0"},"platform":"Node.js v20.15.1, LE","os":{"name":"darwin","architecture":"arm64","version":
"23.6.0","type":"Darwin"}}}}
{"t":{"$date":"2025-01-24T12:37:43.263-05:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn3","msg":"client metadata","attr":{"remote":"127.0.0.1:58290","client":"conn3","negotiatedCompressors
":[],"doc":{"application":{"name":"mongosh 2.3.0"},"driver":{"name":"nodejs|mongosh","version":"6.8.0|2.3.0"},"platform":"Node.js v20.15.1, LE","os":{"name":"darwin","architecture":"arm64","version":
"23.6.0","type":"Darwin"}}}}
{"t":{"$date":"2025-01-24T12:37:43.265-05:00"},"s":"I",  "c":"NETWORK",  "id":6788700, "ctx":"conn2","msg":"Received first command on ingress connection since session start or auth handshake","attr":
{"elapsedMillis":1}}
{"t":{"$date":"2025-01-24T12:37:43.265-05:00"},"s":"I",  "c":"NETWORK",  "id":22943,   "ctx":"listener","msg":"Connection accepted","attr":{"remote":"127.0.0.1:58291","uuid":{"uuid":{"$uuid":"0a9f4f5
f-ed82-4223-aca0-dbba3477e818"}},"connectionId":4,"connectionCount":4}}
{"t":{"$date":"2025-01-24T12:37:43.268-05:00"},"s":"I",  "c":"NETWORK",  "id":22943,   "ctx":"listener","msg":"Connection accepted","attr":{"remote":"127.0.0.1:58292","uuid":{"uuid":{"$uuid":"d4d3141
c-e2a5-45ee-acb7-fd3d66bb644c"}},"connectionId":5,"connectionCount":5}}
{"t":{"$date":"2025-01-24T12:37:43.270-05:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn4","msg":"client metadata","attr":{"remote":"127.0.0.1:58291","client":"conn4","negotiatedCompressors
":[],"doc":{"application":{"name":"mongosh 2.3.0"},"driver":{"name":"nodejs|mongosh","version":"6.8.0|2.3.0"},"platform":"Node.js v20.15.1, LE","os":{"name":"darwin","architecture":"arm64","version":
"23.6.0","type":"Darwin"}}}}
{"t":{"$date":"2025-01-24T12:37:43.271-05:00"},"s":"I",  "c":"NETWORK",  "id":51800,   "ctx":"conn5","msg":"client metadata","attr":{"remote":"127.0.0.1:58292","client":"conn5","negotiatedCompressors
":[],"doc":{"application":{"name":"mongosh 2.3.0"},"driver":{"name":"nodejs|mongosh","version":"6.8.0|2.3.0"},"platform":"Node.js v20.15.1, LE","os":{"name":"darwin","architecture":"arm64","version":
"23.6.0","type":"Darwin"}}}}
{"t":{"$date":"2025-01-24T12:37:43.273-05:00"},"s":"I",  "c":"NETWORK",  "id":6788700, "ctx":"conn4","msg":"Received first command on ingress connection since session start or auth handshake","attr":
{"elapsedMillis":3}}
{"t":{"$date":"2025-01-24T12:37:43.274-05:00"},"s":"I",  "c":"NETWORK",  "id":6788700, "ctx":"conn5","msg":"Received first command on ingress connection since session start or auth handshake","attr":
{"elapsedMillis":3}}
{"t":{"$date":"2025-01-24T12:37:43.283-05:00"},"s":"I",  "c":"NETWORK",  "id":22944,   "ctx":"conn4","msg":"Connection ended","attr":{"remote":"127.0.0.1:58291","uuid":{"uuid":{"$uuid":"0a9f4f5f-ed82
-4223-aca0-dbba3477e818"}},"connectionId":4,"connectionCount":4}}
{"t":{"$date":"2025-01-24T12:37:43.283-05:00"},"s":"I",  "c":"NETWORK",  "id":22944,   "ctx":"conn2","msg":"Connection ended","attr":{"remote":"127.0.0.1:58289","uuid":{"uuid":{"$uuid":"5c89328e-5407
-4d22-b971-1086f4a451fb"}},"connectionId":2,"connectionCount":3}}
{"t":{"$date":"2025-01-24T12:37:43.283-05:00"},"s":"I",  "c":"NETWORK",  "id":22944,   "ctx":"conn3","msg":"Connection ended","attr":{"remote":"127.0.0.1:58290","uuid":{"uuid":{"$uuid":"bd24cfdf-4e33
-4266-b43b-5a947be27ade"}},"connectionId":3,"connectionCount":2}}
{"t":{"$date":"2025-01-24T12:37:43.283-05:00"},"s":"I",  "c":"NETWORK",  "id":22944,   "ctx":"conn5","msg":"Connection ended","attr":{"remote":"127.0.0.1:58292","uuid":{"uuid":{"$uuid":"d4d3141c-e2a5-45ee-acb7-fd3d66bb644c"}},"connectionId":5,"connectionCount":1}}
{"t":{"$date":"2025-01-24T12:37:43.283-05:00"},"s":"I",  "c":"NETWORK",  "id":22944,   "ctx":"conn1","msg":"Connection ended","attr":{"remote":"127.0.0.1:58288","uuid":{"uuid":{"$uuid":"14fc708b-816b-4b73-91c0-238ffae0bbf1"}},"connectionId":1,"connectionCount":0}}
>>> MongoDB server status check ... OK
```