### PR TITLE
refactor(ci): move containerize to ci.yml with max-parallel 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       any_failed: "${{ steps.wait.outputs.any_failed }}"
       failed_workflows: "${{ steps.wait.outputs.failed_workflows }}"
       total_workflows: "${{ steps.wait.outputs.total_workflows }}"
+      successful_envs: "${{ steps.wait.outputs.successful_envs }}"
       pr_number: "${{ steps.wait.outputs.pr_number }}"
       pr_author: "${{ steps.wait.outputs.pr_author }}"
 
@@ -52,6 +53,7 @@ jobs:
               core.setOutput('any_failed', 'false');
               core.setOutput('failed_workflows', '');
               core.setOutput('total_workflows', '0');
+              core.setOutput('successful_envs', '[]');
               core.setOutput('pr_number', '0');
               core.setOutput('pr_author', '');
               return;
@@ -92,6 +94,7 @@ jobs:
                 core.setOutput('any_failed', 'false');
                 core.setOutput('failed_workflows', '');
                 core.setOutput('total_workflows', '0');
+                core.setOutput('successful_envs', '[]');
                 core.setOutput('pr_number', prNumber.toString());
                 core.setOutput('pr_author', prAuthor);
                 return;
@@ -138,6 +141,21 @@ jobs:
                 core.setOutput(
                   'total_workflows', ciRuns.length.toString()
                 );
+
+                // Extract env names from successful workflows
+                // "CI: redis" → "redis"
+                const successfulEnvs = ciRuns
+                  .filter(r => r.conclusion === 'success')
+                  .map(r => r.name.replace('CI: ', ''))
+                  .filter(n => n.length > 0);
+                core.setOutput(
+                  'successful_envs',
+                  JSON.stringify(successfulEnvs)
+                );
+                core.info(
+                  `Successful envs: ${successfulEnvs.join(', ')}`
+                );
+
                 core.setOutput('pr_number', prNumber.toString());
                 core.setOutput('pr_author', prAuthor);
                 return;
@@ -216,3 +234,64 @@ jobs:
             ${{ needs.wait-for-environments.outputs.failed_workflows }}
             | Workflows:
             ${{ needs.wait-for-environments.outputs.total_workflows }}
