### PR TITLE
Test against flox release 1.3.17

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,7 +89,7 @@
       },
       "original": {
         "owner": "flox",
-        "ref": "release-1.3.17",
+        "ref": "refs/tags/v1.3.17",
         "repo": "flox",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -24,11 +24,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1738305171,
-        "narHash": "sha256-Bt7jBEGnOmxyvma4S7MFFf3vbPUiTbr8TJoZLXEDXKc=",
+        "lastModified": 1742452566,
+        "narHash": "sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "667e3751a708b886bb67879147f71c07b0014c7f",
+        "rev": "7d9ba794daf5e8cc7ee728859bc688d8e26d5f06",
         "type": "github"
       },
       "original": {
@@ -80,16 +80,16 @@
         "t3-src": "t3-src"
       },
       "locked": {
-        "lastModified": 1741025483,
-        "narHash": "sha256-6jGwruM+389qisKNPgXHLO7RB/DJ8kwExVHyVR0ufPU=",
+        "lastModified": 1743455869,
+        "narHash": "sha256-K2loLe0GPGhkDEomOKFY8JCzRVveYLhq1u1YCS4MvdU=",
         "owner": "flox",
         "repo": "flox",
-        "rev": "b760d17ef27f6d3c158c02a109b118ba5eb49cc9",
+        "rev": "73e72b57ef6a648deca9183e4d8ebd71360c8148",
         "type": "github"
       },
       "original": {
         "owner": "flox",
-        "ref": "refs/tags/v1.3.16",
+        "ref": "release-1.3.17",
         "repo": "flox",
         "type": "github"
       }
@@ -134,11 +134,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1741010256,
-        "narHash": "sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM=",
+        "lastModified": 1743315132,
+        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ba487dbc9d04e0634c64e3b1f0d25839a0a68246",
+        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1738224931,
-        "narHash": "sha256-1zhfA5NBqin0Z79Se85juvqQteq7uClJMEb7l2pdDUY=",
+        "lastModified": 1742296961,
+        "narHash": "sha256-gCpvEQOrugHWLimD1wTFOJHagnSEP6VYBDspq96Idu0=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "3c2aca1e5e9fbabb4e05fc4baa62e807aadc476a",
+        "rev": "15d87419f1a123d8f888d608129c3ce3ff8f13d4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,9 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  inputs.flox.url = "github:flox/flox/refs/tags/v1.3.16";
+  # inputs.flox.url = "github:flox/flox/refs/tags/v1.3.16";
+  inputs.flox.url = "github:flox/flox/release-1.3.17";
+
 
   outputs =
     {

--- a/flake.nix
+++ b/flake.nix
@@ -4,8 +4,7 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  # inputs.flox.url = "github:flox/flox/refs/tags/v1.3.16";
-  inputs.flox.url = "github:flox/flox/release-1.3.17";
+  inputs.flox.url = "github:flox/flox/refs/tags/v1.3.17";
 
 
   outputs =


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'flox':
    'github:flox/flox/b760d17ef27f6d3c158c02a109b118ba5eb49cc9?narHash=sha256-6jGwruM%2B389qisKNPgXHLO7RB/DJ8kwExVHyVR0ufPU%3D' (2025-03-03)
  → 'github:flox/flox/73e72b57ef6a648deca9183e4d8ebd71360c8148?narHash=sha256-K2loLe0GPGhkDEomOKFY8JCzRVveYLhq1u1YCS4MvdU%3D' (2025-03-31)
• Updated input 'flox/fenix':
    'github:nix-community/fenix/667e3751a708b886bb67879147f71c07b0014c7f?narHash=sha256-Bt7jBEGnOmxyvma4S7MFFf3vbPUiTbr8TJoZLXEDXKc%3D' (2025-01-31)
  → 'github:nix-community/fenix/7d9ba794daf5e8cc7ee728859bc688d8e26d5f06?narHash=sha256-sVuLDQ2UIWfXUBbctzrZrXM2X05YjX08K7XHMztt36E%3D' (2025-03-20)
• Updated input 'flox/fenix/rust-analyzer-src':
    'github:rust-lang/rust-analyzer/3c2aca1e5e9fbabb4e05fc4baa62e807aadc476a?narHash=sha256-1zhfA5NBqin0Z79Se85juvqQteq7uClJMEb7l2pdDUY%3D' (2025-01-30)
  → 'github:rust-lang/rust-analyzer/15d87419f1a123d8f888d608129c3ce3ff8f13d4?narHash=sha256-gCpvEQOrugHWLimD1wTFOJHagnSEP6VYBDspq96Idu0%3D' (2025-03-18)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/ba487dbc9d04e0634c64e3b1f0d25839a0a68246?narHash=sha256-WZNlK/KX7Sni0RyqLSqLPbK8k08Kq7H7RijPJbq9KHM%3D' (2025-03-03)
  → 'github:NixOS/nixpkgs/52faf482a3889b7619003c0daec593a1912fddc1?narHash=sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om%2BD4UnDhlDW9BE%3D' (2025-03-30)