### PR TITLE
Run Sentry workflow after CI workflow is complete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - "main"
       - "preview"
-      - "report-to-sentry"
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - "main"
       - "preview"
+      - "report-to-sentry"
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -5,19 +5,13 @@ on:
     workflows: ['CI']
     types: [completed]
     branches:
-      - "report-to-sentry"
-      # - "main"
-      # - "preview"
-
+      - "main"
 
 jobs:
 
   report:
     name: "Report"
     runs-on: "ubuntu-latest"
-
-    env:
-      TESTIS: "${{ toJSON(github.event.workflow_run }}"
 
     steps:
       - name: "Setup Sentry CLI"
@@ -27,11 +21,7 @@ jobs:
           organization: "flox-dev"
           project:      "floxenvs"
 
-      - name: DEBUG
-        uses: mxschmitt/action-tmate@v3
-
-
-        # 1. fetch jobs
-        # 2. send them to sentry
-
-
+      # 1. fetch jobs
+      # 2. send them to sentry
+      #- name: DEBUG
+      #  uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -1,0 +1,36 @@
+name: "Sentry"
+
+on:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+    branches:
+      - "main"
+      - "preview"
+
+
+jobs:
+
+  report:
+    name: "Report"
+    runs-on: "ubuntu-latest"
+
+    env:
+      TESTIS: "${{ toJSON(github.event.workflow_run }}"
+
+    steps:
+      - name: "Setup Sentry CLI"
+        uses: "matbour/setup-sentry-cli@v2"
+        with:
+          token:        "${{ secrets.MANAGED_FLOXENVS_SENTRY_TOKEN }}"
+          organization: "flox-dev"
+          project:      "floxenvs"
+
+      - name: DEBUG
+        uses: mxschmitt/action-tmate@v3
+
+
+        # 1. fetch jobs
+        # 2. send them to sentry
+
+

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -5,8 +5,9 @@ on:
     workflows: ['CI']
     types: [completed]
     branches:
-      - "main"
-      - "preview"
+      - "report-to-sentry"
+      # - "main"
+      # - "preview"
 
 
 jobs:


### PR DESCRIPTION
The Sentry workflow doesn't do anything right now, but I need to merge this PR to default branch (`main`) in order to work further on this.