### PR TITLE
feat(pkgs): add uv 0.11.7 package

### DIFF
--- a/.flox/pkgs/uv/default.nix
+++ b/.flox/pkgs/uv/default.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  fetchFromGitHub,
+
+  # buildInputs
+  rust-jemalloc-sys,
+
+  # nativeBuildInputs
+  installShellFiles,
+
+  buildPackages,
+  versionCheckHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash cargoHash;
+in
+rustPlatform.buildRustPackage (finalAttrs: {
+  pname = "uv";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "astral-sh";
+    repo = "uv";
+    tag = finalAttrs.version;
+    hash = srcHash;
+  };
+
+  inherit cargoHash;
+
+  buildInputs = [
+    rust-jemalloc-sys
+  ];
+
+  nativeBuildInputs = [ installShellFiles ];
+
+  cargoBuildFlags = [
+    "--package"
+    "uv"
+  ];
+
+  # Tests require python3
+  doCheck = false;
+
+  postInstall = lib.optionalString (stdenv.hostPlatform.emulatorAvailable buildPackages) (
+    let
+      emulator = stdenv.hostPlatform.emulator buildPackages;
+    in
+    ''
+      installShellCompletion --cmd uv \
+        --bash <(${emulator} $out/bin/uv generate-shell-completion bash) \
+        --fish <(${emulator} $out/bin/uv generate-shell-completion fish) \
+        --zsh <(${emulator} $out/bin/uv generate-shell-completion zsh)
+    ''
+  );
+
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  doInstallCheck = true;
+
+  meta = {
+    description = "Extremely fast Python package installer and resolver, written in Rust";
+    homepage = "https://github.com/astral-sh/uv";
+    changelog = "https://github.com/astral-sh/uv/blob/${finalAttrs.version}/CHANGELOG.md";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    mainProgram = "uv";
+    broken = stdenv.buildPlatform.is32bit;
+  };
+})

--- a/.flox/pkgs/uv/hashes.json
+++ b/.flox/pkgs/uv/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.11.7",
+  "srcHash": "sha256-DTYZIsgqS/m7YC5fQKy3UL/56XTKY9H5oCJX4LDJRmY=",
+  "cargoHash": "sha256-wOE7kg0WAVgx8fhrt+N79GjHFviEdI0fuNTYMCn464A="
+}

--- a/.flox/pkgs/uv/upgrade.sh
+++ b/.flox/pkgs/uv/upgrade.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_version=$(curl -sf https://api.github.com/repos/astral-sh/uv/releases/latest \
+  | jq -r '.tag_name')
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating uv from $current_version to $latest_version"
+
+# Download and hash the new source tarball
+src_url="https://github.com/astral-sh/uv/archive/refs/tags/${latest_version}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+# Build with a dummy cargoHash to get the real one
+tmp_hashes=$(mktemp)
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg c "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" \
+  '{version: $v, srcHash: $s, cargoHash: $c}' > "$HASHES_FILE"
+
+echo "Building with dummy cargoHash to compute real one..."
+cargo_hash=$(flox build uv 2>&1 \
+  | grep "got:" \
+  | head -1 \
+  | awk '{print $2}') || true
+
+if [ -z "$cargo_hash" ]; then
+  echo "ERROR: Could not extract cargoHash from build output"
+  # Restore original hashes
+  cp "$tmp_hashes" "$HASHES_FILE"
+  rm -f "$tmp_hashes"
+  exit 1
+fi
+rm -f "$tmp_hashes"
+
+echo "  cargoHash: $cargo_hash"
+
+# Write final hashes
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg c "$cargo_hash" \
+  '{version: $v, srcHash: $s, cargoHash: $c}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"


### PR DESCRIPTION
## Summary

- Import uv nix expression from nixpkgs, updated to latest 0.11.7
- Add `hashes.json` for version/hash tracking
- Add `upgrade.sh` for automated version bumps via GitHub releases API
- Verified builds on all 4 systems: aarch64-darwin, x86_64-darwin, aarch64-linux, x86_64-linux

Refs: AI-14