### PR TITLE
fix: upgrade_envs CI — exclude root .flox, resolve go-demo conflict

### DIFF
--- a/go-demo/.flox/env/manifest.lock
+++ b/go-demo/.flox/env/manifest.lock
@@ -16,7 +16,8 @@
       },
       "gopls": {
         "pkg-path": "gopls",
-        "pkg-group": "go-tools"
+        "pkg-group": "go-tools",
+        "priority": 4
       },
       "gore": {
         "pkg-path": "gore",
@@ -417,7 +418,7 @@
       },
       "system": "aarch64-darwin",
       "group": "go-tools",
-      "priority": 5
+      "priority": 4
     },
     {
       "attr_path": "gopls",
@@ -446,7 +447,7 @@
       },
       "system": "aarch64-linux",
       "group": "go-tools",
-      "priority": 5
+      "priority": 4
     },
     {
       "attr_path": "gopls",
@@ -475,7 +476,7 @@
       },
       "system": "x86_64-darwin",
       "group": "go-tools",
-      "priority": 5
+      "priority": 4
     },
     {
       "attr_path": "gopls",
@@ -504,7 +505,7 @@
       },
       "system": "x86_64-linux",
       "group": "go-tools",
-      "priority": 5
+      "priority": 4
     },
     {
       "attr_path": "gore",
@@ -986,7 +987,8 @@
         },
         "gopls": {
           "pkg-path": "gopls",
-          "pkg-group": "go-tools"
+          "pkg-group": "go-tools",
+          "priority": 4
         },
         "gore": {
           "pkg-path": "gore",

--- a/go-demo/.flox/env/manifest.toml
+++ b/go-demo/.flox/env/manifest.toml
@@ -12,6 +12,7 @@ go-task.pkg-path = "go-task"
 go-task.pkg-group = "go-tools"
 gopls.pkg-path = "gopls"
 gopls.pkg-group = "go-tools"
+gopls.priority = 4
 gotools.pkg-path = "gotools"
 gotools.pkg-group = "go-tools"
 gomodifytags.pkg-path = "gomodifytags"

--- a/scripts/discover-envs.sh
+++ b/scripts/discover-envs.sh
@@ -52,6 +52,7 @@ get_systems() {
 
 find_locks() {
   find "$REPO_ROOT" -maxdepth 4 -path '*/.flox/env/manifest.lock' \
+    -not -path "$REPO_ROOT/.flox/*" \
     -not -path "$REPO_ROOT/_worktrees/*" \
     -not -path '*/remote/*' \
     -not -path '*/.git/*' \


### PR DESCRIPTION
## Summary

- **Root .flox discovered as environment**: `discover-envs.sh` was
  picking up the repo root's `.flox/env/manifest.lock`, creating a
  spurious environment entry (named `floxenvs` in CI). Added exclusion
  for `$REPO_ROOT/.flox/*`.
- **go-demo gopls/gotools conflict**: After upgrade, both `gopls` and
  `gotools` provide `bin/modernize`. Set `gopls.priority = 4` so it
  wins the conflict (default is 5, lower = higher precedence).

## Test plan

- [ ] `upgrade_envs` workflow succeeds for `go` environment
- [ ] Environment discovery no longer includes root `.flox`