### PR TITLE
feat(skills-humanizer): package github.com/blader/humanizer

### DIFF
--- a/.flox/pkgs/skills-humanizer/default.nix
+++ b/.flox/pkgs/skills-humanizer/default.nix
@@ -1,0 +1,51 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+let
+  data = builtins.fromJSON (builtins.readFile ./hashes.json);
+
+  src = fetchFromGitHub {
+    owner = "blader";
+    repo = "humanizer";
+    rev = data.rev;
+    hash = data.srcHash;
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "skills-humanizer";
+  version = data.version;
+  inherit src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    for dest in \
+      "$out/share/claude-code/skills/humanizer" \
+      "$out/share/opencode/skills/humanizer"; do
+      mkdir -p "$dest"
+      cp -r "$src"/. "$dest/"
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Humanizer skill for Claude Code and OpenCode "
+      + "— removes signs of AI-generated writing.";
+    homepage = "https://github.com/blader/humanizer";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/skills-humanizer/hashes.json
+++ b/.flox/pkgs/skills-humanizer/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "2.5.1+unstable-2026-04-01.8b3a178",
+  "rev": "8b3a17889fbf12bedae20974a3c9f9de746ed754",
+  "srcHash": "sha256-3yO13MKUK/zF36Sq+CACMM401BhtmYz5cZmC5FX4VQw="
+}

--- a/.flox/pkgs/skills-humanizer/publish.json
+++ b/.flox/pkgs/skills-humanizer/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/skills-humanizer/upgrade.sh
+++ b/.flox/pkgs/skills-humanizer/upgrade.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="blader"
+REPO="humanizer"
+BRANCH="main"
+
+current_version=$(jq -r '.version // ""' "$HASHES_FILE")
+
+# Resolve current HEAD on main to a full SHA.
+rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/heads/$BRANCH" | awk '{print $1}')
+
+if [ -z "$rev" ]; then
+  echo "Failed to resolve $BRANCH on $OWNER/$REPO" >&2
+  exit 1
+fi
+
+short_sha="${rev:0:7}"
+
+# Committer date (YYYY-MM-DD) via the GitHub commits API.
+commit_json=$(curl -sfL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
+commit_date=$(echo "$commit_json" \
+  | jq -r '.commit.committer.date' \
+  | cut -c1-10)
+
+# Frontmatter `version:` from raw SKILL.md at this rev.
+skill_md=$(curl -sfL \
+  "https://raw.githubusercontent.com/$OWNER/$REPO/$rev/SKILL.md")
+frontmatter_version=$(echo "$skill_md" \
+  | awk '
+      BEGIN { in_fm = 0 }
+      /^---[[:space:]]*$/ {
+        if (in_fm == 0) { in_fm = 1; next }
+        else { exit }
+      }
+      in_fm == 1 && /^version:[[:space:]]*/ {
+        sub(/^version:[[:space:]]*/, "")
+        gsub(/^["'\'']|["'\''][[:space:]]*$/, "")
+        print
+        exit
+      }
+    ')
+
+if [ -z "$frontmatter_version" ]; then
+  echo "Failed to extract frontmatter version from SKILL.md" >&2
+  exit 1
+fi
+
+new_version="${frontmatter_version}+unstable-${commit_date}.${short_sha}"
+
+echo "Current: $current_version"
+echo "Latest:  $new_version"
+
+if [ "$current_version" = "$new_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating skills-humanizer to $new_version"
+
+# Prefetch the source tarball and compute SRI hash.
+sha256_base32=$(nix-prefetch-url --unpack \
+  "https://github.com/$OWNER/$REPO/archive/$rev.tar.gz")
+sri_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$sha256_base32")
+
+jq -n \
+  --arg v "$new_version" \
+  --arg r "$rev" \
+  --arg h "$sri_hash" \
+  '{version: $v, rev: $r, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Wrote $HASHES_FILE:"
+cat "$HASHES_FILE"


### PR DESCRIPTION
## Summary

- Adds `.flox/pkgs/skills-humanizer/` packaging the
  [humanizer](https://github.com/blader/humanizer) Claude Code skill.
- Installs to both `share/claude-code/skills/humanizer/` and
  `share/opencode/skills/humanizer/` (upstream advertises both).
- `upgrade.sh` tracks `main` HEAD; version string format
  `<frontmatter-version>+unstable-<YYYY-MM-DD>.<short-sha>`.
- No CI changes — `ci_pkgs.yml` and `upgrade_pkgs.yml`
  auto-discover the new package.

## Test plan

- [x] `flox build skills-humanizer` succeeds locally on aarch64-darwin
- [x] Both `share/claude-code/skills/humanizer/SKILL.md` and
      `share/opencode/skills/humanizer/SKILL.md` exist in the build output
- [x] `upgrade.sh` is idempotent on an up-to-date `hashes.json`
- [x] `upgrade.sh` detects a manually-rewound `rev` and converges
- [ ] CI green on this PR