### PR TITLE
feat: Test isolation prototype — namespaces and NixOS VMs

### DIFF
--- a/scripts/ISOLATION.md
+++ b/scripts/ISOLATION.md
@@ -1,0 +1,192 @@
+# Test Isolation for floxenvs
+
+## Problem
+
+When multiple environment tests run on the same builder
+machine, services fight over ports and leave orphaned
+processes:
+
+- MySQL tests bind to port 3306 -- two concurrent runs clash
+- Elasticsearch binds to its configured port -- same problem
+- PostgreSQL on port 15432 -- same problem
+- Orphaned service processes from failed runs block new runs
+
+The Tailscale+SSH runner infrastructure works reliably. The
+isolation between tests does not.
+
+## Approaches Considered
+
+### Option A: Linux namespaces (chosen for prototype)
+
+Use `unshare` to give each test its own network and PID
+namespace. Each test gets its own loopback interface with its
+own port space -- no conflicts possible.
+
+Pros:
+
+- Lightest option, no VM overhead
+- No KVM required, works on any Linux kernel 3.8+
+- ~0ms startup overhead
+- PID namespace auto-kills orphaned services on exit
+- Available on all current builders
+
+Cons:
+
+- Shared kernel (less isolation than VMs)
+- User namespaces may be restricted on some kernels
+  (`sysctl kernel.unprivileged_userns_clone`)
+- No GPU isolation (but GPU envs are future work)
+- Linux only (not applicable to macOS builders)
+
+### Option B: systemd-nspawn containers
+
+Lightweight containers using systemd-nspawn. Full filesystem
+and network isolation.
+
+Pros:
+
+- Stronger isolation than raw namespaces
+- Built into systemd (available on most Linux builders)
+- Supports private networking and filesystem overlay
+
+Cons:
+
+- Requires systemd (not available on all build systems)
+- More complex setup than raw unshare
+- Heavier than namespaces for the problem we're solving
+
+### Option C: Firecracker microVMs
+
+Full VM isolation with ~125ms boot time.
+
+Pros:
+
+- Strongest isolation (separate kernel)
+- ~125ms boot, ~5MB memory overhead
+- Battle-tested (used by AWS Lambda)
+
+Cons:
+
+- Requires KVM (`/dev/kvm`)
+- More complex provisioning (needs kernel + rootfs images)
+- Overkill for port conflict isolation
+- No GPU passthrough
+
+### Option D: QEMU/KVM with VFIO
+
+Full VMs with GPU passthrough capability.
+
+Pros:
+
+- Supports GPU passthrough via VFIO
+- Full OS isolation
+- NixOS test framework provides declarative QEMU VMs
+
+Cons:
+
+- Heaviest option (~50-200ms boot)
+- Requires dedicated GPU hardware for passthrough
+- Complex setup
+
+## Prototype: isolated-test.sh
+
+The `scripts/isolated-test.sh` wrapper implements Option A
+(Linux namespaces). It:
+
+1. Detects available namespace support (unprivileged user
+   namespaces, root, or none)
+2. Creates a new namespace with:
+   - Network namespace (own loopback, own port space)
+   - PID namespace (orphaned services killed on exit)
+   - Mount namespace (if root available)
+3. Sets up loopback networking inside the namespace
+4. Copies the environment to an isolated temp directory
+5. Runs `flox activate [--start-services] -- bash test.sh`
+6. Cleans up on exit
+
+### Usage
+
+```bash
+# Run postgres test in isolation
+./scripts/isolated-test.sh postgres --start-services
+
+# Run go test (no services)
+./scripts/isolated-test.sh go
+
+# Run mysql test in isolation
+./scripts/isolated-test.sh mysql --start-services
+```
+
+### Requirements
+
+- Linux with user namespace support (kernel 3.8+)
+- `unshare` from util-linux
+- For full isolation: root or CAP_SYS_ADMIN
+- Falls back gracefully if namespaces unavailable
+
+## CI Integration
+
+To use `isolated-test.sh` in the current CI workflow, the
+test execution in `ci.yml` would change from running the Nix
+flake app directly to running it through the isolation
+wrapper.
+
+### Current flow (flake.nix test runner)
+
+```
+ssh remote-server nix run .#apps.system.test-env -- true
+```
+
+The Nix flake app (`flake.nix`) copies the environment to
+a temp dir and runs `flox activate -- bash test.sh`.
+
+### Proposed flow (with isolation)
+
+The isolation wrapper can be integrated at two levels:
+
+**Level 1: Wrap the flake app (minimal change)**
+
+Modify `flake.nix` `mkFloxEnvPkg` to run the test inside
+an `unshare` namespace. This is the smallest CI change --
+the SSH+Tailscale infrastructure stays identical.
+
+**Level 2: Replace the flake app (bigger change)**
+
+Use `isolated-test.sh` directly over SSH instead of the
+Nix flake app. This simplifies the test runner but requires
+Flox to be installed on the builder (instead of using Nix
+to provide it).
+
+### Recommended: Level 1
+
+Modify the shell script inside `mkFloxEnvPkg` in
+`flake.nix` to wrap the `flox activate` call with
+`unshare --net --pid --fork`. This keeps the existing CI
+pipeline intact and adds isolation transparently.
+
+## Future Directions
+
+### Phase 2: GPU testing (VFIO passthrough)
+
+For CUDA/GPU environments (ollama, pytorch), we need
+dedicated hardware with VFIO passthrough. This requires:
+
+- Bare metal servers with NVIDIA GPUs
+- IOMMU enabled (Intel VT-d or AMD-Vi)
+- One physical GPU per test VM
+- QEMU/KVM as the VM layer (Firecracker has no GPU support)
+
+### Phase 3: macOS isolation (Tart)
+
+For macOS environment testing:
+
+- Mac mini fleet with Apple Silicon
+- Tart (by Cirrus Labs) for macOS VMs
+- ~15-30s boot time per VM
+- No GPU passthrough (Metal requires bare metal)
+
+### Hardware provisioning
+
+Phases 2 and 3 require hardware procurement -- tracked as a
+separate planning item in the environment health testing
+effort.

