### PR TITLE
fix(ci/update): use main instead of of the ref when the action was fired

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -65,6 +65,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v4"
+        with:
+          ref: 'main'
 
       - name: "Install flox"
         uses: "flox/install-flox-action@main"


### PR DESCRIPTION
Instead of using the ref from when the action was fired (which caused the tests to balloon in size), always use main, ensuring it also capture the already auto-merged pull requests.