+
+  containerize:
+    name: "Containerize '${{ matrix.env }}'"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 30
+    needs: ["wait-for-environments", "result"]
+    if: >-
+      github.event_name == 'push'
+      && github.ref_name == 'main'
+      && needs.result.result == 'success'
+      && needs.wait-for-environments.outputs.successful_envs != '[]'
+
+    permissions:
+      contents: "read"
+      packages: "write"
+      attestations: "write"
+      id-token: "write"
+
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        env: ${{ fromJSON(needs.wait-for-environments.outputs.successful_envs) }}
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
+
+      - name: "Install flox"
+        uses: "flox/install-flox-action@c94e7e1ab56ae14fe98bae4fd84384fd135f0c2a" # main
+
+      - name: "Login to GHCR"
+        uses: "docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121" # v4
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Containerize environment"
+        run: |
+          ENV="${{ matrix.env }}"
+          export NIX_CONFIG='extra-experimental-features = nix-command flakes'
+          flox containerize -d "./$ENV"
+          tag=$(echo -n "$ENV" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g')
+          docker tag "$tag:latest" "ghcr.io/flox/floxenvs:$tag-latest"
+          docker push "ghcr.io/flox/floxenvs:$tag-latest"
+
+      - name: "Containerize demo"
+        if: hashFiles(format('{0}-demo/.flox/env/manifest.toml', matrix.env)) != ''
+        run: |
+          ENV="${{ matrix.env }}"
+          DEMO="$ENV-demo"
+          if [ ! -d "$DEMO/.flox/env" ]; then
+            echo "No demo for $ENV, skipping"
+            exit 0
+          fi
+          export NIX_CONFIG='extra-experimental-features = nix-command flakes'
+          flox containerize -d "./$DEMO"
+          tag=$(echo -n "$DEMO" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g')
+          docker tag "$tag:latest" "ghcr.io/flox/floxenvs:$tag-latest"
+          docker push "ghcr.io/flox/floxenvs:$tag-latest"

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -254,41 +254,6 @@ jobs:
                   --option access-tokens "github.com=${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}" \
                   github:flox/floxenvs/${{ github.sha }}#apps.${{ matrix.system }}.run-test -- ${{ inputs.environment }}-demo
 
-  containerize:
-    name: "Containerize '${{ inputs.environment }}'"
-    runs-on: "ubuntu-latest"
-    timeout-minutes: 30
-
-    needs:
-      - "test"
-
-    if: (github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch'
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
-
-      - name: "Install flox"
-        uses: "flox/install-flox-action@c94e7e1ab56ae14fe98bae4fd84384fd135f0c2a" # main
-
-      - name: "Login to Github Container Registry"
-        uses: "docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121" # v4
-        with:
-          registry: "ghcr.io"
-          username: "${{ github.actor }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: "Containerize"
-        run: |
-          export NIX_CONFIG='extra-experimental-features = nix-command flakes'
-          flox containerize -d ./${{ inputs.environment }}
-
-      - name: "Tag & Push"
-        run: |
-          tag=$(echo -n "${{ inputs.environment }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g')
-          docker tag "$tag:latest" "ghcr.io/flox/floxenvs:$tag-latest"
-          docker push "ghcr.io/flox/floxenvs:$tag-latest"
-
   push:
     name: "Push '${{ inputs.environment }}' to FloxHub"
     runs-on: "ubuntu-latest"
@@ -356,67 +321,6 @@ jobs:
           pushd "./$ENV"
           $FLOX_BIN push --dir "remote"
           popd
-
-  containerize-demo:
-    name: "Containerize '${{ inputs.environment }}-demo'"
-    runs-on: "ubuntu-latest"
-    timeout-minutes: 30
-
-    needs:
-      - "discover"
-      - "push"
-      - "test-demo"
-
-    if: >-
-      ((github.event_name == 'push' && github.ref_name == 'main') || github.event_name == 'workflow_dispatch')
-      && needs.discover.outputs.has_demo == 'true'
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
-
-      - name: "Install flox"
-        uses: "flox/install-flox-action@c94e7e1ab56ae14fe98bae4fd84384fd135f0c2a" # main
-
-      - name: "Get FloxHub token"
-        run: |
-          echo "FLOX_FLOXHUB_TOKEN=${{ secrets.FLOX_FLOXHUB_TOKEN }}" >> $GITHUB_ENV
-
-      - name: "Rewrite include to use remote environment"
-        run: |
-          ENV="${{ inputs.environment }}"
-          DEMO_DIR="$ENV-demo"
-          sed -i "s|{ dir = \"../$ENV\" }|{ remote = \"flox/$ENV\" }|g" "$DEMO_DIR/.flox/env/manifest.toml"
-          cat "$DEMO_DIR/.flox/env/manifest.toml"
-
-      - name: "Upgrade includes"
-        run: |
-          ENV="${{ inputs.environment }}"
-          DEMO_DIR="$ENV-demo"
-          pushd "$DEMO_DIR"
-          flox include upgrade
-          popd
-
-      - name: "Login to Github Container Registry"
-        uses: "docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121" # v4
-        with:
-          registry: "ghcr.io"
-          username: "${{ github.actor }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: "Containerize"
-        run: |
-          ENV="${{ inputs.environment }}"
-          DEMO_DIR="$ENV-demo"
-          export NIX_CONFIG='extra-experimental-features = nix-command flakes'
-          flox containerize -d "./$DEMO_DIR"
-
-      - name: "Tag & Push"
-        run: |
-          ENV="${{ inputs.environment }}"
-          tag=$(echo -n "$ENV-demo" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]//g')
-          docker tag "$tag:latest" "ghcr.io/flox/floxenvs:$tag-latest"
-          docker push "ghcr.io/flox/floxenvs:$tag-latest"
 
   push-demo:
     name: "Push '${{ inputs.environment }}-demo' to FloxHub"


### PR DESCRIPTION
## Summary

Move container builds from per-environment workflows
to the central `ci.yml` coordinator with
`max-parallel: 4`.

## Before

Each `ci_<name>.yml` → `environment.yml` ran its own
containerize + containerize-demo jobs. With 15+ envs
changing at once (e.g. flake.nix update), all
containerize jobs ran simultaneously.

## After

- `environment.yml` only does: discover, test,
  test-demo, push, push-demo
- `ci.yml` waits for all env workflows, then runs
  containerize as a matrix job with `max-parallel: 4`
- Both env and demo are containerized in one job
- Only runs on main push after Summary passes

## Test plan

- [x] PR: no containerize jobs run (correct)
- [ ] Main push: containerize runs after Summary
- [ ] Max 4 concurrent container builds
- [ ] Both env and demo images are pushed to GHCR