--- a/scripts/ISOLATION.md
+++ b/scripts/ISOLATION.md
@@ -1,5 +1,8 @@
 # Test Isolation for floxenvs
 
+For the full Nix-native isolation proposal (recommended),
+see [nix-isolation-proposal.md](nix-isolation-proposal.md).
+
 ## Problem
 
 When multiple environment tests run on the same builder

--- a/scripts/flake-unshare-patch.nix
+++ b/scripts/flake-unshare-patch.nix
@@ -1,0 +1,92 @@
+# Prototype: patched mkFloxEnvPkg with namespace isolation
+#
+# This shows the minimal change to flake.nix that adds
+# network + PID namespace isolation to every test run.
+#
+# Diff from current:
+#   + util-linux and iproute2 in packages
+#   + unshare wrapper around flox activate
+#   + loopback setup inside namespace
+#
+# To apply: replace mkFloxEnvPkg in flake.nix with this version.
+
+# mkFloxEnvPkg = name: {
+#   path ? "${inputs.self}/${name}",
+#   packages ? with pkgs; [
+#     coreutils
+#     util-linux      # provides unshare
+#     iproute2        # provides ip (for loopback)
+#     flox.packages."${system}".default
+#   ],
+#   isolated ? true,
+# }: pkgs.writeShellScriptBin "test-${name}" ''
+#   set -exo pipefail
+#
+#   export FLOX_DISABLE_METRICS=true
+#   export FLOX_ENVS_TESTING=1
+#   export PATH="${lib.makeBinPath packages}:$PATH"
+#   export LANG=
+#   export LC_COLLATE="C"
+#   export LC_CTYPE="C"
+#   export LC_MESSAGES="C"
+#   export LC_MONETARY="C"
+#   export LC_NUMERIC="C"
+#   export LC_TIME="C"
+#   export LC_ALL=
+#
+#   mkdir -p /tmp/floxenvs
+#   export TESTDIR="$(mktemp --directory --tmpdir=/tmp/floxenvs --suffix floxenvs-${name}-example || mktemp --directory --tmpdir=/tmp --suffix floxenvs-${name}-example )"
+#   ret=$?
+#   if [ $ret -ne 0 ] || [ "$TESTDIR" = ""] ; then
+#     echo "Error: unable to create temp directory"
+#     exit $ret
+#   fi
+#
+#   chmod g=rwx "$TESTDIR"
+#   cp -R ${path}/* $TESTDIR
+#   cp -R ${path}/.flox* $TESTDIR
+#   if [ -f ${path}/.env ]; then
+#     cp -R ${path}/.env $TESTDIR
+#   fi
+#   chown -R $(whoami) $TESTDIR/.flox*
+#   chmod -R a+w,g+rw $TESTDIR/.flox*
+#
+#   cd $TESTDIR
+#   echo "Running tests in $TESTDIR"
+#
+#   start_services=""
+#   if [ "$1" == "true" ]; then
+#     start_services=" --start-services"
+#   fi
+#
+#   if [ ! -f test.sh ]; then
+#     echo "Error: No test.sh script found"
+#     exit 1
+#   fi
+#
+#   echo "Running ${name} test..."
+#
+#   # --- ISOLATION WRAPPER ---
+#   # On Linux with namespace support, wrap in unshare for
+#   # network + PID isolation. On Darwin or if unshare fails,
+#   # fall back to direct execution.
+#   if [ "$(uname)" == "Linux" ] && command -v unshare >/dev/null 2>&1; then
+#     echo "Isolating test in network+PID namespace..."
+#     exec unshare --net --pid --fork \
+#       ${pkgs.bashInteractive}/bin/bash -c '
+#         # Set up loopback in the new network namespace
+#         ip link set lo up 2>/dev/null || true
+#         cd "'"$TESTDIR"'"
+#         flox activate'"$start_services"' -- ${pkgs.bashInteractive}/bin/bash test.sh
+#       '
+#   else
+#     echo "No namespace support, running without isolation..."
+#     flox activate$start_services -- ${pkgs.bashInteractive}/bin/bash test.sh
+#   fi
+#
+#   ret=$?
+#   if [ $ret -ne 0 ]; then
+#     echo "Error: Tests failed"
+#     exit $ret
+#   fi
+# '';

