### PR TITLE
fix(bazel-demo): simplify build command and drop pkg-group

### DIFF
--- a/bazel-demo/.flox/env/manifest.lock
+++ b/bazel-demo/.flox/env/manifest.lock
@@ -28,8 +28,7 @@
         ]
       },
       "gum": {
-        "pkg-path": "gum",
-        "pkg-group": "demo-tools"
+        "pkg-path": "gum"
       }
     },
     "hook": {
@@ -38,7 +37,7 @@
     "options": {},
     "build": {
       "hello": {
-        "command": "set -eo pipefail\n\n# flox build's local mode doesn't export $FLOX_ENV_CACHE, so\n# park Bazel's output in a fresh tmpdir that is always\n# writable. --repo_contents_cache= keeps Bazel 9's new cache\n# from landing inside the worktree.\nbazel_cache=\"$(mktemp -d)\"\n# Bazel creates read-only action outputs; chmod before rm.\ntrap 'chmod -R u+w \"$bazel_cache\" 2>/dev/null; rm -rf \"$bazel_cache\"' EXIT\n\nbazel --output_user_root=\"$bazel_cache\" \\\n  build //:hello --repo_contents_cache=\n\nmkdir -p \"$out/bin\"\ncp -L bazel-bin/hello_/hello \"$out/bin/hello\"\nchmod +x \"$out/bin/hello\"\n",
+        "command": "set -eo pipefail\n\nbazel build //:hello\n\nmkdir -p \"$out/bin\"\ncp -L bazel-bin/hello_/hello \"$out/bin/hello\"\nchmod +x \"$out/bin/hello\"\n",
         "version": "0.0.1",
         "description": "Sample Go binary built with Bazel + rules_go"
       }
@@ -254,7 +253,7 @@
         "out": "/nix/store/cdpxgzcjwidrmrzsq0zkyr9nxccvy3p6-gum-0.17.0"
       },
       "system": "aarch64-darwin",
-      "group": "demo-tools",
+      "group": "toplevel",
       "priority": 5
     },
     {
@@ -283,7 +282,7 @@
         "out": "/nix/store/kqcb9j9k6wdvb7pjvjzn3p8dc82qmk9x-gum-0.17.0"
       },
       "system": "aarch64-linux",
-      "group": "demo-tools",
+      "group": "toplevel",
       "priority": 5
     },
     {
@@ -312,7 +311,7 @@
         "out": "/nix/store/rznkbgxflsbrfy5c359vhhqrrxw4pfkj-gum-0.17.0"
       },
       "system": "x86_64-darwin",
-      "group": "demo-tools",
+      "group": "toplevel",
       "priority": 5
     },
     {
@@ -341,7 +340,7 @@
         "out": "/nix/store/rf0zlw5q4j051xkjk9djfw5dpb8nwbgm-gum-0.17.0"
       },
       "system": "x86_64-linux",
-      "group": "demo-tools",
+      "group": "toplevel",
       "priority": 5
     }
   ],
@@ -350,8 +349,7 @@
       "schema-version": "1.11.0",
       "install": {
         "gum": {
-          "pkg-path": "gum",
-          "pkg-group": "demo-tools"
+          "pkg-path": "gum"
         }
       },
       "hook": {
@@ -360,7 +358,7 @@
       "options": {},
       "build": {
         "hello": {
-          "command": "set -eo pipefail\n\n# flox build's local mode doesn't export $FLOX_ENV_CACHE, so\n# park Bazel's output in a fresh tmpdir that is always\n# writable. --repo_contents_cache= keeps Bazel 9's new cache\n# from landing inside the worktree.\nbazel_cache=\"$(mktemp -d)\"\n# Bazel creates read-only action outputs; chmod before rm.\ntrap 'chmod -R u+w \"$bazel_cache\" 2>/dev/null; rm -rf \"$bazel_cache\"' EXIT\n\nbazel --output_user_root=\"$bazel_cache\" \\\n  build //:hello --repo_contents_cache=\n\nmkdir -p \"$out/bin\"\ncp -L bazel-bin/hello_/hello \"$out/bin/hello\"\nchmod +x \"$out/bin/hello\"\n",
+          "command": "set -eo pipefail\n\nbazel build //:hello\n\nmkdir -p \"$out/bin\"\ncp -L bazel-bin/hello_/hello \"$out/bin/hello\"\nchmod +x \"$out/bin/hello\"\n",
           "version": "0.0.1",
           "description": "Sample Go binary built with Bazel + rules_go"
         }

--- a/bazel-demo/.flox/env/manifest.toml
+++ b/bazel-demo/.flox/env/manifest.toml
@@ -10,7 +10,6 @@ environments = [
 
 [install]
 gum.pkg-path = "gum"
-gum.pkg-group = "demo-tools"
 
 [hook]
 on-activate = '''
@@ -30,16 +29,7 @@ version = "0.0.1"
 command = '''
 set -eo pipefail
 
-# flox build's local mode doesn't export $FLOX_ENV_CACHE, so
-# park Bazel's output in a fresh tmpdir that is always
-# writable. --repo_contents_cache= keeps Bazel 9's new cache
-# from landing inside the worktree.
-bazel_cache="$(mktemp -d)"
-# Bazel creates read-only action outputs; chmod before rm.
-trap 'chmod -R u+w "$bazel_cache" 2>/dev/null; rm -rf "$bazel_cache"' EXIT
-
-bazel --output_user_root="$bazel_cache" \
-  build //:hello --repo_contents_cache=
+bazel build //:hello
 
 mkdir -p "$out/bin"
 cp -L bazel-bin/hello_/hello "$out/bin/hello"


### PR DESCRIPTION
## Summary
- Drop the local-mode bazel cache workaround in `bazel-demo` — invoke `bazel build //:hello` directly instead of redirecting `--output_user_root` into a tmpdir.
- Move `gum` out of the `demo-tools` pkg-group to the default toplevel group.

## Test plan
- [ ] `cd bazel-demo && flox build`
- [ ] `cd bazel-demo && flox activate -- gum --version`