### PR TITLE
chore: Release 1.3.12

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,7 +89,7 @@
       },
       "original": {
         "owner": "flox",
-        "ref": "release-1.3.12",
+        "ref": "refs/tags/v1.3.12",
         "repo": "flox",
         "type": "github"
       }
@@ -150,11 +150,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1737062831,
-        "narHash": "sha256-Tbk1MZbtV2s5aG+iM99U8FqwxU/YNArMcWAv6clcsBc=",
+        "lastModified": 1738680400,
+        "narHash": "sha256-ooLh+XW8jfa+91F1nhf9OF7qhuA/y1ChLx6lXDNeY5U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5df43628fdf08d642be8ba5b3625a6c70731c19c",
+        "rev": "799ba5bffed04ced7067a91798353d360788b30d",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -80,16 +80,16 @@
         "t3-src": "t3-src"
       },
       "locked": {
-        "lastModified": 1737567930,
-        "narHash": "sha256-Fvcza4ffhFYrxC+az7jlX8xGf+mmlzqiczdfuaXYpdI=",
+        "lastModified": 1738438470,
+        "narHash": "sha256-zkDzMW/Zrmrhc59K3cu3sN4NZhTxGxeWByoYZRy4b/4=",
         "owner": "flox",
         "repo": "flox",
-        "rev": "9557a2067103a9527a07aee0146c19b05e510b22",
+        "rev": "5c9fc36d41d2094f1e46399e5cc396eea8eb8c9f",
         "type": "github"
       },
       "original": {
         "owner": "flox",
-        "ref": "refs/tags/v1.3.11",
+        "ref": "release-1.3.12",
         "repo": "flox",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  inputs.flox.url = "github:flox/flox/refs/tags/v1.3.11";
+  inputs.flox.url = "github:flox/flox/release-1.3.12";
 
   outputs =
     {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  inputs.flox.url = "github:flox/flox/release-1.3.12";
+  inputs.flox.url = "github:flox/flox/refs/tags/v1.3.12";
 
   outputs =
     {


### PR DESCRIPTION
It's a bit after the fact. We can run this as well as based on the proper release.