### PR TITLE
fix(ci): enable nix-command experimental feature for upgrade jobs

### DIFF
--- a/.flox/env/manifest.lock
+++ b/.flox/env/manifest.lock
@@ -25,38 +25,32 @@
     {
       "attr_path": "curl",
       "broken": false,
-      "derivation": "/nix/store/9f2i20yq3jp4yhaxk3qnxhazp7syqmvn-curl-8.18.0.drv",
+      "derivation": "/nix/store/fr5h7hv5af8sbhh37npxkarhdvmgkga8-curl-8.19.0.drv",
       "description": "Command line tool for transferring files with URL syntax",
       "install_id": "curl",
       "license": "curl",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
-      "name": "curl-8.18.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "curl-8.19.0",
       "pname": "curl",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T06:03:33.510401Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:10:22.526087Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "8.18.0",
+      "version": "8.19.0",
       "outputs_to_install": [
         "bin",
-        "bin",
-        "bin",
-        "bin",
-        "man",
-        "man",
-        "man",
         "man"
       ],
       "outputs": {
-        "bin": "/nix/store/gki71gmvlp9d86rqh8b4b6wp7wg396qg-curl-8.18.0-bin",
-        "dev": "/nix/store/2xrq7swcyjrvsbp5wk4qivwbzrqxasxr-curl-8.18.0-dev",
-        "devdoc": "/nix/store/vrff2ib15qhdig8ich94visj28x9m931-curl-8.18.0-devdoc",
-        "man": "/nix/store/wd2w49jdql1n3c6cg4qimqbq5k6m6j4f-curl-8.18.0-man",
-        "out": "/nix/store/7bxrgix4f88r6xvidyl035vxdbn2rnyk-curl-8.18.0"
+        "bin": "/nix/store/j1q7xbajv38k3wgmwf4cbym460mh0i38-curl-8.19.0-bin",
+        "dev": "/nix/store/drdsd796645bwphipiq7vdjw4qd3spgm-curl-8.19.0-dev",
+        "devdoc": "/nix/store/qp9cjijminqlbl3dwc35i9zmcfbdphyg-curl-8.19.0-devdoc",
+        "man": "/nix/store/fyafi0f11l82zdkwgpg1sahkwlrbvk6b-curl-8.19.0-man",
+        "out": "/nix/store/12mp5fb651ivly10ka3xiz0098fzfp4c-curl-8.19.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -65,37 +59,33 @@
     {
       "attr_path": "curl",
       "broken": false,
-      "derivation": "/nix/store/g29rj5wpfqyckm3f1b3jrrslqgaw9rzm-curl-8.18.0.drv",
+      "derivation": "/nix/store/az1wkd2h0z51pkfjjvlngxgy3c23vacj-curl-8.19.0.drv",
       "description": "Command line tool for transferring files with URL syntax",
       "install_id": "curl",
       "license": "curl",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
-      "name": "curl-8.18.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "curl-8.19.0",
       "pname": "curl",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T06:34:59.162077Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:44:34.235292Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "8.18.0",
+      "version": "8.19.0",
       "outputs_to_install": [
         "bin",
-        "bin",
-        "bin",
-        "man",
-        "man",
         "man"
       ],
       "outputs": {
-        "bin": "/nix/store/asrq77x05br50nmmv7akp0ry2n1xxrb4-curl-8.18.0-bin",
-        "debug": "/nix/store/b4mmgwziiqa4jirsrw162r794zi48fz6-curl-8.18.0-debug",
-        "dev": "/nix/store/nxarksm7m9ll9p3r87issf0389hwdz3l-curl-8.18.0-dev",
-        "devdoc": "/nix/store/canqrd4xwygamx7qw3j7dd923l7bmg9n-curl-8.18.0-devdoc",
-        "man": "/nix/store/8z4wa6lizr4gzfpmj3928c2wjk1ldslf-curl-8.18.0-man",
-        "out": "/nix/store/qxkiwf9mg5x9jijpmk0hmz9nkd4xlzph-curl-8.18.0"
+        "bin": "/nix/store/zgb4nz7nfh5ilxs51kck1cj94rmgx4dh-curl-8.19.0-bin",
+        "debug": "/nix/store/b94zxjr3vy1k8mnnfdnjfw62d04mwk6k-curl-8.19.0-debug",
+        "dev": "/nix/store/y8ny10jabky92wll2qia0z4z2y81nll5-curl-8.19.0-dev",
+        "devdoc": "/nix/store/j9b42ralm5hssyv8029fnwi4zp1i5c74-curl-8.19.0-devdoc",
+        "man": "/nix/store/3285jwci6763zax4wl6pzqin1swk9v00-curl-8.19.0-man",
+        "out": "/nix/store/dllixhxh0nlqaw1mb0dhw3cd38bprcfx-curl-8.19.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -104,34 +94,32 @@
     {
       "attr_path": "curl",
       "broken": false,
-      "derivation": "/nix/store/gkm06vy5lkp1n6wlgrr7vvfirf2zgs0g-curl-8.18.0.drv",
+      "derivation": "/nix/store/1fbajizmzjz626khnkvxljrl2775d1ci-curl-8.19.0.drv",
       "description": "Command line tool for transferring files with URL syntax",
       "install_id": "curl",
       "license": "curl",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
-      "name": "curl-8.18.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "curl-8.19.0",
       "pname": "curl",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T07:05:08.582530Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:15:55.512135Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "8.18.0",
+      "version": "8.19.0",
       "outputs_to_install": [
         "bin",
-        "bin",
-        "man",
         "man"
       ],
       "outputs": {
-        "bin": "/nix/store/0h4avs7960hxfgmlayshci76pdd7j1zp-curl-8.18.0-bin",
-        "dev": "/nix/store/rpw29w7jmwrp32bp72s805rh0rchp7fh-curl-8.18.0-dev",
-        "devdoc": "/nix/store/4sbv3g3n1nxlq5nfasd194h893k5nkm9-curl-8.18.0-devdoc",
-        "man": "/nix/store/lb59x8lcbiqjph4gfl5a99l8wh1ckvfy-curl-8.18.0-man",
-        "out": "/nix/store/sdf4br1wm1s10y67yz062mc1vmkykm0f-curl-8.18.0"
+        "bin": "/nix/store/a8hawq0pswlwcz0fmyc9qr3aprzzq3ps-curl-8.19.0-bin",
+        "dev": "/nix/store/074rz5g82fh6m5lw283nrpq5d2mphliq-curl-8.19.0-dev",
+        "devdoc": "/nix/store/nb1b303q9f828bzl9k6aglk5s1q6ldka-curl-8.19.0-devdoc",
+        "man": "/nix/store/gyzpm3pcny7y61lzh1qbqgz6bmb0wz2r-curl-8.19.0-man",
+        "out": "/nix/store/ilvxgsha4q03lgx85nqig6a0hkxf59ml-curl-8.19.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -140,22 +128,22 @@
     {
       "attr_path": "curl",
       "broken": false,
-      "derivation": "/nix/store/1wrll60slxlmvb56g6zk7amw3pwylcng-curl-8.18.0.drv",
+      "derivation": "/nix/store/qyc63by7jdcnqwzk9gj2x3z2nh6r1r3a-curl-8.19.0.drv",
       "description": "Command line tool for transferring files with URL syntax",
       "install_id": "curl",
       "license": "curl",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
-      "name": "curl-8.18.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "curl-8.19.0",
       "pname": "curl",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T07:39:13.317760Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:52:11.428536Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "8.18.0",
+      "version": "8.19.0",
       "outputs_to_install": [
         "bin",
         "bin",
@@ -163,12 +151,12 @@
         "man"
       ],
       "outputs": {
-        "bin": "/nix/store/6j3b51rypymg5inhr27rcc7in5cxbvjz-curl-8.18.0-bin",
-        "debug": "/nix/store/9gvh3ymdh38n7lkbjd61cwx6ff510wpb-curl-8.18.0-debug",
-        "dev": "/nix/store/m2b7j4s1jlhlnpxhpf2sjwvd2nn0x8hx-curl-8.18.0-dev",
-        "devdoc": "/nix/store/r2xswgdxf2z7h9vnirhzkzj4k721nbhh-curl-8.18.0-devdoc",
-        "man": "/nix/store/gxspg74jdwaxdb80giixl4517nw6q139-curl-8.18.0-man",
-        "out": "/nix/store/dhdysbgmgqp936mvkf5f9s8fh2mk68k5-curl-8.18.0"
+        "bin": "/nix/store/sm2nq18jjqp4x0sxpl6lrvwl9rx6mvj2-curl-8.19.0-bin",
+        "debug": "/nix/store/jk4szs9lvdmwwh9p372im3rpnl7sdb63-curl-8.19.0-debug",
+        "dev": "/nix/store/7xvb5060qcf36ncp47wz62rl3fsccv1g-curl-8.19.0-dev",
+        "devdoc": "/nix/store/7kpxw181nfry6ax0hsawdy1n91sxl8w9-curl-8.19.0-devdoc",
+        "man": "/nix/store/8qlb8vwqn254fwc4rvvkgq26ypdx8sdx-curl-8.19.0-man",
+        "out": "/nix/store/pz6b64891m180yb4hadj1jjg3wm3ybng-curl-8.19.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -177,27 +165,27 @@
     {
       "attr_path": "go",
       "broken": false,
-      "derivation": "/nix/store/jj5lr2n85rl99d40dcgvv8kh4p37i47d-go-1.26.1.drv",
+      "derivation": "/nix/store/97qfa61h35q0nqppixvxknsq6wj612gv-go-1.26.2.drv",
       "description": "Go Programming language",
       "install_id": "go",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
-      "name": "go-1.26.1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "go-1.26.2",
       "pname": "go",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T06:03:34.355215Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:10:23.428177Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.26.1",
+      "version": "1.26.2",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/kh43nhaz1qcpwws2xq805lrmwpmn9i3k-go-1.26.1"
+        "out": "/nix/store/fkzywh7rg8lg1n2p0r161iqjwhz540wx-go-1.26.2"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -206,27 +194,27 @@
     {
       "attr_path": "go",
       "broken": false,
-      "derivation": "/nix/store/bgblqd7l0v7x7s504csalw9b5vwf4czc-go-1.26.1.drv",
+      "derivation": "/nix/store/79wmlk24kqdnxmpj5l833ib2fsxpwca0-go-1.26.2.drv",
       "description": "Go Programming language",
       "install_id": "go",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
-      "name": "go-1.26.1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "go-1.26.2",
       "pname": "go",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T06:35:00.956514Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:44:36.062342Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.26.1",
+      "version": "1.26.2",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/rz1pqbm5z3zfby250i0djfmfzzj7khg9-go-1.26.1"
+        "out": "/nix/store/w4i7p78y3735jcy69sk4lcy9zyxr0cav-go-1.26.2"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -235,27 +223,27 @@
     {
       "attr_path": "go",
       "broken": false,
-      "derivation": "/nix/store/pcwra0rv1n0pq3r6sjlc6sx6a0bv499x-go-1.26.1.drv",
+      "derivation": "/nix/store/7f579nxnclv9nql5z2d5g2qyv7zfdl16-go-1.26.2.drv",
       "description": "Go Programming language",
       "install_id": "go",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
-      "name": "go-1.26.1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "go-1.26.2",
       "pname": "go",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T07:05:09.453582Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:15:56.389619Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.26.1",
+      "version": "1.26.2",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/yv6jj27racylbfjw6a1cdr91ndxbgyf6-go-1.26.1"
+        "out": "/nix/store/g0b45l45nlb1kqiywzja7fh49yn7lla5-go-1.26.2"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -264,28 +252,27 @@
     {
       "attr_path": "go",
       "broken": false,
-      "derivation": "/nix/store/f7rh1lw0shd5471j9y6wpvc2j43czglz-go-1.26.1.drv",
+      "derivation": "/nix/store/5a501r66jxszbpw9af1q1a5z3rnrcmfs-go-1.26.2.drv",
       "description": "Go Programming language",
       "install_id": "go",
       "license": "BSD-3-Clause",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
-      "name": "go-1.26.1",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "go-1.26.2",
       "pname": "go",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T07:39:15.217256Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:52:13.405709Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "1.26.1",
+      "version": "1.26.2",
       "outputs_to_install": [
-        "out",
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/ckcq2mj8zk0drhaaacy6mp9d924hnr4m-go-1.26.1"
+        "out": "/nix/store/dimnagks1qsp7180yw74z0npp7z2ihs3-go-1.26.2"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -294,17 +281,17 @@
     {
       "attr_path": "jq",
       "broken": false,
-      "derivation": "/nix/store/y1glsdj47nwma5cg6gkwxaidlcqdvmv1-jq-1.8.1.drv",
+      "derivation": "/nix/store/8m1acd54mxn25zahyn0scbi10a49v91c-jq-1.8.1.drv",
       "description": "Lightweight and flexible command-line JSON processor",
       "install_id": "jq",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
       "name": "jq-1.8.1",
       "pname": "jq",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T06:03:49.950832Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:10:39.115214Z",
       "stabilities": [
         "unstable"
       ],
@@ -312,18 +299,14 @@
       "version": "1.8.1",
       "outputs_to_install": [
         "bin",
-        "bin",
-        "bin",
-        "man",
-        "man",
         "man"
       ],
       "outputs": {
-        "bin": "/nix/store/bb450vb2gl547zwba8sihcyilsg2rqfa-jq-1.8.1-bin",
-        "dev": "/nix/store/irxgyhi0rq34f2y721a26ii09nynq2ha-jq-1.8.1-dev",
-        "doc": "/nix/store/rnkk37licxmcicz44sm368bk2fsrk52j-jq-1.8.1-doc",
-        "man": "/nix/store/vs96fwfhd5gjycxs5yc58wkrizscww92-jq-1.8.1-man",
-        "out": "/nix/store/y4gq3lbz2nq75cl3v28ixrqrr90pk4lf-jq-1.8.1"
+        "bin": "/nix/store/zpaiv3csv85i5qdhwlivlbg8a5clnqmh-jq-1.8.1-bin",
+        "dev": "/nix/store/h46rnp90pvk5ky12r9drbzhl1fqlmjnf-jq-1.8.1-dev",
+        "doc": "/nix/store/iksz05vk9j78ls9agfg9blhax9azgv69-jq-1.8.1-doc",
+        "man": "/nix/store/vs9rx9xgqachcay4mn95m1gwifzxrhm4-jq-1.8.1-man",
+        "out": "/nix/store/inmyqx7646xrcqrwxipacv5gkf3ca6m3-jq-1.8.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -332,17 +315,17 @@
     {
       "attr_path": "jq",
       "broken": false,
-      "derivation": "/nix/store/r7xkf6ii1frn2kcdwb48mbwbvikldhmy-jq-1.8.1.drv",
+      "derivation": "/nix/store/6bm9kiq3c81i6f3hs1qdvk281w8sjk1s-jq-1.8.1.drv",
       "description": "Lightweight and flexible command-line JSON processor",
       "install_id": "jq",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
       "name": "jq-1.8.1",
       "pname": "jq",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T06:35:21.237723Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:44:55.658231Z",
       "stabilities": [
         "unstable"
       ],
@@ -351,16 +334,14 @@
       "outputs_to_install": [
         "bin",
         "bin",
-        "bin",
-        "man",
         "man"
       ],
       "outputs": {
-        "bin": "/nix/store/h68aklwk28xbrg7pqaw078w1hvvvf419-jq-1.8.1-bin",
-        "dev": "/nix/store/kzsszlf69lndqilpgysw1j9b4hrfwjfx-jq-1.8.1-dev",
-        "doc": "/nix/store/rr0a4brsd47393640zn9zgw844rbkrsl-jq-1.8.1-doc",
-        "man": "/nix/store/l4npc0sgk51lz2d6jqnl4r18hmn6qckr-jq-1.8.1-man",
-        "out": "/nix/store/5jf55qkwrnd769ri9wxiy7z9kp5zb4ca-jq-1.8.1"
+        "bin": "/nix/store/blgzs73jx017qji4n78v4wg1qxcg3cav-jq-1.8.1-bin",
+        "dev": "/nix/store/lx675fc624glij1dh9iw89pavkvfkv73-jq-1.8.1-dev",
+        "doc": "/nix/store/r992wf8cylhf9ayxwf64lawdfxcr4cl8-jq-1.8.1-doc",
+        "man": "/nix/store/s8h2klkc7rw485yqj3s73ancc5915v2m-jq-1.8.1-man",
+        "out": "/nix/store/2v9443fs97gdg5mz9lk3q603hryhqijm-jq-1.8.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -369,17 +350,17 @@
     {
       "attr_path": "jq",
       "broken": false,
-      "derivation": "/nix/store/j7s0v2z7qngwmszf6cl59d80w2bankzf-jq-1.8.1.drv",
+      "derivation": "/nix/store/kma4dqri44q18xcdicm42rh69fvxf2q8-jq-1.8.1.drv",
       "description": "Lightweight and flexible command-line JSON processor",
       "install_id": "jq",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
       "name": "jq-1.8.1",
       "pname": "jq",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T07:05:24.944193Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:16:12.423458Z",
       "stabilities": [
         "unstable"
       ],
@@ -387,16 +368,14 @@
       "version": "1.8.1",
       "outputs_to_install": [
         "bin",
-        "bin",
-        "man",
         "man"
       ],
       "outputs": {
-        "bin": "/nix/store/y699jyfkqhj7lm51zdxm1df28izg6zgj-jq-1.8.1-bin",
-        "dev": "/nix/store/681w0vijzacwyhcwylkvbppd4kps33fw-jq-1.8.1-dev",
-        "doc": "/nix/store/2bvvha8apma6crzhsnpjrghnjbjj6hpm-jq-1.8.1-doc",
-        "man": "/nix/store/0h261wdn6mlrn564adwhyw52a2dfnbg5-jq-1.8.1-man",
-        "out": "/nix/store/44i56yshwqwgw912idz0m9zx30d1xg8z-jq-1.8.1"
+        "bin": "/nix/store/cpq0n6nrgs7jwyr121qshzk2fvjkmjbh-jq-1.8.1-bin",
+        "dev": "/nix/store/0p7h41icsq99c08sym6iw4wzdsl35r13-jq-1.8.1-dev",
+        "doc": "/nix/store/h6wn2lzbxq1v2dypaj4kpv4nnkkm9yld-jq-1.8.1-doc",
+        "man": "/nix/store/flsm1xvpbr9681y4y8101v5c5m3qmcim-jq-1.8.1-man",
+        "out": "/nix/store/spn7m9y4302yvw9zafpy1g2sz3z9xnx1-jq-1.8.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -405,17 +384,17 @@
     {
       "attr_path": "jq",
       "broken": false,
-      "derivation": "/nix/store/0vb08cn5pf24mzjbibpc7n37g62lacfj-jq-1.8.1.drv",
+      "derivation": "/nix/store/b7xrk5idxkza33wiaizqzs9fqzvw5lqb-jq-1.8.1.drv",
       "description": "Lightweight and flexible command-line JSON processor",
       "install_id": "jq",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
       "name": "jq-1.8.1",
       "pname": "jq",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T07:39:35.046735Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:52:33.997337Z",
       "stabilities": [
         "unstable"
       ],
@@ -424,15 +403,14 @@
       "outputs_to_install": [
         "bin",
         "bin",
-        "bin",
         "man"
       ],
       "outputs": {
-        "bin": "/nix/store/fc13hvlj7541i1xmwdka7f61qicdzr5a-jq-1.8.1-bin",
-        "dev": "/nix/store/plinh1rzkh83n4gfpkxl748zgaydpxll-jq-1.8.1-dev",
-        "doc": "/nix/store/ihgrvb9w91mwbhxx3fi3gcwwx3qlsdfv-jq-1.8.1-doc",
-        "man": "/nix/store/crwv17pim6csnfr4jmsd7kf60sp3c5dh-jq-1.8.1-man",
-        "out": "/nix/store/s4w1j16dj8wyriv1ljfypr9s1r39yjwp-jq-1.8.1"
+        "bin": "/nix/store/v5c3inhfq6xshmwg1c254vfbcy4jp3k9-jq-1.8.1-bin",
+        "dev": "/nix/store/p8x5zv9s9qg3ld8b7jdm03hkpdqybjl9-jq-1.8.1-dev",
+        "doc": "/nix/store/g2wlgi44rn837jdirpwi3lk5f2iy13zg-jq-1.8.1-doc",
+        "man": "/nix/store/lsyqny7h1riwhzajwy2vjjdd63viiwvm-jq-1.8.1-man",
+        "out": "/nix/store/09bq2i0kb008ccg3qdbyxv81ggxxnn09-jq-1.8.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -441,29 +419,27 @@
     {
       "attr_path": "nodejs",
       "broken": false,
-      "derivation": "/nix/store/g2yfx00n1lp9i8ka7nbl11fawc0yfm7n-nodejs-24.14.0.drv",
+      "derivation": "/nix/store/1m7745r13n7wk43fzx5yr3jjr3vdc1db-nodejs-24.14.1.drv",
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
       "install_id": "nodejs",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
-      "name": "nodejs-24.14.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "nodejs-24.14.1",
       "pname": "nodejs",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T06:03:57.707117Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:10:46.933335Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "24.14.0",
+      "version": "24.14.1",
       "outputs_to_install": [
-        "out",
-        "out",
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/d5hw52iialz64hvfzfp9qm1gr2fp43kx-nodejs-24.14.0"
+        "out": "/nix/store/sf85v1qd1glkmsyfxwn9p8wridb4qf6y-nodejs-24.14.1"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -472,28 +448,27 @@
     {
       "attr_path": "nodejs",
       "broken": false,
-      "derivation": "/nix/store/jj8rw2gnisil7dw10xi2qdinad9jqp7s-nodejs-24.14.0.drv",
+      "derivation": "/nix/store/3h5ymdg61db3f9xwhwclj05afipbxiq2-nodejs-24.14.1.drv",
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
       "install_id": "nodejs",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
-      "name": "nodejs-24.14.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "nodejs-24.14.1",
       "pname": "nodejs",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T06:35:36.458758Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:45:12.070811Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "24.14.0",
+      "version": "24.14.1",
       "outputs_to_install": [
-        "out",
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/vs8zaq8fvbbjqfg4bzn424kn55sj7s7y-nodejs-24.14.0"
+        "out": "/nix/store/amh21igq2gjg6ai42f3ksan8fh89qvpm-nodejs-24.14.1"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -502,28 +477,27 @@
     {
       "attr_path": "nodejs",
       "broken": false,
-      "derivation": "/nix/store/l9ksrfa960964gqf23yfr7a66a2n18c1-nodejs-24.14.0.drv",
+      "derivation": "/nix/store/aarkp2y0aj12skgji58mbf5va0dcf9bd-nodejs-24.14.1.drv",
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
       "install_id": "nodejs",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
-      "name": "nodejs-24.14.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "nodejs-24.14.1",
       "pname": "nodejs",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T07:05:32.402959Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:16:20.068451Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "24.14.0",
+      "version": "24.14.1",
       "outputs_to_install": [
-        "out",
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/70ypbaj273w2kk0nrs4vijizyqgbg48v-nodejs-24.14.0"
+        "out": "/nix/store/w9axwcpzxv1cd78d6v748az2j08k6vfw-nodejs-24.14.1"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -532,28 +506,27 @@
     {
       "attr_path": "nodejs",
       "broken": false,
-      "derivation": "/nix/store/15s1kk2n6vg180wg04wj2wgnl19f03v7-nodejs-24.14.0.drv",
+      "derivation": "/nix/store/8l6p07vmrcj7lsry0jz2ayp1rmpyjdai-nodejs-24.14.1.drv",
       "description": "Event-driven I/O framework for the V8 JavaScript engine",
       "install_id": "nodejs",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
-      "name": "nodejs-24.14.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "nodejs-24.14.1",
       "pname": "nodejs",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T07:39:52.537424Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:52:51.723886Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "24.14.0",
+      "version": "24.14.1",
       "outputs_to_install": [
-        "out",
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/v2210ar51jddnrcx46m53ivv9palc26m-nodejs-24.14.0"
+        "out": "/nix/store/785jidgnryzj566s25s3rb262d4g5znb-nodejs-24.14.1"
       },
       "system": "x86_64-linux",
       "group": "toplevel",
@@ -562,17 +535,17 @@
     {
       "attr_path": "prefetch-npm-deps",
       "broken": false,
-      "derivation": "/nix/store/a2k7fbhjwaixgql873340p7wf10n0kn5-prefetch-npm-deps-0.1.0.drv",
+      "derivation": "/nix/store/xdwlv4jz37kqalvg1haf0v0i4zqlndda-prefetch-npm-deps-0.1.0.drv",
       "description": "Prefetch dependencies from npm (for use with `fetchNpmDeps`)",
       "install_id": "prefetch-npm-deps",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
       "name": "prefetch-npm-deps-0.1.0",
       "pname": "prefetch-npm-deps",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T06:04:13.716839Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:11:02.649504Z",
       "stabilities": [
         "unstable"
       ],
@@ -582,7 +555,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/srzb724qbl2s871jjkjja61zdfqwzv2j-prefetch-npm-deps-0.1.0"
+        "out": "/nix/store/h772140sbxw75r3azrf6cjvywxjhxp2n-prefetch-npm-deps-0.1.0"
       },
       "system": "aarch64-darwin",
       "group": "toplevel",
@@ -591,17 +564,17 @@
     {
       "attr_path": "prefetch-npm-deps",
       "broken": false,
-      "derivation": "/nix/store/vkwj44c47a7fvayzx81baih6rlb9sv5c-prefetch-npm-deps-0.1.0.drv",
+      "derivation": "/nix/store/6rbcz05f8xzml75r4ldm532jrc4j407d-prefetch-npm-deps-0.1.0.drv",
       "description": "Prefetch dependencies from npm (for use with `fetchNpmDeps`)",
       "install_id": "prefetch-npm-deps",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
       "name": "prefetch-npm-deps-0.1.0",
       "pname": "prefetch-npm-deps",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T06:35:56.877441Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:45:32.920672Z",
       "stabilities": [
         "unstable"
       ],
@@ -611,7 +584,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/zv2cxfghiqwy407r6q5hrwip16vixg1a-prefetch-npm-deps-0.1.0"
+        "out": "/nix/store/4d66r258h41pkfmd7v8vrn99jdaqcyq6-prefetch-npm-deps-0.1.0"
       },
       "system": "aarch64-linux",
       "group": "toplevel",
@@ -620,17 +593,17 @@
     {
       "attr_path": "prefetch-npm-deps",
       "broken": false,
-      "derivation": "/nix/store/9waadjw83fm8wibk7ssccyqc0m1pwbq8-prefetch-npm-deps-0.1.0.drv",
+      "derivation": "/nix/store/1wss64xxfq4hbyjhmz4w3b4vfcxq7ffq-prefetch-npm-deps-0.1.0.drv",
       "description": "Prefetch dependencies from npm (for use with `fetchNpmDeps`)",
       "install_id": "prefetch-npm-deps",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
       "name": "prefetch-npm-deps-0.1.0",
       "pname": "prefetch-npm-deps",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T07:05:47.428277Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:16:35.287843Z",
       "stabilities": [
         "unstable"
       ],
@@ -640,7 +613,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/y1c6xnq88rd25lv7lpffadadw1a9gxbb-prefetch-npm-deps-0.1.0"
+        "out": "/nix/store/kllf9g2kl9brcz27h262vcy61zfqcphp-prefetch-npm-deps-0.1.0"
       },
       "system": "x86_64-darwin",
       "group": "toplevel",
@@ -649,17 +622,17 @@
     {
       "attr_path": "prefetch-npm-deps",
       "broken": false,
-      "derivation": "/nix/store/r0srk1lvsj4jwd2hnn0ns39pcf6644zn-prefetch-npm-deps-0.1.0.drv",
+      "derivation": "/nix/store/hjy4hjaxgfg6jsbjvc00h9by6v8j201x-prefetch-npm-deps-0.1.0.drv",
       "description": "Prefetch dependencies from npm (for use with `fetchNpmDeps`)",
       "install_id": "prefetch-npm-deps",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/nixpkgs?rev=4c1018dae018162ec878d42fec712642d214fdfa",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
       "name": "prefetch-npm-deps-0.1.0",
       "pname": "prefetch-npm-deps",
-      "rev": "4c1018dae018162ec878d42fec712642d214fdfa",
-      "rev_count": 977467,
-      "rev_date": "2026-04-09T04:48:10Z",
-      "scrape_date": "2026-04-11T07:40:14.519029Z",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:53:13.733838Z",
       "stabilities": [
         "unstable"
       ],
@@ -669,7 +642,7 @@
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/n03cgggjd4wildg5ipr0zx9hks702v08-prefetch-npm-deps-0.1.0"
+        "out": "/nix/store/qdnbv2yrbl3ld59ipdll2bw7x9fh6fzi-prefetch-npm-deps-0.1.0"
       },
       "system": "x86_64-linux",
       "group": "toplevel",

--- a/.flox/pkgs/crush/default.nix
+++ b/.flox/pkgs/crush/default.nix
@@ -24,10 +24,23 @@ buildGo126Module rec {
 
   inherit vendorHash;
 
-  # Crush bumps go.mod's go directive faster than flox/nixpkgs ships
-  # patch-level Go updates (e.g. requires 1.26.2 while we have 1.26.1).
-  # Patch versions are binary compatible per Go 1 stability, so rewrite
-  # the directive to whatever toolchain buildGo126Module provides.
+  # WORKAROUND: crush bumps go.mod's `go` directive faster than
+  # flox/nixpkgs ships patch-level Go updates. For example, v0.65.2
+  # requires Go 1.26.2 but buildGo126Module currently provides 1.26.1.
+  #
+  # The directive is a minimum-version check enforced by Go's toolchain.
+  # Nix builds run with GOTOOLCHAIN=local (the sandbox has no network),
+  # so Go can't auto-fetch a newer toolchain and the build aborts:
+  #
+  #   go: go.mod requires go >= 1.26.2 (running go 1.26.1; GOTOOLCHAIN=local)
+  #
+  # Patch versions of Go are binary- and source-compatible (Go 1
+  # stability guarantee), so rewriting the directive to match the
+  # toolchain we have is safe. The substitution is dynamic so it keeps
+  # working as crush bumps further (e.g. 1.26.3, 1.26.4, ...).
+  #
+  # Remove this once flox/nixpkgs catches up to whatever Go version
+  # upstream's go.mod requires.
   postPatch = ''
     go_ver=$(go env GOVERSION | sed 's/^go//')
     sed -i "s/^go [0-9.]\+$/go $go_ver/" go.mod

--- a/.flox/pkgs/crush/default.nix
+++ b/.flox/pkgs/crush/default.nix
@@ -24,6 +24,15 @@ buildGo126Module rec {
 
   inherit vendorHash;
 
+  # Crush bumps go.mod's go directive faster than flox/nixpkgs ships
+  # patch-level Go updates (e.g. requires 1.26.2 while we have 1.26.1).
+  # Patch versions are binary compatible per Go 1 stability, so rewrite
+  # the directive to whatever toolchain buildGo126Module provides.
+  postPatch = ''
+    go_ver=$(go env GOVERSION | sed 's/^go//')
+    sed -i "s/^go [0-9.]\+$/go $go_ver/" go.mod
+  '';
+
   subPackages = [ "." ];
 
   ldflags = [

--- a/.flox/pkgs/crush/upgrade.sh
+++ b/.flox/pkgs/crush/upgrade.sh
@@ -25,9 +25,9 @@ src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
 src_sri=$(nix hash convert --hash-algo sha256 --to sri "$src_hash")
 echo "  srcHash: $src_sri"
 
-# Compute vendorHash by building just the goModules fixed-output derivation
-# with a fake hash. This isolates the hash mismatch — a full `flox build`
-# would also compile and test, masking real errors as "vendorHash failed".
+# Build with a dummy vendorHash to get the real one. The goModules
+# fixed-output derivation is built before compilation, so the hash
+# mismatch surfaces immediately.
 tmp_hashes=$(mktemp)
 cp "$HASHES_FILE" "$tmp_hashes"
 
@@ -37,11 +37,9 @@ jq -n \
   --arg vh "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" \
   '{version: $v, srcHash: $s, vendorHash: $vh}' > "$HASHES_FILE"
 
-echo "Fetching Go module dependencies to compute vendorHash..."
+echo "Building with dummy vendorHash to compute real one..."
 prefetch_log=$(mktemp)
-NIXPKGS_ALLOW_UNFREE=1 nix build --impure --no-link \
-  --expr '((import <nixpkgs> {}).callPackage ./.flox/pkgs/crush {}).goModules' \
-  > "$prefetch_log" 2>&1 || true
+flox build crush > "$prefetch_log" 2>&1 || true
 
 vendor_hash=$(awk '/hash mismatch in fixed-output derivation/,0 {
   if (/got:/) { print $NF; exit }

--- a/.flox/pkgs/pi/upgrade.sh
+++ b/.flox/pkgs/pi/upgrade.sh
@@ -63,9 +63,7 @@ jq -n \
 
 echo "Computing npmDepsHash..."
 prefetch_log=$(mktemp)
-nix build --impure --no-link \
-  --expr '((import <nixpkgs> {}).callPackage ./.flox/pkgs/pi {}).npmDeps' \
-  > "$prefetch_log" 2>&1 || true
+flox build pi > "$prefetch_log" 2>&1 || true
 
 npm_deps_hash=$(awk '/hash mismatch in fixed-output derivation/,0 {
   if (/got:/) { print $NF; exit }

--- a/.github/workflows/upgrade_pkgs.yml
+++ b/.github/workflows/upgrade_pkgs.yml
@@ -15,6 +15,7 @@ on:
 
 env:
   FLOX_DISABLE_METRICS: "true"
+  NIX_CONFIG: "extra-experimental-features = nix-command"
 
 jobs:
 

--- a/bazel-demo/.flox/env/manifest.lock
+++ b/bazel-demo/.flox/env/manifest.lock
@@ -28,8 +28,7 @@
         ]
       },
       "gum": {
-        "pkg-path": "gum",
-        "pkg-group": "demo-tools"
+        "pkg-path": "gum"
       }
     },
     "hook": {
@@ -38,7 +37,7 @@
     "options": {},
     "build": {
       "hello": {
-        "command": "set -eo pipefail\n\n# flox build's local mode doesn't export $FLOX_ENV_CACHE, so\n# park Bazel's output in a fresh tmpdir that is always\n# writable. --repo_contents_cache= keeps Bazel 9's new cache\n# from landing inside the worktree.\nbazel_cache=\"$(mktemp -d)\"\n# Bazel creates read-only action outputs; chmod before rm.\ntrap 'chmod -R u+w \"$bazel_cache\" 2>/dev/null; rm -rf \"$bazel_cache\"' EXIT\n\nbazel --output_user_root=\"$bazel_cache\" \\\n  build //:hello --repo_contents_cache=\n\nmkdir -p \"$out/bin\"\ncp -L bazel-bin/hello_/hello \"$out/bin/hello\"\nchmod +x \"$out/bin/hello\"\n",
+        "command": "set -eo pipefail\n\nbazel build //:hello\n\nmkdir -p \"$out/bin\"\ncp -L bazel-bin/hello_/hello \"$out/bin/hello\"\nchmod +x \"$out/bin/hello\"\n",
         "version": "0.0.1",
         "description": "Sample Go binary built with Bazel + rules_go"
       }
@@ -254,7 +253,7 @@
         "out": "/nix/store/cdpxgzcjwidrmrzsq0zkyr9nxccvy3p6-gum-0.17.0"
       },
       "system": "aarch64-darwin",
-      "group": "demo-tools",
+      "group": "toplevel",
       "priority": 5
     },
     {
@@ -283,7 +282,7 @@
         "out": "/nix/store/kqcb9j9k6wdvb7pjvjzn3p8dc82qmk9x-gum-0.17.0"
       },
       "system": "aarch64-linux",
-      "group": "demo-tools",
+      "group": "toplevel",
       "priority": 5
     },
     {
@@ -312,7 +311,7 @@
         "out": "/nix/store/rznkbgxflsbrfy5c359vhhqrrxw4pfkj-gum-0.17.0"
       },
       "system": "x86_64-darwin",
-      "group": "demo-tools",
+      "group": "toplevel",
       "priority": 5
     },
     {
@@ -341,7 +340,7 @@
         "out": "/nix/store/rf0zlw5q4j051xkjk9djfw5dpb8nwbgm-gum-0.17.0"
       },
       "system": "x86_64-linux",
-      "group": "demo-tools",
+      "group": "toplevel",
       "priority": 5
     }
   ],
@@ -350,8 +349,7 @@
       "schema-version": "1.11.0",
       "install": {
         "gum": {
-          "pkg-path": "gum",
-          "pkg-group": "demo-tools"
+          "pkg-path": "gum"
         }
       },
       "hook": {
@@ -360,7 +358,7 @@
       "options": {},
       "build": {
         "hello": {
-          "command": "set -eo pipefail\n\n# flox build's local mode doesn't export $FLOX_ENV_CACHE, so\n# park Bazel's output in a fresh tmpdir that is always\n# writable. --repo_contents_cache= keeps Bazel 9's new cache\n# from landing inside the worktree.\nbazel_cache=\"$(mktemp -d)\"\n# Bazel creates read-only action outputs; chmod before rm.\ntrap 'chmod -R u+w \"$bazel_cache\" 2>/dev/null; rm -rf \"$bazel_cache\"' EXIT\n\nbazel --output_user_root=\"$bazel_cache\" \\\n  build //:hello --repo_contents_cache=\n\nmkdir -p \"$out/bin\"\ncp -L bazel-bin/hello_/hello \"$out/bin/hello\"\nchmod +x \"$out/bin/hello\"\n",
+          "command": "set -eo pipefail\n\nbazel build //:hello\n\nmkdir -p \"$out/bin\"\ncp -L bazel-bin/hello_/hello \"$out/bin/hello\"\nchmod +x \"$out/bin/hello\"\n",
           "version": "0.0.1",
           "description": "Sample Go binary built with Bazel + rules_go"
         }

--- a/bazel-demo/.flox/env/manifest.toml
+++ b/bazel-demo/.flox/env/manifest.toml
@@ -10,7 +10,6 @@ environments = [
 
 [install]
 gum.pkg-path = "gum"
-gum.pkg-group = "demo-tools"
 
 [hook]
 on-activate = '''
@@ -30,16 +29,7 @@ version = "0.0.1"
 command = '''
 set -eo pipefail
 
-# flox build's local mode doesn't export $FLOX_ENV_CACHE, so
-# park Bazel's output in a fresh tmpdir that is always
-# writable. --repo_contents_cache= keeps Bazel 9's new cache
-# from landing inside the worktree.
-bazel_cache="$(mktemp -d)"
-# Bazel creates read-only action outputs; chmod before rm.
-trap 'chmod -R u+w "$bazel_cache" 2>/dev/null; rm -rf "$bazel_cache"' EXIT
-
-bazel --output_user_root="$bazel_cache" \
-  build //:hello --repo_contents_cache=
+bazel build //:hello
 
 mkdir -p "$out/bin"
 cp -L bazel-bin/hello_/hello "$out/bin/hello"


### PR DESCRIPTION
## Summary
- Upgrade scripts (`agent-deck`, `crush`, `pi`, `uv`, `bazel`) call `nix hash convert` which requires the `nix-command` experimental feature.
- Set `NIX_CONFIG` at workflow level so all matrix jobs and `nix` invocations pick it up automatically — no need to modify individual `upgrade.sh` scripts.

## Context
Failing run: https://github.com/flox/floxenvs/actions/runs/25319218134

All 4 failing jobs errored with:
```
error: experimental Nix feature 'nix-command' is disabled
```
Bazel only passed because it was already up-to-date and exited before reaching its `nix` call.

## Test plan
- [x] Trigger `Upgrade Packages` workflow from this branch and confirm previously-failing jobs succeed