--- a/scripts/isolated-test.sh
+++ b/scripts/isolated-test.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+#
+# isolated-test.sh - Run floxenvs tests in isolated Linux namespaces
+#
+# Solves the problem of concurrent test runs fighting over ports
+# (MySQL, Elasticsearch, PostgreSQL) and leaving orphaned services
+# on shared builder machines.
+#
+# Each test gets its own:
+#   - Network namespace (own loopback, own port space)
+#   - PID namespace (orphaned services killed on exit)
+#   - Mount namespace (private /tmp, clean state)
+#
+# Usage:
+#   ./scripts/isolated-test.sh <env-name> [--start-services]
+#
+# Examples:
+#   ./scripts/isolated-test.sh postgres --start-services
+#   ./scripts/isolated-test.sh go
+#   ./scripts/isolated-test.sh mysql --start-services
+#
+# Requirements:
+#   - Linux with user namespace support (most modern kernels)
+#   - unshare(1) from util-linux
+#   - For full isolation: root or CAP_SYS_ADMIN capability
+#   - Falls back to network-only isolation if PID/mount
+#     namespaces are unavailable
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(dirname "$SCRIPT_DIR")"
+
+# --- Argument parsing ---
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <env-name> [--start-services]"
+  echo ""
+  echo "Run an environment's test.sh in an isolated namespace."
+  echo ""
+  echo "Examples:"
+  echo "  $0 postgres --start-services"
+  echo "  $0 go"
+  exit 1
+fi
+
+ENV_NAME="$1"
+START_SERVICES=""
+if [[ "${2:-}" == "--start-services" ]] || [[ "${2:-}" == "true" ]]; then
+  START_SERVICES="--start-services"
+fi
+
+ENV_DIR="$REPO_DIR/$ENV_NAME"
+
+if [[ ! -d "$ENV_DIR" ]]; then
+  echo "Error: Environment '$ENV_NAME' not found at $ENV_DIR"
+  exit 1
+fi
+
+if [[ ! -f "$ENV_DIR/test.sh" ]]; then
+  echo "Error: No test.sh found in $ENV_DIR"
+  exit 1
+fi
+
+# --- Detect capabilities ---
+
+detect_namespace_support() {
+  # Check if we can use user namespaces (unprivileged)
+  if unshare --user --net true 2>/dev/null; then
+    echo "user"
+    return
+  fi
+
+  # Check if we have root or CAP_SYS_ADMIN
+  if [[ $EUID -eq 0 ]] || unshare --net true 2>/dev/null; then
+    echo "root"
+    return
+  fi
+
+  echo "none"
+}
+
+NS_SUPPORT=$(detect_namespace_support)
+
+# --- Build unshare flags ---
+
+build_unshare_cmd() {
+  local flags=""
+
+  case "$NS_SUPPORT" in
+    user)
+      # Unprivileged: user + network + PID namespaces
+      # Mount namespace requires more privileges
+      flags="--user --map-root-user --net --pid --fork"
+      ;;
+    root)
+      # Privileged: full isolation
+      flags="--net --pid --mount --fork"
+      ;;
+    none)
+      echo "Warning: Namespace support not available." >&2
+      echo "Warning: Running without isolation." >&2
+      echo ""
+      return
+      ;;
+  esac
+
+  echo "unshare $flags"
+}
+
+UNSHARE_CMD=$(build_unshare_cmd)
+
+# --- Inner test script ---
+#
+# This runs inside the namespace. It:
+# 1. Sets up loopback networking
+# 2. Copies the environment to a temp directory
+# 3. Runs the test
+# 4. Cleans up on exit
+
+INNER_SCRIPT='
+set -euo pipefail
+
+ENV_DIR="$1"
+ENV_NAME="$2"
+START_SERVICES="$3"
+
+# Set up loopback in the network namespace
+if command -v ip >/dev/null 2>&1; then
+  ip link set lo up 2>/dev/null || true
+fi
+
+# Create isolated temp directory
+TESTDIR=$(mktemp -d "/tmp/floxenvs-test-${ENV_NAME}-XXXXXX")
+
+cleanup() {
+  # Kill any remaining processes in our namespace
+  # (PID namespace handles this, but belt and suspenders)
+  if [[ -n "${TESTDIR:-}" ]] && [[ -d "$TESTDIR" ]]; then
+    rm -rf "$TESTDIR" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# Copy environment to temp dir
+cp -R "$ENV_DIR"/* "$TESTDIR/" 2>/dev/null || true
+cp -R "$ENV_DIR"/.flox* "$TESTDIR/"
+if [[ -f "$ENV_DIR/.env" ]]; then
+  cp "$ENV_DIR/.env" "$TESTDIR/"
+fi
+if [[ -f "$ENV_DIR/.gitignore" ]]; then
+  cp "$ENV_DIR/.gitignore" "$TESTDIR/"
+fi
+
+cd "$TESTDIR"
+
+# Set testing mode
+export FLOX_ENVS_TESTING=1
+export FLOX_DISABLE_METRICS=true
+
+echo "=== Isolated test: $ENV_NAME ==="
+echo "  Namespace: active"
+echo "  Test dir:  $TESTDIR"
+echo "  Services:  ${START_SERVICES:-none}"
+echo ""
+
+# Run the test
+activate_flags=""
+if [[ -n "$START_SERVICES" ]]; then
+  activate_flags="--start-services"
+fi
+
+flox activate $activate_flags -- bash test.sh
+'
+
+# --- Execute ---
+
+echo ">>> Running '$ENV_NAME' test in isolated namespace..."
+echo ">>> Namespace support: $NS_SUPPORT"
+echo ""
+
+if [[ -n "$UNSHARE_CMD" ]]; then
+  $UNSHARE_CMD bash -c "$INNER_SCRIPT" -- \
+    "$ENV_DIR" "$ENV_NAME" "$START_SERVICES"
+else
+  # Fallback: run without isolation
+  bash -c "$INNER_SCRIPT" -- \
+    "$ENV_DIR" "$ENV_NAME" "$START_SERVICES"
+fi
+
+echo ""
+echo ">>> Test '$ENV_NAME' completed successfully."

--- a/scripts/nix-isolation-proposal.md
+++ b/scripts/nix-isolation-proposal.md
@@ -1,0 +1,204 @@
+# Nix-Native Test Isolation Proposal
+
+## Why Nix-native?
+
+The floxenvs builders are already Nix-capable machines. The
+test runner is already a Nix flake app (`flake.nix`). Using
+Nix for isolation means:
+
+- Nix store caching for free (VM images, dependencies)
+- No additional tooling to install on builders
+- Declarative, reproducible test environments
+- Consistent with the existing test execution model
+
+## Approach 1: unshare in mkFloxEnvPkg (minimal change)
+
+Add `util-linux` to the test script's packages and wrap
+the `flox activate` call with `unshare`. This is the
+smallest possible change.
+
+### Current mkFloxEnvPkg (simplified)
+
+```nix
+mkFloxEnvPkg = name: { packages ? [ coreutils flox ], ... }:
+  pkgs.writeShellScriptBin "test-${name}" ''
+    # ... setup ...
+    flox activate$start_services -- bash test.sh
+  '';
+```
+
+### Proposed change
+
+```nix
+mkFloxEnvPkg = name: {
+  packages ? with pkgs; [
+    coreutils
+    util-linux   # <-- adds unshare
+    iproute2     # <-- adds ip (for loopback setup)
+    flox.packages."${system}".default
+  ],
+  isolated ? true,   # <-- new flag
+}: pkgs.writeShellScriptBin "test-${name}" ''
+  # ... existing setup ...
+
+  if [ "${if isolated then "1" else "0"}" == "1" ]; then
+    echo "Running in isolated namespace..."
+    exec unshare --net --pid --fork bash -c '
+      # Set up loopback in the namespace
+      ip link set lo up 2>/dev/null || true
+      cd '"$TESTDIR"'
+      flox activate'"$start_services"' -- bash test.sh
+    '
+  else
+    flox activate$start_services -- bash test.sh
+  fi
+'';
+```
+
+### Pros
+
+- Minimal change to existing flake.nix (~10 lines)
+- No CI workflow changes needed at all
+- Nix caches the test script derivation (with deps)
+- Isolation is transparent to test.sh authors
+- Falls back gracefully on systems without namespace support
+
+### Cons
+
+- Requires root or user namespace support on builder
+- Less isolation than a full VM
+- Linux only (macOS builders can't use unshare)
+
+## Approach 2: NixOS VM tests (stronger isolation)
+
+The NixOS test framework (`nixos/tests`) provides
+declarative QEMU VMs for testing. Each test gets a fresh
+VM with its own kernel, networking, and filesystem.
+
+### How it works
+
+```nix
+# In flake.nix, add a checks output:
+checks.x86_64-linux.test-postgres =
+  nixpkgs.lib.nixos.runTest {
+    name = "floxenvs-postgres";
+    nodes.machine = { pkgs, ... }: {
+      # Install Flox in the VM
+      environment.systemPackages = [
+        flox.packages.x86_64-linux.default
+      ];
+      # Forward the environment files
+      virtualisation.sharedDirectories.env = {
+        source = "${self}/postgres";
+        target = "/env";
+      };
+    };
+    testScript = ''
+      machine.wait_for_unit("multi-user.target")
+      machine.succeed(
+        "cd /env && "
+        "FLOX_ENVS_TESTING=1 "
+        "flox activate --start-services -- bash test.sh"
+      )
+    '';
+  };
+```
+
+### Pros
+
+- Full kernel isolation (separate VM per test)
+- Nix caches the VM image and all dependencies
+- Declarative: VM config is version-controlled
+- Built-in multi-machine networking for complex tests
+- Well-documented in NixOS manual
+- No port conflicts possible (separate network stack)
+- Services auto-cleaned on VM shutdown
+
+### Cons
+
+- NixOS guests only (tests run inside NixOS, not Ubuntu)
+  - This is fine for floxenvs since we control the test env
+- Slower boot (~10-30s per VM vs ~0ms for unshare)
+- More complex Nix expressions
+- QEMU required (available on Linux builders, not macOS)
+- x86_64-linux and aarch64-linux only (no Darwin)
+
+### Caching benefits
+
+With NixOS VM tests, the VM image is a Nix derivation:
+
+- Base NixOS image: cached after first build
+- Flox package: cached from flox binary cache
+- Test environment files: cached per environment
+- Only the test execution itself runs fresh each time
+
+On builders with a populated Nix store, subsequent test
+runs boot in seconds because everything is cached.
+
+## Approach 3: Hybrid (recommended)
+
+Combine both approaches:
+
+- **Linux service environments** (postgres, mysql,
+  elasticsearch, redis, etc.): Use NixOS VM tests for
+  strong isolation. These are the environments that
+  actually fight over ports.
+
+- **Linux non-service environments** (go, python, rust,
+  etc.): Use unshare namespace isolation. Lightweight,
+  fast, sufficient since there are no port conflicts.
+
+- **macOS environments**: No isolation available via Nix
+  on Darwin. Continue with current approach. Future
+  work: Tart VMs on Mac minis.
+
+### Implementation plan
+
+Phase 1: Add `unshare` wrapping to `mkFloxEnvPkg`
+
+- Modify `flake.nix` to include `util-linux` and `iproute2`
+- Wrap `flox activate` with `unshare --net --pid --fork`
+- Add loopback setup inside the namespace
+- Test with postgres, mysql, elasticsearch
+- Zero CI changes needed
+
+Phase 2: Add NixOS VM tests for service environments
+
+- Add `checks` output to `flake.nix`
+- Create VM test definitions for service environments
+- Run via `nix flake check` or targeted
+  `nix build .#checks.system.test-env`
+- Update CI to use VM tests for service environments
+
+Phase 3: GPU and macOS (future)
+
+- GPU: QEMU+VFIO on dedicated hardware
+- macOS: Tart VMs on Mac mini fleet
+
+## Integration with current CI
+
+### Phase 1 (unshare) — no CI changes
+
+The `nix run .#apps.system.test-env` command already runs
+the test script from `mkFloxEnvPkg`. Adding `unshare`
+inside that script means the SSH command in ci.yml stays
+identical:
+
+```yaml
+ssh remote-server nix run .#apps.system.test-env -- true
+```
+
+The isolation is invisible to CI.
+
+### Phase 2 (NixOS VM tests) — small CI change
+
+Add a new CI job or modify the test job to use:
+
+```yaml
+ssh remote-server nix build \
+  .#checks.system.test-env \
+  --accept-flake-config
+```
+
+The NixOS test framework returns success/failure as the
+build result. Failed tests = failed Nix build.

--- a/scripts/nix-isolation-proposal.md
+++ b/scripts/nix-isolation-proposal.md
@@ -274,18 +274,62 @@ overhead for postgres, mysql, elasticsearch, redis, etc.
 | Complexity | Low | Low | Medium |
 | Deps on builder | util-linux | None (Nix provides) | None (Nix provides) |
 
+## Darwin / macOS: no namespace support
+
+**Confirmed:** macOS has no equivalent to `unshare --net`.
+Darwin's kernel does not support Linux namespaces. There is
+no way to give a process its own network stack on macOS
+without a full VM.
+
+What macOS does have:
+
+- **`sandbox-exec` (Seatbelt):** Can deny network access
+  but cannot isolate port spaces. Two processes still share
+  the same loopback — port conflicts remain. Also
+  deprecated by Apple (but still used by system software).
+- **Virtualization.framework (Tart):** Full VM isolation,
+  ~15-30s boot. This is the only real option for port
+  isolation on macOS.
+- **Darwin Containers:** Requires disabling SIP.
+  Experimental, not production-ready.
+
+### macOS mitigation options
+
+1. **Accept no isolation on macOS.** Port conflicts are
+   less likely on macOS because fewer builders and fewer
+   concurrent test runs. Current behavior continues.
+
+2. **Randomize ports per test run.** Instead of hardcoded
+   `PGPORT=15432`, generate a random port. Doesn't solve
+   orphaned services but prevents most port conflicts.
+   Lightweight but fragile.
+
+3. **Tart VMs on Mac minis (phase 3).** Full isolation via
+   Virtualization.framework. Heavier but actually works.
+   Requires Mac mini fleet provisioning.
+
+### Recommendation for macOS
+
+Start with option 1 (no isolation) — it matches current
+behavior and macOS conflicts are rare. If they become a
+problem, go straight to option 3 (Tart VMs). Port
+randomization (option 2) is fragile and not worth the
+complexity for a temporary workaround.
+
 ## Recommended approach
 
-**Phase 1 (now):** Solution 2 (Nix+unshare). Modify
-`mkFloxEnvPkg` to wrap tests in namespaces. Zero CI changes.
-Solves port conflicts and orphaned services immediately.
+**Phase 1 (now):** Solution 2 (Nix+unshare) on Linux.
+Modify `mkFloxEnvPkg` to wrap tests in namespaces. Zero CI
+changes. Solves port conflicts and orphaned services on
+Linux builders immediately. macOS continues without
+isolation (current behavior).
 
-**Phase 2 (if needed):** Solution 3 (NixOS VMs) for service
-environments that need stronger isolation. Nix+unshare for
-non-service environments (go, python, rust).
+**Phase 2 (if needed):** Solution 3 (NixOS VMs) for Linux
+service environments that need stronger isolation.
+Nix+unshare for non-service environments (go, python, rust).
 
-**Phase 3 (future):** GPU testing via QEMU+VFIO on
-dedicated hardware. macOS isolation via Tart on Mac minis.
+**Phase 3 (future):** macOS isolation via Tart on Mac minis.
+GPU testing via QEMU+VFIO on dedicated hardware.
 
 ## Files in this directory
 

--- a/scripts/nix-isolation-proposal.md
+++ b/scripts/nix-isolation-proposal.md
@@ -1,93 +1,189 @@
-# Nix-Native Test Isolation Proposal
+# Test Isolation Solutions
 
-## Why Nix-native?
+Three approaches for isolating floxenvs test runs on shared
+builder machines. All solve the core problem: port conflicts
+and orphaned services between concurrent test runs.
 
-The floxenvs builders are already Nix-capable machines. The
-test runner is already a Nix flake app (`flake.nix`). Using
-Nix for isolation means:
+## Context
 
-- Nix store caching for free (VM images, dependencies)
-- No additional tooling to install on builders
-- Declarative, reproducible test environments
-- Consistent with the existing test execution model
+- Builders are Nix-capable Linux machines on a tailnet
+- Test runner is a Nix flake app (`flake.nix`, `mkFloxEnvPkg`)
+- Tests run over Tailscale+SSH (this works, don't replace it)
+- `test.sh` is the entry point for every environment
+- Service environments (postgres, mysql, elasticsearch) are
+  the main source of conflicts
 
-## Approach 1: unshare in mkFloxEnvPkg (minimal change)
+## Solution 1: Linux namespaces (standalone wrapper)
 
-Add `util-linux` to the test script's packages and wrap
-the `flox activate` call with `unshare`. This is the
-smallest possible change.
+Run each test inside Linux namespaces using `unshare`. This
+is independent of Nix — a plain bash wrapper that can be
+used with any test execution method.
 
-### Current mkFloxEnvPkg (simplified)
+### How it works
 
-```nix
-mkFloxEnvPkg = name: { packages ? [ coreutils flox ], ... }:
-  pkgs.writeShellScriptBin "test-${name}" ''
-    # ... setup ...
-    flox activate$start_services -- bash test.sh
-  '';
+The `isolated-test.sh` script (in this directory) wraps
+any environment test:
+
+```bash
+./scripts/isolated-test.sh postgres --start-services
 ```
 
-### Proposed change
+It calls `unshare --net --pid --fork` to create:
+
+- **Network namespace**: own loopback, own port space.
+  Postgres on port 15432 in one namespace does not conflict
+  with Postgres on 15432 in another.
+- **PID namespace**: all child processes (including services)
+  are killed when the test exits. No orphaned MySQL or
+  Elasticsearch left behind.
+
+Inside the namespace it sets up loopback (`ip link set lo up`)
+and runs `flox activate [--start-services] -- bash test.sh`.
+
+### Integration with CI
+
+Two options:
+
+**Option A: Modify the Nix flake test runner**
+
+The `mkFloxEnvPkg` in `flake.nix` already generates the
+test scripts. Add `unshare` wrapping inside:
+
+```bash
+# Inside the generated test script:
+if [ "$(uname)" == "Linux" ] && command -v unshare >/dev/null; then
+  exec unshare --net --pid --fork bash -c '
+    ip link set lo up 2>/dev/null || true
+    cd "$TESTDIR"
+    flox activate --start-services -- bash test.sh
+  '
+else
+  flox activate --start-services -- bash test.sh
+fi
+```
+
+Zero CI workflow changes — the SSH command stays identical.
+
+**Option B: Wrap the SSH call in ci.yml**
+
+Change the test step to invoke the wrapper over SSH:
+
+```yaml
+ssh remote-server \
+  "cd /path/to/checkout && ./scripts/isolated-test.sh ${{ matrix.example }} ${{ matrix.start_services }}"
+```
+
+### Pros
+
+- Simplest to implement (~10 lines of bash or Nix)
+- Zero or near-zero overhead (~0ms namespace creation)
+- Solves both port conflicts and orphaned services
+- No additional packages on builders (util-linux is
+  standard on Linux)
+- Falls back gracefully on systems without support
+- Works with the existing flake test runner
+
+### Cons
+
+- Requires user namespace support or root/CAP_SYS_ADMIN
+  on the builder (check: `sysctl kernel.unprivileged_userns_clone`)
+- Shared kernel — less isolation than a VM
+- Linux only — no macOS support
+- No GPU isolation (shared hardware)
+
+### When to use
+
+Good first step. Solves the immediate port conflict problem
+with minimal effort. Can be implemented today.
+
+## Solution 2: unshare via Nix flake (Nix-integrated)
+
+Same `unshare` mechanism as Solution 1, but integrated into
+the Nix flake derivation so that isolation is part of the
+cached test script.
+
+### How it works
+
+Modify `mkFloxEnvPkg` in `flake.nix` to include `util-linux`
+and `iproute2` in the derivation's dependencies and wrap the
+test execution:
 
 ```nix
 mkFloxEnvPkg = name: {
   packages ? with pkgs; [
     coreutils
-    util-linux   # <-- adds unshare
-    iproute2     # <-- adds ip (for loopback setup)
+    util-linux   # provides unshare
+    iproute2     # provides ip (for loopback)
     flox.packages."${system}".default
   ],
-  isolated ? true,   # <-- new flag
 }: pkgs.writeShellScriptBin "test-${name}" ''
-  # ... existing setup ...
+  # ... existing setup (env vars, temp dir, copy files) ...
 
-  if [ "${if isolated then "1" else "0"}" == "1" ]; then
-    echo "Running in isolated namespace..."
-    exec unshare --net --pid --fork bash -c '
-      # Set up loopback in the namespace
-      ip link set lo up 2>/dev/null || true
-      cd '"$TESTDIR"'
-      flox activate'"$start_services"' -- bash test.sh
-    '
+  # Isolate on Linux, fallback on Darwin
+  if [ "$(uname)" == "Linux" ] \
+      && command -v unshare >/dev/null 2>&1; then
+    echo "Isolating in network+PID namespace..."
+    exec unshare --net --pid --fork \
+      ${pkgs.bashInteractive}/bin/bash -c '
+        ip link set lo up 2>/dev/null || true
+        cd "'"$TESTDIR"'"
+        flox activate'"$start_services"' \
+          -- ${pkgs.bashInteractive}/bin/bash test.sh
+      '
   else
-    flox activate$start_services -- bash test.sh
+    flox activate$start_services \
+      -- ${pkgs.bashInteractive}/bin/bash test.sh
   fi
 '';
 ```
 
+A concrete patch is in `flake-unshare-patch.nix`.
+
 ### Pros
 
-- Minimal change to existing flake.nix (~10 lines)
-- No CI workflow changes needed at all
-- Nix caches the test script derivation (with deps)
-- Isolation is transparent to test.sh authors
-- Falls back gracefully on systems without namespace support
+Everything from Solution 1, plus:
+
+- `util-linux` and `iproute2` are Nix-provided — no need
+  to check if they exist on the builder
+- The test script derivation (with isolation) is cached
+  in the Nix store
+- Declarative: isolation is part of the build, not a
+  runtime wrapper
+- Zero CI changes — `nix run .#apps.system.test-env` just
+  works with isolation baked in
 
 ### Cons
 
-- Requires root or user namespace support on builder
-- Less isolation than a full VM
-- Linux only (macOS builders can't use unshare)
+- Same namespace limitations as Solution 1 (user ns
+  support, shared kernel, Linux only)
+- Slightly more complex than the standalone wrapper
+- Need to update `flake.nix` (but it's a small change)
 
-## Approach 2: NixOS VM tests (stronger isolation)
+### When to use
 
-The NixOS test framework (`nixos/tests`) provides
-declarative QEMU VMs for testing. Each test gets a fresh
-VM with its own kernel, networking, and filesystem.
+Better than Solution 1 if you want isolation to be part of
+the Nix derivation rather than an external wrapper. Same
+isolation strength, better packaging.
+
+## Solution 3: NixOS VM tests (strongest isolation)
+
+Use the NixOS test framework (`nixos/lib/testing`) to run
+each test in a fresh QEMU virtual machine. Full kernel
+isolation.
 
 ### How it works
 
+Add a `checks` output to `flake.nix` with VM test
+definitions:
+
 ```nix
-# In flake.nix, add a checks output:
 checks.x86_64-linux.test-postgres =
   nixpkgs.lib.nixos.runTest {
     name = "floxenvs-postgres";
     nodes.machine = { pkgs, ... }: {
-      # Install Flox in the VM
       environment.systemPackages = [
         flox.packages.x86_64-linux.default
       ];
-      # Forward the environment files
       virtualisation.sharedDirectories.env = {
         source = "${self}/postgres";
         target = "/env";
@@ -98,107 +194,104 @@ checks.x86_64-linux.test-postgres =
       machine.succeed(
         "cd /env && "
         "FLOX_ENVS_TESTING=1 "
-        "flox activate --start-services -- bash test.sh"
+        "flox activate --start-services "
+        "-- bash test.sh"
       )
     '';
   };
 ```
 
-### Pros
+Run with:
 
-- Full kernel isolation (separate VM per test)
-- Nix caches the VM image and all dependencies
-- Declarative: VM config is version-controlled
-- Built-in multi-machine networking for complex tests
-- Well-documented in NixOS manual
-- No port conflicts possible (separate network stack)
-- Services auto-cleaned on VM shutdown
+```bash
+nix build .#checks.x86_64-linux.test-postgres
+```
 
-### Cons
+### Caching
 
-- NixOS guests only (tests run inside NixOS, not Ubuntu)
-  - This is fine for floxenvs since we control the test env
-- Slower boot (~10-30s per VM vs ~0ms for unshare)
-- More complex Nix expressions
-- QEMU required (available on Linux builders, not macOS)
-- x86_64-linux and aarch64-linux only (no Darwin)
-
-### Caching benefits
-
-With NixOS VM tests, the VM image is a Nix derivation:
+The VM image is a Nix derivation:
 
 - Base NixOS image: cached after first build
 - Flox package: cached from flox binary cache
-- Test environment files: cached per environment
-- Only the test execution itself runs fresh each time
+- Environment files: cached per environment
+- Only test execution runs fresh each time
 
-On builders with a populated Nix store, subsequent test
-runs boot in seconds because everything is cached.
+On builders with populated Nix stores, subsequent runs
+boot quickly because everything is cached.
 
-## Approach 3: Hybrid (recommended)
+### CI integration
 
-Combine both approaches:
-
-- **Linux service environments** (postgres, mysql,
-  elasticsearch, redis, etc.): Use NixOS VM tests for
-  strong isolation. These are the environments that
-  actually fight over ports.
-
-- **Linux non-service environments** (go, python, rust,
-  etc.): Use unshare namespace isolation. Lightweight,
-  fast, sufficient since there are no port conflicts.
-
-- **macOS environments**: No isolation available via Nix
-  on Darwin. Continue with current approach. Future
-  work: Tart VMs on Mac minis.
-
-### Implementation plan
-
-Phase 1: Add `unshare` wrapping to `mkFloxEnvPkg`
-
-- Modify `flake.nix` to include `util-linux` and `iproute2`
-- Wrap `flox activate` with `unshare --net --pid --fork`
-- Add loopback setup inside the namespace
-- Test with postgres, mysql, elasticsearch
-- Zero CI changes needed
-
-Phase 2: Add NixOS VM tests for service environments
-
-- Add `checks` output to `flake.nix`
-- Create VM test definitions for service environments
-- Run via `nix flake check` or targeted
-  `nix build .#checks.system.test-env`
-- Update CI to use VM tests for service environments
-
-Phase 3: GPU and macOS (future)
-
-- GPU: QEMU+VFIO on dedicated hardware
-- macOS: Tart VMs on Mac mini fleet
-
-## Integration with current CI
-
-### Phase 1 (unshare) — no CI changes
-
-The `nix run .#apps.system.test-env` command already runs
-the test script from `mkFloxEnvPkg`. Adding `unshare`
-inside that script means the SSH command in ci.yml stays
-identical:
-
-```yaml
-ssh remote-server nix run .#apps.system.test-env -- true
-```
-
-The isolation is invisible to CI.
-
-### Phase 2 (NixOS VM tests) — small CI change
-
-Add a new CI job or modify the test job to use:
+Small change to the test step in `ci.yml`:
 
 ```yaml
 ssh remote-server nix build \
-  .#checks.system.test-env \
+  .#checks.${{ matrix.system }}.test-${{ matrix.example }} \
   --accept-flake-config
 ```
 
-The NixOS test framework returns success/failure as the
-build result. Failed tests = failed Nix build.
+Failed test = failed Nix build = CI failure.
+
+### Pros
+
+- Full kernel isolation (separate VM per test)
+- No port conflicts possible (own network stack)
+- Services auto-cleaned on VM shutdown
+- Nix caches VM images and all dependencies
+- Declarative VM config, version-controlled
+- Built-in multi-machine networking for complex tests
+- No root or user namespace support required
+- Well-documented in NixOS manual
+
+### Cons
+
+- NixOS guests only (tests run inside NixOS, not Ubuntu
+  or other distros — acceptable since we control the env)
+- Slower boot (~10-30s per VM vs ~0ms for namespaces)
+- More complex Nix expressions to maintain
+- QEMU required (available on Linux builders, not macOS)
+- x86_64-linux and aarch64-linux only (no Darwin)
+- First build of VM image is slow (subsequent cached)
+
+### When to use
+
+Best for service environments where port conflicts are the
+actual problem. The stronger isolation is worth the boot
+overhead for postgres, mysql, elasticsearch, redis, etc.
+
+## Comparison
+
+| | Namespaces | Nix+unshare | NixOS VMs |
+| --- | --- | --- | --- |
+| Isolation | Network+PID | Network+PID | Full kernel |
+| Overhead | ~0ms | ~0ms | ~10-30s boot |
+| Port conflicts | Solved | Solved | Solved |
+| Orphaned svc | Solved (PID ns) | Solved (PID ns) | Solved (VM exit) |
+| Nix caching | No | Script cached | VM image cached |
+| CI changes | Small | None | Small |
+| Root needed | Maybe | Maybe | No |
+| macOS | No | No | No |
+| GPU (future) | No | No | VFIO possible |
+| Complexity | Low | Low | Medium |
+| Deps on builder | util-linux | None (Nix provides) | None (Nix provides) |
+
+## Recommended approach
+
+**Phase 1 (now):** Solution 2 (Nix+unshare). Modify
+`mkFloxEnvPkg` to wrap tests in namespaces. Zero CI changes.
+Solves port conflicts and orphaned services immediately.
+
+**Phase 2 (if needed):** Solution 3 (NixOS VMs) for service
+environments that need stronger isolation. Nix+unshare for
+non-service environments (go, python, rust).
+
+**Phase 3 (future):** GPU testing via QEMU+VFIO on
+dedicated hardware. macOS isolation via Tart on Mac minis.
+
+## Files in this directory
+
+- `isolated-test.sh` — Standalone namespace wrapper
+  (Solution 1)
+- `flake-unshare-patch.nix` — Concrete flake.nix patch
+  (Solution 2)
+- `ISOLATION.md` — Original research notes
+- This file — Unified solution comparison


### PR DESCRIPTION
## Summary

Prototype and research for isolated test execution (ST-006 in the
environment health testing effort). Addresses the core problem:
concurrent test runs on shared builders fight over ports (MySQL,
Elasticsearch, Postgres) and leave orphaned services.

Three solutions documented and compared:

| Solution | Isolation | Overhead | CI changes |
| -------- | --------- | -------- | ---------- |
| Linux namespaces | Network+PID | ~0ms | Small |
| Nix+unshare | Network+PID | ~0ms | None |
| NixOS VM tests | Full kernel | ~10-30s | Small |

**Recommended: Nix+unshare as default** — bake namespace
isolation into `mkFloxEnvPkg` in `flake.nix`. Zero CI changes,
Nix provides all deps and caches the derivation. Needs further
investigation for Darwin equivalent to achieve cross-platform
isolation.

## What's included

- `scripts/isolated-test.sh` — Standalone namespace wrapper
  (Solution 1). Usage: `./scripts/isolated-test.sh postgres --start-services`
- `scripts/flake-unshare-patch.nix` — Concrete flake.nix patch
  showing the Nix+unshare approach (Solution 2)
- `scripts/nix-isolation-proposal.md` — Unified comparison of
  all three solutions with pros/cons and phased rollout plan
- `scripts/ISOLATION.md` — Original research notes

## Key findings

- Port conflicts are hardcoded in manifest vars (Postgres 15432,
  MySQL 13306, Elasticsearch 19200)
- `unshare --net --pid --fork` gives each test its own loopback
  and port space — conflicts impossible
- PID namespace auto-kills orphaned services on test exit
- Nix+unshare is the sweet spot: isolation baked into the cached
  Nix derivation, zero CI changes, ~0ms overhead
- NixOS VM tests are stronger but heavier — good for phase 2
  if namespaces prove insufficient
- Darwin isolation needs further investigation (no unshare on
  macOS, but sandbox-exec or Virtualization.framework may work)

## Open questions

- Does Darwin have an equivalent isolation mechanism?
  (`sandbox-exec`, Seatbelt, Virtualization.framework?)
- Do the builders have user namespace support enabled?
  (`sysctl kernel.unprivileged_userns_clone`)
- Should we apply isolation to all environments or only
  service environments?

## Related

- Effort: `efforts/2026/02-environment-health-testing/` (ST-006, TH-004)
- Forge PR: flox/forge#485

## Test plan

- [ ] `./scripts/isolated-test.sh postgres --start-services`
  runs without port conflicts on Linux
- [ ] Two concurrent postgres tests on same machine don't clash
- [ ] Orphaned services are cleaned up after test failure
- [ ] Non-service environments (go, python) work with isolation
- [ ] Fallback works on systems without namespace support

---
*Via Forge (interactive) • 97e38ba*