### PR TITLE
set max-parallel to 1 in CI test strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+concurrency:
+  group: floxenvs-tests
+
 env:
   FLOX_DISABLE_METRICS: "true"
 
@@ -89,14 +92,14 @@ jobs:
   test:
     name: "Test '${{ matrix.example }}' example on '${{ matrix.system }}'"
     runs-on: "ubuntu-latest"
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     needs:
       - "envs"
 
     strategy:
       fail-fast: false
-      max-parallel: 8
+      max-parallel: ${{ github.ref == 'refs/head/main' && 1 || 4 }}
       matrix:
         include: ${{ fromJSON(needs.envs.outputs.envs_per_system ) }}
 


### PR DESCRIPTION
We'd like to test if setting the strategy's max-parallel to 1, which makes the
jobs run in serial, fixes some of the race conditions and general flakey CI
we've been seeing.