### PR TITLE
fix(ci): allow publish on workflow_dispatch

### DIFF
--- a/.github/workflows/ci_pkgs.yml
+++ b/.github/workflows/ci_pkgs.yml
@@ -115,7 +115,7 @@ jobs:
     timeout-minutes: 30
     needs: ["discover", "build"]
     if: >-
-      github.event_name == 'push'
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       && github.ref_name == 'main'
       && needs.discover.outputs.packages != '[]'
 


### PR DESCRIPTION
Allow flox publish to run when manually triggered via workflow_dispatch (not just push to main).