### PR TITLE
fix: no macos sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,6 +227,8 @@ jobs:
       max-parallel: 8
       matrix:
         example: ${{ fromJSON(needs.envs.outputs.envs_only ) }}
+        exclude:
+          - example: "macos"
 
     steps:
       - name: "Checkout"


### PR DESCRIPTION
Sync from Ubuntu fails. Ideal would be to add an OSX runner for these cases. Removing for now to get to a green state.