### PR TITLE
fix(ci): auto-approve floxbot PRs before merging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
   merge_group:
   workflow_dispatch:
 
+permissions:
+  pull-requests: write
+
 env:
   FLOX_DISABLE_METRICS: "true"
 
@@ -180,6 +183,17 @@ jobs:
       && needs.wait-for-environments.outputs.total_workflows != '0'
 
     steps:
+      - name: "Approve PR"
+        env:
+          PR_NUMBER: >-
+            ${{ needs.wait-for-environments.outputs.pr_number }}
+          GITHUB_TOKEN: >-
+            ${{ github.token }}
+        run: |
+          gh pr review "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --approve
+
       - name: "Merge PR"
         env:
           PR_NUMBER: >-


### PR DESCRIPTION
## Summary

Floxbot lockfile update PRs can't auto-merge because
branch protection requires 1 approval and floxbot
can't approve its own PRs.

Fix: the CI auto-merge job now approves the PR using
the workflow's `GITHUB_TOKEN` (github-actions bot)
before merging with floxbot's token.

## Test plan

- [ ] Next floxbot PR auto-merges without manual
  approval