### PR TITLE
feat(claude-seo): add claude-code-plugin-claude-seo package

### DIFF
--- a/.flox/pkgs/claude-code-plugin-claude-seo/default.nix
+++ b/.flox/pkgs/claude-code-plugin-claude-seo/default.nix
@@ -1,8 +1,41 @@
-{ stdenv, lib, fetchFromGitHub }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  makeWrapper,
+  python3,
+  curl,
+  gh,
+  git,
+  jq,
+  nodejs,
+}:
 
 let
   versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
   inherit (versionData) version srcHash;
+
+  # Python interpreter pre-loaded with every third-party module the
+  # plugin's own scripts/ + hooks/ + extensions/ tree imports.
+  pythonEnv = python3.withPackages (ps: with ps; [
+    beautifulsoup4
+    google-api-python-client
+    google-auth
+    google-auth-httplib2
+    google-auth-oauthlib
+    lxml
+    matplotlib
+    numpy
+    openpyxl
+    pillow
+    playwright
+    pypdf
+    requests
+    urllib3
+    validators
+    weasyprint
+  ]);
 in
 stdenv.mkDerivation {
   pname = "claude-code-plugin-claude-seo";
@@ -15,22 +48,69 @@ stdenv.mkDerivation {
     hash = srcHash;
   };
 
+  # makeBinaryWrapper produces a compiled C wrapper for python3 so it
+  # is exec'd directly by the kernel via shebang on Darwin, where
+  # shebang chains through a shell script wrapper are unreliable
+  # under stripped environments. makeWrapper is still needed for the
+  # bash extension scripts (wrapProgram).
+  nativeBuildInputs = [ makeBinaryWrapper makeWrapper ];
+
   installPhase = ''
+    runHook preInstall
+
     PLUGIN_DIR="$out/share/claude-code/plugins/claude-seo"
     mkdir -p "$PLUGIN_DIR"
     cp -r "$src"/. "$PLUGIN_DIR/"
     chmod -R u+w "$PLUGIN_DIR"
+
     rm -rf "$PLUGIN_DIR/.github" \
            "$PLUGIN_DIR/.devcontainer" \
            "$PLUGIN_DIR/install.sh" \
            "$PLUGIN_DIR/install.ps1" \
            "$PLUGIN_DIR/uninstall.sh" \
            "$PLUGIN_DIR/uninstall.ps1"
+
+    # Wrap python3 so subprocess.run() inside plugin scripts finds
+    # gh/curl/jq/git/node/npx without depending on the caller's PATH.
+    runtimeBins=${lib.makeBinPath [ curl gh git jq nodejs ]}
+    mkdir -p "$out/bin"
+    makeBinaryWrapper "${pythonEnv}/bin/python3" "$out/bin/python3" \
+      --prefix PATH : "$runtimeBins"
+
+    # Repoint every #!/usr/bin/env python3 shebang at the wrapped
+    # python3. Marks files executable so the kernel honors the
+    # shebang when Claude Code invokes them.
+    while IFS= read -r f; do
+      head -1 "$f" | grep -q '/usr/bin/env python3' || continue
+      substituteInPlace "$f" --replace-fail \
+        '#!/usr/bin/env python3' "#!$out/bin/python3"
+      chmod +x "$f"
+    done < <(find "$PLUGIN_DIR" -name '*.py' -type f)
+
+    # hooks.json invokes 'python3 path/to/script' which would resolve
+    # python3 from the caller's PATH. Drop the explicit interpreter
+    # so the patched shebang on validate-schema.py is honored.
+    substituteInPlace "$PLUGIN_DIR/hooks/hooks.json" --replace-fail \
+      'python3 \"''${CLAUDE_PLUGIN_ROOT}/hooks/validate-schema.py\"' \
+      '\"''${CLAUDE_PLUGIN_ROOT}/hooks/validate-schema.py\"'
+
+    # Wrap each extension install/uninstall script so 'node', 'npx',
+    # 'python3', 'jq', etc. resolve from Nix when a user runs them.
+    # Note: 'claude' is intentionally not bundled — it is provided by
+    # the consumer's flox/claude-code package.
+    for f in "$PLUGIN_DIR"/extensions/*/install.sh \
+             "$PLUGIN_DIR"/extensions/*/uninstall.sh; do
+      [ -f "$f" ] || continue
+      chmod +x "$f"
+      wrapProgram "$f" --prefix PATH : "$runtimeBins:$out/bin"
+    done
+
+    runHook postInstall
   '';
 
   meta = {
     description =
-      "Universal SEO plugin for Claude Code (skills, agents, hooks, extensions)";
+      "Universal SEO plugin for Claude Code (skills, agents, hooks, extensions) with Python + binaries bundled";
     homepage = "https://github.com/AgriciDaniel/claude-seo";
     license = lib.licenses.mit;
   };

--- a/.flox/pkgs/claude-code-plugin-claude-seo/default.nix
+++ b/.flox/pkgs/claude-code-plugin-claude-seo/default.nix
@@ -1,0 +1,37 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash;
+in
+stdenv.mkDerivation {
+  pname = "claude-code-plugin-claude-seo";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "AgriciDaniel";
+    repo = "claude-seo";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  installPhase = ''
+    PLUGIN_DIR="$out/share/claude-code/plugins/claude-seo"
+    mkdir -p "$PLUGIN_DIR"
+    cp -r "$src"/. "$PLUGIN_DIR/"
+    chmod -R u+w "$PLUGIN_DIR"
+    rm -rf "$PLUGIN_DIR/.github" \
+           "$PLUGIN_DIR/.devcontainer" \
+           "$PLUGIN_DIR/install.sh" \
+           "$PLUGIN_DIR/install.ps1" \
+           "$PLUGIN_DIR/uninstall.sh" \
+           "$PLUGIN_DIR/uninstall.ps1"
+  '';
+
+  meta = {
+    description =
+      "Universal SEO plugin for Claude Code (skills, agents, hooks, extensions)";
+    homepage = "https://github.com/AgriciDaniel/claude-seo";
+    license = lib.licenses.mit;
+  };
+}

--- a/.flox/pkgs/claude-code-plugin-claude-seo/default.nix
+++ b/.flox/pkgs/claude-code-plugin-claude-seo/default.nix
@@ -105,6 +105,13 @@ stdenv.mkDerivation {
       wrapProgram "$f" --prefix PATH : "$runtimeBins:$out/bin"
     done
 
+    # Rewrite upstream-install path references in markdown files to
+    # the ''${CLAUDE_PLUGIN_ROOT}/... form that Claude Code uses for
+    # plugins. Driven by a basename index of the plugin tree, so new
+    # upstream files added in future versions are picked up without
+    # changing this derivation.
+    "$out/bin/python3" ${./fix_md_paths.py} "$PLUGIN_DIR"
+
     runHook postInstall
   '';
 

--- a/.flox/pkgs/claude-code-plugin-claude-seo/fix_md_paths.py
+++ b/.flox/pkgs/claude-code-plugin-claude-seo/fix_md_paths.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Build-time helper: rewrite upstream-install path references in
+plugin markdown files to ${CLAUDE_PLUGIN_ROOT}/<actual-path>.
+
+The upstream repo's docs reference scripts and agent files at the
+paths the upstream install.sh creates them at:
+
+    ~/.claude/skills/seo/scripts/foo.py
+    ~/.claude/skills/seo-image-gen/scripts/foo.py
+    ~/.claude/agents/seo-foo.md
+    skills/seo/scripts/foo.py            (bare relative form)
+    agents/seo-foo.md                    (bare relative form)
+
+In a Flox-managed install the same files live under the plugin root
+exposed to Claude Code via ${CLAUDE_PLUGIN_ROOT}. This script walks
+the plugin tree, indexes every file by every path suffix, and for
+each reference picks the longest unambiguous suffix that matches a
+real file. That mapping drives the rewrite.
+
+Forwards-compatible: the index is built from whatever files are in
+the plugin tree at build time, so new upstream files are picked up
+automatically. Ambiguous suffixes (e.g. bare 'SKILL.md', which
+collides 27 times) fall through to longer suffixes; if nothing
+unambiguous is found, the reference is left alone.
+
+Usage: fix_md_paths.py <plugin-dir>
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+
+SUFFIXES_INDEXED = (".py", ".md", ".sh", ".json", ".txt", ".toml")
+PREFIX = "${CLAUDE_PLUGIN_ROOT}/"
+
+# Form 1: ~/, $HOME, or ${HOME} expansion of ~/.claude/<anything>.
+HOME_REF_RE = re.compile(
+    r"(?:~|\$HOME|\$\{HOME\})/\.claude/[A-Za-z0-9_./-]+"
+)
+
+# Form 2: bare 'skills/...' or 'agents/...' starting at a word
+# boundary. Anchored to (skills|agents) on purpose so this does not
+# match arbitrary relative paths.
+BARE_REF_RE = re.compile(
+    r"(?<![A-Za-z0-9_./~$-])(?:skills|agents)/[A-Za-z0-9_./-]+"
+)
+
+
+def build_indexes(
+    plugin_dir: str,
+) -> tuple[set[str], dict[str, set[str]]]:
+    """Walk the plugin tree and build two indexes.
+
+    Returns (all_relpaths, suffix_to_relpaths) where:
+    - all_relpaths is the set of every rel-path of an indexed file
+      (relative to plugin_dir, using '/' as separator)
+    - suffix_to_relpaths maps every '/'-separated suffix of every
+      rel-path back to the set of rel-paths that end with it. For a
+      file at 'a/b/c/d.py' the suffixes are 'd.py', 'c/d.py',
+      'b/c/d.py', and 'a/b/c/d.py'.
+    """
+    all_relpaths: set[str] = set()
+    suffix_to_relpaths: dict[str, set[str]] = {}
+    for root, _, files in os.walk(plugin_dir):
+        for fn in files:
+            if not fn.endswith(SUFFIXES_INDEXED):
+                continue
+            abs_path = os.path.join(root, fn)
+            rel = os.path.relpath(abs_path, plugin_dir).replace(os.sep, "/")
+            all_relpaths.add(rel)
+            parts = rel.split("/")
+            for i in range(len(parts)):
+                suffix = "/".join(parts[i:])
+                suffix_to_relpaths.setdefault(suffix, set()).add(rel)
+    return all_relpaths, suffix_to_relpaths
+
+
+def find_rel(
+    trailing: str,
+    all_relpaths: set[str],
+    suffix_to_relpaths: dict[str, set[str]],
+) -> str | None:
+    """Resolve a reference's trailing path to a real rel-path.
+
+    Strategy: try exact rel-path match first (so e.g.
+    'skills/seo-image-gen/SKILL.md' resolves to itself even though
+    it is also a suffix of 'extensions/banana/skills/seo-image-gen/
+    SKILL.md'). Fall back to matching progressively shorter
+    suffixes; accept a suffix only if it points to exactly one
+    rel-path or to an exact rel-path.
+    """
+    if trailing in all_relpaths:
+        return trailing
+    parts = trailing.split("/")
+    for i in range(1, len(parts)):
+        suffix = "/".join(parts[i:])
+        if not suffix:
+            continue
+        if suffix in all_relpaths:
+            return suffix
+        candidates = suffix_to_relpaths.get(suffix)
+        if candidates is not None and len(candidates) == 1:
+            return next(iter(candidates))
+    return None
+
+
+def trailing_after_dotclaude(ref: str) -> str:
+    """Strip the leading '~/.claude/' (or $HOME/.claude/) prefix."""
+    for prefix in ("~/.claude/", "$HOME/.claude/", "${HOME}/.claude/"):
+        if ref.startswith(prefix):
+            return ref[len(prefix):]
+    return ref
+
+
+def rewrite_text(
+    text: str,
+    all_relpaths: set[str],
+    suffix_to_relpaths: dict[str, set[str]],
+) -> tuple[str, int]:
+    rewrites = 0
+
+    def make_resolver(strip_dotclaude: bool):
+        def resolve(match: re.Match[str]) -> str:
+            nonlocal rewrites
+            full = match.group(0)
+            trailing = (
+                trailing_after_dotclaude(full) if strip_dotclaude else full
+            )
+            rel = find_rel(trailing, all_relpaths, suffix_to_relpaths)
+            if rel is None:
+                return full
+            replacement = PREFIX + rel
+            if replacement == full:
+                return full
+            rewrites += 1
+            return replacement
+        return resolve
+
+    text = HOME_REF_RE.sub(make_resolver(strip_dotclaude=True), text)
+    text = BARE_REF_RE.sub(make_resolver(strip_dotclaude=False), text)
+    return text, rewrites
+
+
+def main(plugin_dir: str) -> None:
+    all_relpaths, suffix_to_relpaths = build_indexes(plugin_dir)
+
+    files_changed = 0
+    refs_changed = 0
+    for root, _, files in os.walk(plugin_dir):
+        for fn in files:
+            if not fn.endswith(".md"):
+                continue
+            path = os.path.join(root, fn)
+            try:
+                with open(path, "r", encoding="utf-8") as fh:
+                    content = fh.read()
+            except (UnicodeDecodeError, OSError):
+                continue
+            new_content, n = rewrite_text(
+                content, all_relpaths, suffix_to_relpaths
+            )
+            if n == 0:
+                continue
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(new_content)
+            files_changed += 1
+            refs_changed += n
+
+    print(
+        f"fix_md_paths: rewrote {refs_changed} reference(s) "
+        f"across {files_changed} markdown file(s); "
+        f"indexed {len(all_relpaths)} file(s)"
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: fix_md_paths.py <plugin-dir>", file=sys.stderr)
+        sys.exit(2)
+    main(sys.argv[1])

--- a/.flox/pkgs/claude-code-plugin-claude-seo/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-claude-seo/hashes.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.9.6",
+  "srcHash": "sha256-7t0OtRvs958Qa0h1WHgbeEq9q9WRpY8Njjvut9w6dcE="
+}

--- a/.flox/pkgs/claude-code-plugin-claude-seo/publish.json
+++ b/.flox/pkgs/claude-code-plugin-claude-seo/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/claude-code-plugin-claude-seo/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-claude-seo/upgrade.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_tag=$(curl -sf \
+  https://api.github.com/repos/AgriciDaniel/claude-seo/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating claude-code-plugin-claude-seo from $current_version to $latest_version"
+
+src_url="https://github.com/AgriciDaniel/claude-seo/archive/refs/tags/v${latest_version}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  '{version: $v, srcHash: $s}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"


### PR DESCRIPTION
## Summary

Adds a new Flox package `claude-code-plugin-claude-seo` that wraps the upstream [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) Claude Code plugin (v1.9.6, MIT) and ships everything needed to run it — Python interpreter, every third-party Python module the plugin imports, and the supporting CLIs (`gh`, `curl`, `jq`, `git`, `nodejs`) — bundled from nixpkgs.

Three commits:

1. **`feat(claude-seo): add claude-code-plugin-claude-seo package`** — barebones derivation that fetches the upstream tarball via `fetchFromGitHub`, installs it under `share/claude-code/plugins/claude-seo/`, strips upstream install/uninstall scripts and dev infra (`.github`, `.devcontainer`), and ships an `upgrade.sh` modeled on `.flox/pkgs/agent-deck/upgrade.sh`.
2. **`feat(claude-seo): bundle python3 + binaries from nix into the plugin`** — wraps a `python3.withPackages` (beautifulsoup4, lxml, matplotlib, numpy, openpyxl, pillow, playwright, pypdf, requests, urllib3, validators, weasyprint, the google-api-python-client / google-auth stack) with `makeBinaryWrapper` so it sees `gh`, `curl`, `jq`, `git`, `nodejs` on `PATH`. Then patches every `#!/usr/bin/env python3` shebang under `scripts/`, `hooks/`, and `extensions/*/scripts/` to point at that wrapped python, rewrites `hooks/hooks.json` to invoke `validate-schema.py` directly so the patched shebang is honored, and `wrapProgram`-wraps every `extensions/*/{install,uninstall}.sh` with the same runtime PATH. `makeBinaryWrapper` is used for python because Darwin's shebang-chain handling is unreliable for shell-script wrappers under stripped environments.
3. **`feat(claude-seo): rewrite upstream-install path refs in markdown`** — adds a build-time helper (`fix_md_paths.py`) that walks the staged plugin tree, indexes every file by every `/`-separated path suffix, and rewrites references in markdown that point at the upstream `install.sh` layout (`~/.claude/skills/seo/...`, `~/.claude/agents/...`, bare `skills/...` or `agents/...` relative paths) to the `${CLAUDE_PLUGIN_ROOT}/<rel-path>` form Claude Code uses for plugins. Resolution prefers an exact rel-path match over a suffix match, falls through to longer/shorter unambiguous suffixes, and leaves genuinely ambiguous refs alone. Forwards-compatible: index is rebuilt from whatever files the upstream tarball contains at build time, so new files added in future versions get the same treatment without touching the derivation. On v1.9.6 this rewrites 180 references across 23 markdown files (English `docs/`, all `SKILL.md` files where applicable, and the Ukrainian translations under `translations/uk/`).

## Closure size

Bundling the full Python + binary stack is heavy. On `aarch64-darwin`:

| Metric | Value |
| ------ | ----- |
| Output path (this derivation only) | 4.4 MB |
| **Full runtime closure (all transitive deps)** | **2.1 GB** |
| Number of store paths in closure | 249 |

Largest contributors:

- LLVM 21 + Clang 21 lib + Apple SDK 14.4: ~1.0 GB (pulled in via matplotlib / numpy / weasyprint compile-time deps; could potentially be trimmed by binary-stripping, separate follow-up)
- Python 3.13 interpreter + stdlib: ~107 MB
- `google-api-python-client`: ~94 MB
- `nodejs-slim` 24.14.0: ~75 MB
- `numpy` 2.4.2: ~45 MB

Each `flox publish --system <sys>` will upload an archive in this size class. Builders need disk + bandwidth budget accordingly. The first publish for all four systems is run manually after merge per the saved publish workflow.

## Notes for the reviewer

- `claude` itself is intentionally NOT in the wrapped runtime PATH — it is provided by the consumer's `flox/claude-code` package. Users running `extensions/*/install.sh` to wire up MCP servers still need an active flox env that includes claude-code on PATH.
- `playwright` is bundled but the browser binaries it needs are not. Skills that drive a browser will still require a separate `playwright install` step or `playwright-driver` integration in a follow-up.
- `google-analytics-data` was in `requirements.txt` but is not in nixpkgs; the `seo-google` skill's GA4 code path will fail at import time until upstream stops requiring it or it lands in nixpkgs.
- No environment is added or modified in this PR. A follow-up could add the package to `claude-demo/` or create a dedicated `claude-seo/` env with `flox/claude` and this package.

## Test plan

- [x] `nix-instantiate --parse default.nix` succeeds
- [x] `flox build claude-code-plugin-claude-seo` succeeds locally on `aarch64-darwin`
- [x] Plugin layout verified: `.claude-plugin/plugin.json` reports `claude-seo 1.9.6`, all three extensions present, install/uninstall scripts and `.github`/`.devcontainer` stripped
- [x] `bash upgrade.sh` is a no-op on the pinned version
- [x] Wrapped python is a Mach-O / ELF binary (not a shell script)
- [x] Smoke test under stripped env (`env -i PATH=/usr/bin:/bin`): `validate-schema.py` runs as Python, `python3 -c "import requests"` works, plugin scripts (`google_auth.py --help`) execute, `subprocess.run(["gh", "--version"])` finds gh
- [x] Markdown rewriter output: `fix_md_paths: rewrote 180 reference(s) across 23 markdown file(s); indexed 257 file(s)`
- [ ] Publish for all four systems via `flox publish -o flox claude-code-plugin-claude-seo --system <system>` (manual, after merge)