### PR TITLE
fix(opencode,codex): publish to flox org

### DIFF
--- a/.flox/pkgs/codex/publish.json
+++ b/.flox/pkgs/codex/publish.json
@@ -1,3 +1,3 @@
 {
-  "org": "flox-ai"
+  "org": "flox"
 }

--- a/.flox/pkgs/opencode/publish.json
+++ b/.flox/pkgs/opencode/publish.json
@@ -1,3 +1,3 @@
 {
-  "org": "flox-ai"
+  "org": "flox"
 }


### PR DESCRIPTION
## Summary

- Switch `opencode` and `codex` custom packages from `flox-ai` org to `flox` org (matches `claude-code`, `crush`, `agent-deck` pattern).
- No environments consume these packages yet, so no lockfile updates needed.

## Publish notes

CI only publishes on pushes to `main`, so after this merges the packages need to be re-published manually under the `flox` org for all 4 systems:

```
flox publish -o flox opencode --system <aarch64-darwin|aarch64-linux|x86_64-darwin|x86_64-linux>
flox publish -o flox codex    --system <aarch64-darwin|aarch64-linux|x86_64-darwin|x86_64-linux>
```

## Test plan

- [x] CI green on `fix/ci`
- [ ] After merge: `flox publish -o flox` succeeds for both packages across all 4 systems