### PR TITLE
test: Test against release 1.4.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,20 +76,19 @@
         "crane": "crane",
         "fenix": "fenix",
         "nixpkgs": "nixpkgs",
-        "pre-commit-hooks": "pre-commit-hooks",
-        "t3-src": "t3-src"
+        "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1743455869,
-        "narHash": "sha256-K2loLe0GPGhkDEomOKFY8JCzRVveYLhq1u1YCS4MvdU=",
+        "lastModified": 1744634521,
+        "narHash": "sha256-8UmVcD+XopLOsCUXm43uAzem6llBK0eZZhggtSrIKBU=",
         "owner": "flox",
         "repo": "flox",
-        "rev": "73e72b57ef6a648deca9183e4d8ebd71360c8148",
+        "rev": "f01265848caca6ac70dac968ede0e1917b87a624",
         "type": "github"
       },
       "original": {
         "owner": "flox",
-        "ref": "refs/tags/v1.3.17",
+        "ref": "release-1.4.0",
         "repo": "flox",
         "type": "github"
       }
@@ -118,11 +117,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1734649271,
-        "narHash": "sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ=",
+        "lastModified": 1742889210,
+        "narHash": "sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw=",
         "owner": "flox",
         "repo": "nixpkgs",
-        "rev": "d70bd19e0a38ad4790d3913bf08fcbfc9eeca507",
+        "rev": "698214a32beb4f4c8e3942372c694f40848b360d",
         "type": "github"
       },
       "original": {
@@ -134,11 +133,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743315132,
-        "narHash": "sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om+D4UnDhlDW9BE=",
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "52faf482a3889b7619003c0daec593a1912fddc1",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
         "type": "github"
       },
       "original": {
@@ -207,23 +206,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "t3-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1738681975,
-        "narHash": "sha256-QLaOMYlEYjUZpuXJ/MOKb+UqzrTiOu6Isuqj07HTxkQ=",
-        "owner": "flox",
-        "repo": "t3",
-        "rev": "83caeb1cc47fd07117ee5cf478f82cc177cca598",
-        "type": "github"
-      },
-      "original": {
-        "owner": "flox",
-        "ref": "v1.0.7",
-        "repo": "t3",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -79,16 +79,16 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1744634521,
-        "narHash": "sha256-8UmVcD+XopLOsCUXm43uAzem6llBK0eZZhggtSrIKBU=",
+        "lastModified": 1744670737,
+        "narHash": "sha256-OarUl4BUnS4+J1lqUzC3744BKD/x9KE6dOd5sBgMb6E=",
         "owner": "flox",
         "repo": "flox",
-        "rev": "f01265848caca6ac70dac968ede0e1917b87a624",
+        "rev": "081c0772e5ee4f3bc0edd157ae342f04580e9e0c",
         "type": "github"
       },
       "original": {
         "owner": "flox",
-        "ref": "release-1.4.0",
+        "ref": "refs/tags/v1.4.0",
         "repo": "flox",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  inputs.flox.url = "github:flox/flox/refs/tags/v1.3.17";
+  inputs.flox.url = "github:flox/flox/refs/tags/v1.4.0";
 
 
   outputs =


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'flox':
    'github:flox/flox/73e72b57ef6a648deca9183e4d8ebd71360c8148?narHash=sha256-K2loLe0GPGhkDEomOKFY8JCzRVveYLhq1u1YCS4MvdU%3D' (2025-03-31)
  → 'github:flox/flox/f01265848caca6ac70dac968ede0e1917b87a624?narHash=sha256-8UmVcD%2BXopLOsCUXm43uAzem6llBK0eZZhggtSrIKBU%3D' (2025-04-14)
• Updated input 'flox/nixpkgs':
    'github:flox/nixpkgs/d70bd19e0a38ad4790d3913bf08fcbfc9eeca507?narHash=sha256-4EVBRhOjMDuGtMaofAIqzJbg4Ql7Ai0PSeuVZTHjyKQ%3D' (2024-12-19)
  → 'github:flox/nixpkgs/698214a32beb4f4c8e3942372c694f40848b360d?narHash=sha256-hw63HnwnqU3ZQfsMclLhMvOezpM7RSB0dMAtD5/sOiw%3D' (2025-03-25)
• Removed input 'flox/t3-src'
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/52faf482a3889b7619003c0daec593a1912fddc1?narHash=sha256-6hl6L/tRnwubHcA4pfUUtk542wn2Om%2BD4UnDhlDW9BE%3D' (2025-03-30)
  → 'github:NixOS/nixpkgs/2631b0b7abcea6e640ce31cd78ea58910d31e650?narHash=sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR%2BXhw3kr/3Xd0GPTM%3D' (2025-04-12)