### PR TITLE
Revert "fix(ci): remove "Setup SSH" step"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,11 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@v5"
 
+      - name: "Setup SSH"
+        uses: "webfactory/ssh-agent@v0.9.1"
+        with:
+          ssh-private-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
+
       - name: "Setup Tailscale"
         uses: "tailscale/github-action@v4"
         with:


### PR DESCRIPTION
temporarily disabled tailscale ssh on darwin builders, so need key again to connect to them.