### PR TITLE
feat(impeccable): add claude-code-plugin-impeccable package

### DIFF
--- a/.flox/pkgs/claude-code-plugin-impeccable/default.nix
+++ b/.flox/pkgs/claude-code-plugin-impeccable/default.nix
@@ -80,6 +80,27 @@ stdenv.mkDerivation {
     done < <(find "$PLUGIN_DIR" -type f -name '*.md')
     echo "fix_md_paths: rewrote refs in $rewritten markdown file(s)"
 
+    # Drop an installed_plugins.json next to the plugin so claude-managed
+    # registers it in $CLAUDE_CONFIG_DIR/plugins/installed_plugins.json
+    # — without that file Claude Code lists the plugin but won't trust it.
+    # Schema follows the v2 (`plugins` wrapper) format claude-managed uses;
+    # installPath is patched to the real symlink target by `plugins add`.
+    cat > "$PLUGIN_DIR/installed_plugins.json" <<JSON
+    {
+      "plugins": {
+        "impeccable@flox": [
+          {
+            "installPath": "",
+            "scope": "project",
+            "version": "${version}",
+            "gitCommitSha": "flox-managed"
+          }
+        ]
+      },
+      "version": 2
+    }
+    JSON
+
     runHook postInstall
   '';
 

--- a/.flox/pkgs/claude-code-plugin-impeccable/default.nix
+++ b/.flox/pkgs/claude-code-plugin-impeccable/default.nix
@@ -1,4 +1,11 @@
-{ stdenv, lib, fetchFromGitHub }:
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  nodejs,
+  git,
+}:
 
 let
   versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
@@ -15,7 +22,15 @@ stdenv.mkDerivation {
     hash = srcHash;
   };
 
+  # makeBinaryWrapper produces a compiled C wrapper for node so it
+  # is exec'd directly by the kernel via shebang on Darwin, where
+  # shebang chains through a shell-script wrapper are unreliable
+  # under stripped environments.
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
   installPhase = ''
+    runHook preInstall
+
     PLUGIN_DIR="$out/share/claude-code/plugins/impeccable"
     mkdir -p "$PLUGIN_DIR"
 
@@ -24,11 +39,32 @@ stdenv.mkDerivation {
     # subdirectory — that's what marketplace.json points at.
     cp -r "$src/plugin/." "$PLUGIN_DIR/"
     chmod -R u+w "$PLUGIN_DIR"
+
+    # Wrap node so the one git invocation in scripts/is-generated.mjs
+    # (`git check-ignore`) and the npx-based external impeccable CLI
+    # referenced from markdown resolve from Nix without depending on
+    # the caller's PATH.
+    runtimeBins=${lib.makeBinPath [ git nodejs ]}
+    mkdir -p "$out/bin"
+    makeBinaryWrapper "${nodejs}/bin/node" "$out/bin/node" \
+      --prefix PATH : "$runtimeBins"
+
+    # Repoint every #!/usr/bin/env node shebang at the wrapped node.
+    # Marks files executable so the kernel honors the shebang when
+    # Claude Code invokes them.
+    while IFS= read -r f; do
+      head -1 "$f" | grep -q '/usr/bin/env node' || continue
+      substituteInPlace "$f" --replace-fail \
+        '#!/usr/bin/env node' "#!$out/bin/node"
+      chmod +x "$f"
+    done < <(find "$PLUGIN_DIR" -type f \( -name '*.mjs' -o -name '*.js' \))
+
+    runHook postInstall
   '';
 
   meta = {
     description =
-      "Impeccable design fluency plugin for Claude Code (1 skill, 23 commands)";
+      "Impeccable design fluency plugin for Claude Code (1 skill, 23 commands) with Node.js bundled";
     homepage = "https://github.com/pbakaus/impeccable";
     license = lib.licenses.asl20;
   };

--- a/.flox/pkgs/claude-code-plugin-impeccable/default.nix
+++ b/.flox/pkgs/claude-code-plugin-impeccable/default.nix
@@ -49,10 +49,19 @@ stdenv.mkDerivation {
     # (`git check-ignore`) and the npx-based external impeccable CLI
     # referenced from markdown resolve from Nix without depending on
     # the caller's PATH.
+    #
+    # Place node *inside* the plugin tree so users can call it via
+    # ''${CLAUDE_PLUGIN_ROOT}/bin/node — the consumer's flox env doesn't
+    # ship nodejs (and shouldn't have to, just because they want this
+    # plugin), so Claude's `Bash(node ...)` invocations would otherwise
+    # fail with `command not found: node`.
     runtimeBins=${lib.makeBinPath [ git nodejs ]}
-    mkdir -p "$out/bin"
-    makeBinaryWrapper "${nodejs}/bin/node" "$out/bin/node" \
+    mkdir -p "$PLUGIN_DIR/bin"
+    makeBinaryWrapper "${nodejs}/bin/node" "$PLUGIN_DIR/bin/node" \
       --prefix PATH : "$runtimeBins"
+    # npx is a JS script; it'll find the wrapped node via the wrapper
+    # itself prepending nodejs onto PATH at exec time.
+    ln -s "${nodejs}/bin/npx" "$PLUGIN_DIR/bin/npx"
 
     # Repoint every #!/usr/bin/env node shebang at the wrapped node.
     # Marks files executable so the kernel honors the shebang when
@@ -60,7 +69,7 @@ stdenv.mkDerivation {
     while IFS= read -r f; do
       head -1 "$f" | grep -q '/usr/bin/env node' || continue
       substituteInPlace "$f" --replace-fail \
-        '#!/usr/bin/env node' "#!$out/bin/node"
+        '#!/usr/bin/env node' "#!$PLUGIN_DIR/bin/node"
       chmod +x "$f"
     done < <(find "$PLUGIN_DIR" -type f \( -name '*.mjs' -o -name '*.js' \))
 
@@ -69,14 +78,32 @@ stdenv.mkDerivation {
     # the form Claude Code uses for plugins. Upstream's markdown is shared
     # across harnesses so it embeds the user-install layout, which is wrong
     # under a plugin install where the plugin root is `plugin/`.
+    #
+    # Then prefix bare `node ''${CLAUDE_PLUGIN_ROOT}/...` and
+    # `npx impeccable ...` invocations with our bundled binaries, so
+    # they don't depend on the consumer env having nodejs installed.
     rewritten=0
     while IFS= read -r f; do
+      changed=0
       if grep -q '\.claude/skills/impeccable/scripts/' "$f"; then
         substituteInPlace "$f" --replace-quiet \
           '.claude/skills/impeccable/scripts/' \
           '${pluginRootRef}/skills/impeccable/scripts/'
-        rewritten=$((rewritten + 1))
+        changed=1
       fi
+      if grep -qF 'node ${pluginRootRef}/' "$f"; then
+        substituteInPlace "$f" --replace-quiet \
+          'node ${pluginRootRef}/' \
+          '${pluginRootRef}/bin/node ${pluginRootRef}/'
+        changed=1
+      fi
+      if grep -q 'npx impeccable' "$f"; then
+        substituteInPlace "$f" --replace-quiet \
+          'npx impeccable' \
+          '${pluginRootRef}/bin/npx impeccable'
+        changed=1
+      fi
+      [ $changed -eq 1 ] && rewritten=$((rewritten + 1))
     done < <(find "$PLUGIN_DIR" -type f -name '*.md')
     echo "fix_md_paths: rewrote refs in $rewritten markdown file(s)"
 

--- a/.flox/pkgs/claude-code-plugin-impeccable/default.nix
+++ b/.flox/pkgs/claude-code-plugin-impeccable/default.nix
@@ -9,7 +9,7 @@
 
 let
   versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
-  inherit (versionData) version srcHash;
+  inherit (versionData) version srcHash commitSha;
 
   # Escape so the indented-string interpolation below produces the
   # literal token `${CLAUDE_PLUGIN_ROOT}` in the resulting bash, with
@@ -93,7 +93,7 @@ stdenv.mkDerivation {
             "installPath": "",
             "scope": "project",
             "version": "${version}",
-            "gitCommitSha": "flox-managed"
+            "gitCommitSha": "${commitSha}"
           }
         ]
       },

--- a/.flox/pkgs/claude-code-plugin-impeccable/default.nix
+++ b/.flox/pkgs/claude-code-plugin-impeccable/default.nix
@@ -10,6 +10,11 @@
 let
   versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
   inherit (versionData) version srcHash;
+
+  # Escape so the indented-string interpolation below produces the
+  # literal token `${CLAUDE_PLUGIN_ROOT}` in the resulting bash, with
+  # no further Nix or bash expansion.
+  pluginRootRef = "\${CLAUDE_PLUGIN_ROOT}";
 in
 stdenv.mkDerivation {
   pname = "claude-code-plugin-impeccable";
@@ -58,6 +63,22 @@ stdenv.mkDerivation {
         '#!/usr/bin/env node' "#!$out/bin/node"
       chmod +x "$f"
     done < <(find "$PLUGIN_DIR" -type f \( -name '*.mjs' -o -name '*.js' \))
+
+    # Rewrite hardcoded `.claude/skills/impeccable/scripts/<X>` references
+    # in markdown to `''${CLAUDE_PLUGIN_ROOT}/skills/impeccable/scripts/<X>`,
+    # the form Claude Code uses for plugins. Upstream's markdown is shared
+    # across harnesses so it embeds the user-install layout, which is wrong
+    # under a plugin install where the plugin root is `plugin/`.
+    rewritten=0
+    while IFS= read -r f; do
+      if grep -q '\.claude/skills/impeccable/scripts/' "$f"; then
+        substituteInPlace "$f" --replace-quiet \
+          '.claude/skills/impeccable/scripts/' \
+          '${pluginRootRef}/skills/impeccable/scripts/'
+        rewritten=$((rewritten + 1))
+      fi
+    done < <(find "$PLUGIN_DIR" -type f -name '*.md')
+    echo "fix_md_paths: rewrote refs in $rewritten markdown file(s)"
 
     runHook postInstall
   '';

--- a/.flox/pkgs/claude-code-plugin-impeccable/default.nix
+++ b/.flox/pkgs/claude-code-plugin-impeccable/default.nix
@@ -1,0 +1,35 @@
+{ stdenv, lib, fetchFromGitHub }:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash;
+in
+stdenv.mkDerivation {
+  pname = "claude-code-plugin-impeccable";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "pbakaus";
+    repo = "impeccable";
+    tag = "skill-v${version}";
+    hash = srcHash;
+  };
+
+  installPhase = ''
+    PLUGIN_DIR="$out/share/claude-code/plugins/impeccable"
+    mkdir -p "$PLUGIN_DIR"
+
+    # Upstream ships per-harness mirrors at top-level (.claude/, .cursor/,
+    # .gemini/, etc.). The Claude Code plugin source is the `plugin/`
+    # subdirectory — that's what marketplace.json points at.
+    cp -r "$src/plugin/." "$PLUGIN_DIR/"
+    chmod -R u+w "$PLUGIN_DIR"
+  '';
+
+  meta = {
+    description =
+      "Impeccable design fluency plugin for Claude Code (1 skill, 23 commands)";
+    homepage = "https://github.com/pbakaus/impeccable";
+    license = lib.licenses.asl20;
+  };
+}

--- a/.flox/pkgs/claude-code-plugin-impeccable/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-impeccable/hashes.json
@@ -1,4 +1,5 @@
 {
   "version": "3.0.7",
-  "srcHash": "sha256-8EhIVNz31086zvuJ4ShgGcV3fzPv4Axu/ItVu+H5RFw="
+  "srcHash": "sha256-8EhIVNz31086zvuJ4ShgGcV3fzPv4Axu/ItVu+H5RFw=",
+  "commitSha": "cf6f6081dcca4fda55599b0bfb6c40d26de0ff14"
 }

--- a/.flox/pkgs/claude-code-plugin-impeccable/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-impeccable/hashes.json
@@ -1,0 +1,4 @@
+{
+  "version": "3.0.7",
+  "srcHash": "sha256-8EhIVNz31086zvuJ4ShgGcV3fzPv4Axu/ItVu+H5RFw="
+}

--- a/.flox/pkgs/claude-code-plugin-impeccable/publish.json
+++ b/.flox/pkgs/claude-code-plugin-impeccable/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/claude-code-plugin-impeccable/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-impeccable/upgrade.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+
+# Upstream tags releases as `skill-vX.Y.Z`. Pull the latest such tag.
+latest_tag=$(curl -sf \
+  https://api.github.com/repos/pbakaus/impeccable/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#skill-v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating claude-code-plugin-impeccable from $current_version to $latest_version"
+
+src_url="https://github.com/pbakaus/impeccable/archive/refs/tags/skill-v${latest_version}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  '{version: $v, srcHash: $s}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.flox/pkgs/claude-code-plugin-impeccable/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-impeccable/upgrade.sh
@@ -29,9 +29,21 @@ src_sri=$(nix --extra-experimental-features nix-command \
   hash convert --hash-algo sha256 --to sri "$src_hash")
 echo "  srcHash: $src_sri"
 
+# Resolve the tag to its commit SHA — Claude Code's installed_plugins.json
+# records gitCommitSha per entry, and shipping the real SHA lets users
+# reproduce or audit exactly which upstream commit they have.
+commit_sha=$(git ls-remote https://github.com/pbakaus/impeccable.git \
+  "refs/tags/skill-v${latest_version}" | awk '{print $1}')
+if [ -z "$commit_sha" ]; then
+  echo "ERROR: could not resolve skill-v${latest_version} to a commit SHA"
+  exit 1
+fi
+echo "  commitSha: $commit_sha"
+
 jq -n \
   --arg v "$latest_version" \
   --arg s "$src_sri" \
-  '{version: $v, srcHash: $s}' > "$HASHES_FILE"
+  --arg c "$commit_sha" \
+  '{version: $v, srcHash: $s, commitSha: $c}' > "$HASHES_FILE"
 
 echo "Updated to $latest_version"

--- a/.flox/pkgs/claude-managed/default.nix
+++ b/.flox/pkgs/claude-managed/default.nix
@@ -5,7 +5,7 @@
 
 buildGoModule {
   pname = "claude-managed";
-  version = "0.2.8";
+  version = "0.2.9";
 
   src = ./.;
 

--- a/.flox/pkgs/claude-managed/internal/emit/emit.go
+++ b/.flox/pkgs/claude-managed/internal/emit/emit.go
@@ -27,6 +27,7 @@ func HookCode(p *Params) string {
 
 	emitKeychainBridge(&sb)
 	emitFragments(&sb, p)
+	emitPluginWrapper(&sb)
 	emitCleanupFunc(&sb)
 
 	return sb.String()
@@ -126,10 +127,6 @@ func emitFragments(sb *strings.Builder, p *Params) {
 	for _, f := range p.Frags.Plugins {
 		fmt.Fprintf(sb, "claude-managed --config-dir \"$CLAUDE_CONFIG_DIR\" plugins add \"$FLOX_ENV/share/claude-code/plugins/%s\"\n", f.Name)
 	}
-
-	if len(p.Frags.Plugins) > 0 {
-		emitPluginWrapper(sb, p)
-	}
 }
 
 // nameForFragment returns the name to use in the add command path.
@@ -141,21 +138,33 @@ func nameForFragment(typeName string, f discover.Fragment) string {
 	return f.Name + ".md"
 }
 
-func emitPluginWrapper(sb *strings.Builder, p *Params) {
-	sb.WriteString("\n# create claude wrapper to load plugins\n")
-	// reference env vars instead of baked-in absolute paths so the wrapper
-	// stays valid across nix store rebuilds and across machines that share
-	// the same $FLOX_ENV_PROJECT. $FLOX_ENV/bin/claude is used verbatim
-	// because `command -v claude` from inside the hook resolves back to
-	// this wrapper (PATH already has $CLAUDE_CONFIG_DIR/bin prepended)
-	sb.WriteString("{\n")
-	sb.WriteString("  echo '#!/usr/bin/env bash'\n")
-	sb.WriteString("  echo 'exec \"$FLOX_ENV/bin/claude\" \\'\n")
-	for _, f := range p.Frags.Plugins {
-		fmt.Fprintf(sb, "  echo '  --plugin-dir \"$CLAUDE_CONFIG_DIR/plugins/%s\" \\'\n", f.Name)
-	}
-	sb.WriteString("  echo '  \"$@\"'\n")
-	sb.WriteString("} > \"$CLAUDE_CONFIG_DIR/bin/claude\"\n")
+// emitPluginWrapper writes a thin claude wrapper at
+// $CLAUDE_CONFIG_DIR/bin/claude that discovers plugins at exec time
+// from $CLAUDE_CONFIG_DIR/plugins/*/. This means plugins added later
+// (e.g. via `claude-managed plugins add <abspath>` for a locally-built
+// package not yet in the env's share dir) are picked up without
+// regenerating the wrapper.
+//
+// Always emitted: even if no plugins are present at activation time,
+// shipping the wrapper means the moment a user adds one it's already
+// on PATH and ready to load it. The runtime loop is a no-op when the
+// plugins dir is empty or absent.
+func emitPluginWrapper(sb *strings.Builder) {
+	sb.WriteString("\n# claude wrapper: discovers plugins at exec time from $CLAUDE_CONFIG_DIR/plugins/*/\n")
+	sb.WriteString("cat > \"$CLAUDE_CONFIG_DIR/bin/claude\" <<'WRAPPER'\n")
+	sb.WriteString("#!/usr/bin/env bash\n")
+	sb.WriteString("plugin_args=()\n")
+	sb.WriteString("if [ -d \"$CLAUDE_CONFIG_DIR/plugins\" ]; then\n")
+	sb.WriteString("  for d in \"$CLAUDE_CONFIG_DIR/plugins\"/*/; do\n")
+	sb.WriteString("    [ -d \"$d\" ] || continue\n")
+	sb.WriteString("    plugin_args+=(--plugin-dir \"${d%/}\")\n")
+	sb.WriteString("  done\n")
+	sb.WriteString("fi\n")
+	// $FLOX_ENV/bin/claude is used verbatim because `command -v claude`
+	// from inside this wrapper would resolve back to itself (PATH has
+	// $CLAUDE_CONFIG_DIR/bin prepended).
+	sb.WriteString("exec \"$FLOX_ENV/bin/claude\" \"${plugin_args[@]}\" \"$@\"\n")
+	sb.WriteString("WRAPPER\n")
 	sb.WriteString("chmod +x \"$CLAUDE_CONFIG_DIR/bin/claude\"\n")
 }
 

--- a/.flox/pkgs/claude-managed/internal/emit/emit_test.go
+++ b/.flox/pkgs/claude-managed/internal/emit/emit_test.go
@@ -24,8 +24,15 @@ func TestHookCode_Full(t *testing.T) {
 	if !strings.Contains(result, `exec "$FLOX_ENV/bin/claude"`) {
 		t.Errorf("wrapper body must reference $FLOX_ENV/bin/claude at runtime")
 	}
-	if !strings.Contains(result, `--plugin-dir "$CLAUDE_CONFIG_DIR/plugins/typescript-lsp"`) {
-		t.Errorf("wrapper body must reference $CLAUDE_CONFIG_DIR/plugins/... at runtime")
+	// wrapper must discover plugins at exec time, not bake them in at hook time
+	if !strings.Contains(result, `for d in "$CLAUDE_CONFIG_DIR/plugins"/*/`) {
+		t.Errorf("wrapper must iterate $CLAUDE_CONFIG_DIR/plugins/*/ at runtime")
+	}
+	if !strings.Contains(result, `plugin_args+=(--plugin-dir`) {
+		t.Errorf("wrapper must build --plugin-dir args at runtime")
+	}
+	if strings.Contains(result, `--plugin-dir "$CLAUDE_CONFIG_DIR/plugins/typescript-lsp"`) {
+		t.Errorf("wrapper should NOT bake plugin names in at hook time")
 	}
 	if strings.Contains(result, `_cm_real=`) {
 		t.Errorf("wrapper should not resolve claude eagerly; use $FLOX_ENV at runtime")
@@ -98,6 +105,14 @@ func TestHookCode_NoFragments(t *testing.T) {
 	}
 	if !strings.Contains(result, "_claude_managed_cleanup()") {
 		t.Errorf("missing cleanup function")
+	}
+	// wrapper is emitted unconditionally so manually-added plugins
+	// (claude-managed plugins add <abspath>) work without re-activation
+	if !strings.Contains(result, `cat > "$CLAUDE_CONFIG_DIR/bin/claude"`) {
+		t.Errorf("wrapper must be emitted even when no plugins are discovered")
+	}
+	if !strings.Contains(result, `for d in "$CLAUDE_CONFIG_DIR/plugins"/*/`) {
+		t.Errorf("wrapper must iterate plugins at runtime even when none discovered")
 	}
 }
 

--- a/.flox/pkgs/claude-managed/main.go
+++ b/.flox/pkgs/claude-managed/main.go
@@ -15,7 +15,7 @@ import (
 	"flox.dev/claude-managed/internal/symlinks"
 )
 
-const version = "0.2.8"
+const version = "0.2.9"
 
 // ANSI color helpers
 func ansi(code, s string) string { return "\033[" + code + "m" + s + "\033[0m" }

--- a/claude-demo/.flox/env/manifest.lock
+++ b/claude-demo/.flox/env/manifest.lock
@@ -38,27 +38,27 @@
     {
       "attr_path": "claude-code",
       "broken": false,
-      "derivation": "/nix/store/6pbshqnkrzpg3xj23jkprwsih88s9s5i-claude-code-2.1.118.drv",
+      "derivation": "/nix/store/kpyp51m8s6mr8yyxvvjmagljngj73b64-claude-code-2.1.128.drv",
       "description": "Agentic coding tool from Anthropic",
       "install_id": "claude-code",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/floxenvs?rev=68bbb95e3946234785720a1a21138a66eaa8823c",
-      "name": "claude-code-2.1.118",
+      "locked_url": "https://github.com/flox/floxenvs?rev=50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "name": "claude-code-2.1.128",
       "pname": "claude-code",
-      "rev": "68bbb95e3946234785720a1a21138a66eaa8823c",
-      "rev_count": 2853,
-      "rev_date": "2026-04-23T08:12:25Z",
-      "scrape_date": "2026-05-04T01:21:27.931304353Z",
+      "rev": "50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "rev_count": 2988,
+      "rev_date": "2026-05-05T09:37:59Z",
+      "scrape_date": "2026-05-05T12:30:31.837438Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": true,
-      "version": "2.1.118",
+      "version": "2.1.128",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/jr1wi667yjn32071wph00i2ky62c2smw-claude-code-2.1.118"
+        "out": "/nix/store/xxkfnidc8d4c8sgkyg45srkd920zq5bh-claude-code-2.1.128"
       },
       "system": "aarch64-darwin",
       "group": "claude-code",
@@ -67,27 +67,27 @@
     {
       "attr_path": "claude-code",
       "broken": false,
-      "derivation": "/nix/store/8hwa0fvymv4bf64408z60gxgwz45iqhi-claude-code-2.1.118.drv",
+      "derivation": "/nix/store/wkdpjcwlmdvgkhaqh9zh2b992als394l-claude-code-2.1.128.drv",
       "description": "Agentic coding tool from Anthropic",
       "install_id": "claude-code",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/floxenvs?rev=68bbb95e3946234785720a1a21138a66eaa8823c",
-      "name": "claude-code-2.1.118",
+      "locked_url": "https://github.com/flox/floxenvs?rev=50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "name": "claude-code-2.1.128",
       "pname": "claude-code",
-      "rev": "68bbb95e3946234785720a1a21138a66eaa8823c",
-      "rev_count": 2853,
-      "rev_date": "2026-04-23T08:12:25Z",
-      "scrape_date": "2026-05-04T01:21:27.931308469Z",
+      "rev": "50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "rev_count": 2988,
+      "rev_date": "2026-05-05T09:37:59Z",
+      "scrape_date": "2026-05-05T12:30:31.837440Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": true,
-      "version": "2.1.118",
+      "version": "2.1.128",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/9aqm32n4gm0h05p40vf6bpsj5bycmis0-claude-code-2.1.118"
+        "out": "/nix/store/0gxhbpa9q2abxkj3vq83rcprn9kljyv4-claude-code-2.1.128"
       },
       "system": "aarch64-linux",
       "group": "claude-code",
@@ -96,27 +96,27 @@
     {
       "attr_path": "claude-code",
       "broken": false,
-      "derivation": "/nix/store/qy3x66jgq6clmbq26kbr2s5sbgksk4g8-claude-code-2.1.118.drv",
+      "derivation": "/nix/store/xzwfg3ja2dib9m17xa2m1lw49453w4lc-claude-code-2.1.128.drv",
       "description": "Agentic coding tool from Anthropic",
       "install_id": "claude-code",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/floxenvs?rev=68bbb95e3946234785720a1a21138a66eaa8823c",
-      "name": "claude-code-2.1.118",
+      "locked_url": "https://github.com/flox/floxenvs?rev=50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "name": "claude-code-2.1.128",
       "pname": "claude-code",
-      "rev": "68bbb95e3946234785720a1a21138a66eaa8823c",
-      "rev_count": 2853,
-      "rev_date": "2026-04-23T08:12:25Z",
-      "scrape_date": "2026-05-04T01:21:27.931309080Z",
+      "rev": "50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "rev_count": 2988,
+      "rev_date": "2026-05-05T09:37:59Z",
+      "scrape_date": "2026-05-05T12:30:31.837441Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": true,
-      "version": "2.1.118",
+      "version": "2.1.128",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/3f00lyb2glasbwrm4sx85iyv3k0zgpna-claude-code-2.1.118"
+        "out": "/nix/store/hsgcr9wfbykxgk369lz7ql9fab0kwsv3-claude-code-2.1.128"
       },
       "system": "x86_64-darwin",
       "group": "claude-code",
@@ -125,27 +125,27 @@
     {
       "attr_path": "claude-code",
       "broken": false,
-      "derivation": "/nix/store/vnhlw5kwn923q3vwww1wzpwl3n233ysm-claude-code-2.1.118.drv",
+      "derivation": "/nix/store/wf0qfmgjli19zif1an950lcvhr9pj50v-claude-code-2.1.128.drv",
       "description": "Agentic coding tool from Anthropic",
       "install_id": "claude-code",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/floxenvs?rev=68bbb95e3946234785720a1a21138a66eaa8823c",
-      "name": "claude-code-2.1.118",
+      "locked_url": "https://github.com/flox/floxenvs?rev=50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "name": "claude-code-2.1.128",
       "pname": "claude-code",
-      "rev": "68bbb95e3946234785720a1a21138a66eaa8823c",
-      "rev_count": 2853,
-      "rev_date": "2026-04-23T08:12:25Z",
-      "scrape_date": "2026-05-04T01:21:27.931309631Z",
+      "rev": "50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "rev_count": 2988,
+      "rev_date": "2026-05-05T09:37:59Z",
+      "scrape_date": "2026-05-05T12:30:31.837441Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": true,
-      "version": "2.1.118",
+      "version": "2.1.128",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/5j6djxvjszinc3z1fmp1ah96420z90zl-claude-code-2.1.118"
+        "out": "/nix/store/82skqpdqjznysnj4iv24s1byljch7xc6-claude-code-2.1.128"
       },
       "system": "x86_64-linux",
       "group": "claude-code",
@@ -162,7 +162,7 @@
       "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
       "rev_count": 2851,
       "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:27.931315109Z",
+      "scrape_date": "2026-05-05T12:30:31.837448Z",
       "stabilities": [
         "unstable"
       ],
@@ -189,7 +189,7 @@
       "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
       "rev_count": 2851,
       "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:27.931316842Z",
+      "scrape_date": "2026-05-05T12:30:31.837451Z",
       "stabilities": [
         "unstable"
       ],
@@ -216,7 +216,7 @@
       "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
       "rev_count": 2851,
       "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:27.931317342Z",
+      "scrape_date": "2026-05-05T12:30:31.837451Z",
       "stabilities": [
         "unstable"
       ],
@@ -243,7 +243,7 @@
       "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
       "rev_count": 2851,
       "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:27.931317893Z",
+      "scrape_date": "2026-05-05T12:30:31.837452Z",
       "stabilities": [
         "unstable"
       ],
@@ -262,27 +262,27 @@
     {
       "attr_path": "claude-managed",
       "broken": false,
-      "derivation": "/nix/store/kkbinyqmj9m0crylzwqll64r119nqmg8-claude-managed-0.2.8.drv",
+      "derivation": "/nix/store/qbw6bs6a38lxkfyfxgm52g7ljb16vz2p-claude-managed-0.2.9.drv",
       "description": "Flox-native config management for Claude Code CLI",
       "install_id": "claude-managed",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "name": "claude-managed-0.2.8",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "name": "claude-managed-0.2.9",
       "pname": "claude-managed",
-      "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "rev_count": 2851,
-      "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:27.931323191Z",
+      "rev": "2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "rev_count": 2908,
+      "rev_date": "2026-05-05T12:12:15Z",
+      "scrape_date": "2026-05-05T12:30:31.837457Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.2.8",
+      "version": "0.2.9",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/63vh9djrqk42p5mc4rzvzvr4fnwgwb24-claude-managed-0.2.8"
+        "out": "/nix/store/yn3x7wrnayja10vdsqsy8gwzpayabbjb-claude-managed-0.2.9"
       },
       "system": "aarch64-darwin",
       "group": "claude-managed",
@@ -291,27 +291,27 @@
     {
       "attr_path": "claude-managed",
       "broken": false,
-      "derivation": "/nix/store/vggb7bf18ifpc0lrk8rnaq6grgicgsm4-claude-managed-0.2.8.drv",
+      "derivation": "/nix/store/2bw6awsbzsx59c2y0bqyx1ajhn9xi0h3-claude-managed-0.2.9.drv",
       "description": "Flox-native config management for Claude Code CLI",
       "install_id": "claude-managed",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "name": "claude-managed-0.2.8",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "name": "claude-managed-0.2.9",
       "pname": "claude-managed",
-      "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "rev_count": 2851,
-      "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:27.931323862Z",
+      "rev": "2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "rev_count": 2908,
+      "rev_date": "2026-05-05T12:12:15Z",
+      "scrape_date": "2026-05-05T12:30:31.837463Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.2.8",
+      "version": "0.2.9",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/ybarjfx04djmyg6rrmn04agj21r78jis-claude-managed-0.2.8"
+        "out": "/nix/store/ljvb0qxflvh36lm1cly5g26p5y01pxbj-claude-managed-0.2.9"
       },
       "system": "aarch64-linux",
       "group": "claude-managed",
@@ -320,27 +320,27 @@
     {
       "attr_path": "claude-managed",
       "broken": false,
-      "derivation": "/nix/store/fisr7avvqxhy7ys6a7lrnmwfxi94hcb2-claude-managed-0.2.8.drv",
+      "derivation": "/nix/store/qlcdrfj644vnqvmhlsdfgj61znzh3nr9-claude-managed-0.2.9.drv",
       "description": "Flox-native config management for Claude Code CLI",
       "install_id": "claude-managed",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "name": "claude-managed-0.2.8",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "name": "claude-managed-0.2.9",
       "pname": "claude-managed",
-      "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "rev_count": 2851,
-      "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:27.931324343Z",
+      "rev": "2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "rev_count": 2908,
+      "rev_date": "2026-05-05T12:12:15Z",
+      "scrape_date": "2026-05-05T12:30:31.837463Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.2.8",
+      "version": "0.2.9",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/vv1pl586bmmn60irfcinivdmf864cj0a-claude-managed-0.2.8"
+        "out": "/nix/store/86kyq3raz8y1xiy2f6z2a4akkvnr40xx-claude-managed-0.2.9"
       },
       "system": "x86_64-darwin",
       "group": "claude-managed",
@@ -349,27 +349,27 @@
     {
       "attr_path": "claude-managed",
       "broken": false,
-      "derivation": "/nix/store/yw9swwb0jlhibqryaagm28wryvyl4f4d-claude-managed-0.2.8.drv",
+      "derivation": "/nix/store/0nrr07rnkb2d07wd2hv1xg6v23bzqcp1-claude-managed-0.2.9.drv",
       "description": "Flox-native config management for Claude Code CLI",
       "install_id": "claude-managed",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "name": "claude-managed-0.2.8",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "name": "claude-managed-0.2.9",
       "pname": "claude-managed",
-      "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "rev_count": 2851,
-      "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:27.931324794Z",
+      "rev": "2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "rev_count": 2908,
+      "rev_date": "2026-05-05T12:12:15Z",
+      "scrape_date": "2026-05-05T12:30:31.837464Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.2.8",
+      "version": "0.2.9",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/hh60f8agqvk7pzrjzrb4cvj28mfc36sz-claude-managed-0.2.8"
+        "out": "/nix/store/drs45xh59fvmfj3a1dm114i48p72ij9x-claude-managed-0.2.9"
       },
       "system": "x86_64-linux",
       "group": "claude-managed",
@@ -502,7 +502,7 @@
       "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
       "rev_count": 2851,
       "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:27.931336461Z",
+      "scrape_date": "2026-05-05T12:30:31.837475Z",
       "stabilities": [
         "unstable"
       ],
@@ -529,7 +529,7 @@
       "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
       "rev_count": 2851,
       "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:27.931337022Z",
+      "scrape_date": "2026-05-05T12:30:31.837479Z",
       "stabilities": [
         "unstable"
       ],
@@ -556,7 +556,7 @@
       "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
       "rev_count": 2851,
       "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:27.931337382Z",
+      "scrape_date": "2026-05-05T12:30:31.837480Z",
       "stabilities": [
         "unstable"
       ],
@@ -583,7 +583,7 @@
       "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
       "rev_count": 2851,
       "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:27.931337773Z",
+      "scrape_date": "2026-05-05T12:30:31.837481Z",
       "stabilities": [
         "unstable"
       ],

--- a/claude/.flox/env/manifest.lock
+++ b/claude/.flox/env/manifest.lock
@@ -26,27 +26,27 @@
     {
       "attr_path": "claude-code",
       "broken": false,
-      "derivation": "/nix/store/6pbshqnkrzpg3xj23jkprwsih88s9s5i-claude-code-2.1.118.drv",
+      "derivation": "/nix/store/kpyp51m8s6mr8yyxvvjmagljngj73b64-claude-code-2.1.128.drv",
       "description": "Agentic coding tool from Anthropic",
       "install_id": "claude-code",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/floxenvs?rev=68bbb95e3946234785720a1a21138a66eaa8823c",
-      "name": "claude-code-2.1.118",
+      "locked_url": "https://github.com/flox/floxenvs?rev=50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "name": "claude-code-2.1.128",
       "pname": "claude-code",
-      "rev": "68bbb95e3946234785720a1a21138a66eaa8823c",
-      "rev_count": 2853,
-      "rev_date": "2026-04-23T08:12:25Z",
-      "scrape_date": "2026-05-04T01:21:22.527435711Z",
+      "rev": "50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "rev_count": 2988,
+      "rev_date": "2026-05-05T09:37:59Z",
+      "scrape_date": "2026-05-05T12:30:29.707437Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": true,
-      "version": "2.1.118",
+      "version": "2.1.128",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/jr1wi667yjn32071wph00i2ky62c2smw-claude-code-2.1.118"
+        "out": "/nix/store/xxkfnidc8d4c8sgkyg45srkd920zq5bh-claude-code-2.1.128"
       },
       "system": "aarch64-darwin",
       "group": "claude-code",
@@ -55,27 +55,27 @@
     {
       "attr_path": "claude-code",
       "broken": false,
-      "derivation": "/nix/store/8hwa0fvymv4bf64408z60gxgwz45iqhi-claude-code-2.1.118.drv",
+      "derivation": "/nix/store/wkdpjcwlmdvgkhaqh9zh2b992als394l-claude-code-2.1.128.drv",
       "description": "Agentic coding tool from Anthropic",
       "install_id": "claude-code",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/floxenvs?rev=68bbb95e3946234785720a1a21138a66eaa8823c",
-      "name": "claude-code-2.1.118",
+      "locked_url": "https://github.com/flox/floxenvs?rev=50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "name": "claude-code-2.1.128",
       "pname": "claude-code",
-      "rev": "68bbb95e3946234785720a1a21138a66eaa8823c",
-      "rev_count": 2853,
-      "rev_date": "2026-04-23T08:12:25Z",
-      "scrape_date": "2026-05-04T01:21:22.527440749Z",
+      "rev": "50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "rev_count": 2988,
+      "rev_date": "2026-05-05T09:37:59Z",
+      "scrape_date": "2026-05-05T12:30:29.707442Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": true,
-      "version": "2.1.118",
+      "version": "2.1.128",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/9aqm32n4gm0h05p40vf6bpsj5bycmis0-claude-code-2.1.118"
+        "out": "/nix/store/0gxhbpa9q2abxkj3vq83rcprn9kljyv4-claude-code-2.1.128"
       },
       "system": "aarch64-linux",
       "group": "claude-code",
@@ -84,27 +84,27 @@
     {
       "attr_path": "claude-code",
       "broken": false,
-      "derivation": "/nix/store/qy3x66jgq6clmbq26kbr2s5sbgksk4g8-claude-code-2.1.118.drv",
+      "derivation": "/nix/store/xzwfg3ja2dib9m17xa2m1lw49453w4lc-claude-code-2.1.128.drv",
       "description": "Agentic coding tool from Anthropic",
       "install_id": "claude-code",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/floxenvs?rev=68bbb95e3946234785720a1a21138a66eaa8823c",
-      "name": "claude-code-2.1.118",
+      "locked_url": "https://github.com/flox/floxenvs?rev=50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "name": "claude-code-2.1.128",
       "pname": "claude-code",
-      "rev": "68bbb95e3946234785720a1a21138a66eaa8823c",
-      "rev_count": 2853,
-      "rev_date": "2026-04-23T08:12:25Z",
-      "scrape_date": "2026-05-04T01:21:22.527441631Z",
+      "rev": "50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "rev_count": 2988,
+      "rev_date": "2026-05-05T09:37:59Z",
+      "scrape_date": "2026-05-05T12:30:29.707443Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": true,
-      "version": "2.1.118",
+      "version": "2.1.128",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/3f00lyb2glasbwrm4sx85iyv3k0zgpna-claude-code-2.1.118"
+        "out": "/nix/store/hsgcr9wfbykxgk369lz7ql9fab0kwsv3-claude-code-2.1.128"
       },
       "system": "x86_64-darwin",
       "group": "claude-code",
@@ -113,27 +113,27 @@
     {
       "attr_path": "claude-code",
       "broken": false,
-      "derivation": "/nix/store/vnhlw5kwn923q3vwww1wzpwl3n233ysm-claude-code-2.1.118.drv",
+      "derivation": "/nix/store/wf0qfmgjli19zif1an950lcvhr9pj50v-claude-code-2.1.128.drv",
       "description": "Agentic coding tool from Anthropic",
       "install_id": "claude-code",
       "license": "Unfree",
-      "locked_url": "https://github.com/flox/floxenvs?rev=68bbb95e3946234785720a1a21138a66eaa8823c",
-      "name": "claude-code-2.1.118",
+      "locked_url": "https://github.com/flox/floxenvs?rev=50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "name": "claude-code-2.1.128",
       "pname": "claude-code",
-      "rev": "68bbb95e3946234785720a1a21138a66eaa8823c",
-      "rev_count": 2853,
-      "rev_date": "2026-04-23T08:12:25Z",
-      "scrape_date": "2026-05-04T01:21:22.527442392Z",
+      "rev": "50a9bcab23cdfe7a2b64dc3792e7a775c5fae054",
+      "rev_count": 2988,
+      "rev_date": "2026-05-05T09:37:59Z",
+      "scrape_date": "2026-05-05T12:30:29.707443Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": true,
-      "version": "2.1.118",
+      "version": "2.1.128",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/5j6djxvjszinc3z1fmp1ah96420z90zl-claude-code-2.1.118"
+        "out": "/nix/store/82skqpdqjznysnj4iv24s1byljch7xc6-claude-code-2.1.128"
       },
       "system": "x86_64-linux",
       "group": "claude-code",
@@ -142,27 +142,27 @@
     {
       "attr_path": "claude-managed",
       "broken": false,
-      "derivation": "/nix/store/kkbinyqmj9m0crylzwqll64r119nqmg8-claude-managed-0.2.8.drv",
+      "derivation": "/nix/store/qbw6bs6a38lxkfyfxgm52g7ljb16vz2p-claude-managed-0.2.9.drv",
       "description": "Flox-native config management for Claude Code CLI",
       "install_id": "claude-managed",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "name": "claude-managed-0.2.8",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "name": "claude-managed-0.2.9",
       "pname": "claude-managed",
-      "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "rev_count": 2851,
-      "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:22.527448171Z",
+      "rev": "2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "rev_count": 2908,
+      "rev_date": "2026-05-05T12:12:15Z",
+      "scrape_date": "2026-05-05T12:30:29.707448Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.2.8",
+      "version": "0.2.9",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/63vh9djrqk42p5mc4rzvzvr4fnwgwb24-claude-managed-0.2.8"
+        "out": "/nix/store/yn3x7wrnayja10vdsqsy8gwzpayabbjb-claude-managed-0.2.9"
       },
       "system": "aarch64-darwin",
       "group": "claude-managed",
@@ -171,27 +171,27 @@
     {
       "attr_path": "claude-managed",
       "broken": false,
-      "derivation": "/nix/store/vggb7bf18ifpc0lrk8rnaq6grgicgsm4-claude-managed-0.2.8.drv",
+      "derivation": "/nix/store/2bw6awsbzsx59c2y0bqyx1ajhn9xi0h3-claude-managed-0.2.9.drv",
       "description": "Flox-native config management for Claude Code CLI",
       "install_id": "claude-managed",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "name": "claude-managed-0.2.8",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "name": "claude-managed-0.2.9",
       "pname": "claude-managed",
-      "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "rev_count": 2851,
-      "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:22.527450384Z",
+      "rev": "2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "rev_count": 2908,
+      "rev_date": "2026-05-05T12:12:15Z",
+      "scrape_date": "2026-05-05T12:30:29.707449Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.2.8",
+      "version": "0.2.9",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/ybarjfx04djmyg6rrmn04agj21r78jis-claude-managed-0.2.8"
+        "out": "/nix/store/ljvb0qxflvh36lm1cly5g26p5y01pxbj-claude-managed-0.2.9"
       },
       "system": "aarch64-linux",
       "group": "claude-managed",
@@ -200,27 +200,27 @@
     {
       "attr_path": "claude-managed",
       "broken": false,
-      "derivation": "/nix/store/fisr7avvqxhy7ys6a7lrnmwfxi94hcb2-claude-managed-0.2.8.drv",
+      "derivation": "/nix/store/qlcdrfj644vnqvmhlsdfgj61znzh3nr9-claude-managed-0.2.9.drv",
       "description": "Flox-native config management for Claude Code CLI",
       "install_id": "claude-managed",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "name": "claude-managed-0.2.8",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "name": "claude-managed-0.2.9",
       "pname": "claude-managed",
-      "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "rev_count": 2851,
-      "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:22.527451046Z",
+      "rev": "2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "rev_count": 2908,
+      "rev_date": "2026-05-05T12:12:15Z",
+      "scrape_date": "2026-05-05T12:30:29.707449Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.2.8",
+      "version": "0.2.9",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/vv1pl586bmmn60irfcinivdmf864cj0a-claude-managed-0.2.8"
+        "out": "/nix/store/86kyq3raz8y1xiy2f6z2a4akkvnr40xx-claude-managed-0.2.9"
       },
       "system": "x86_64-darwin",
       "group": "claude-managed",
@@ -229,27 +229,27 @@
     {
       "attr_path": "claude-managed",
       "broken": false,
-      "derivation": "/nix/store/yw9swwb0jlhibqryaagm28wryvyl4f4d-claude-managed-0.2.8.drv",
+      "derivation": "/nix/store/0nrr07rnkb2d07wd2hv1xg6v23bzqcp1-claude-managed-0.2.9.drv",
       "description": "Flox-native config management for Claude Code CLI",
       "install_id": "claude-managed",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "name": "claude-managed-0.2.8",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "name": "claude-managed-0.2.9",
       "pname": "claude-managed",
-      "rev": "c7113cfe659b33fec2f100f8c87fc6a604a15978",
-      "rev_count": 2851,
-      "rev_date": "2026-04-22T16:41:38Z",
-      "scrape_date": "2026-05-04T01:21:22.527451787Z",
+      "rev": "2a5dcd69af0c5677126c4b79bc5b8a680197358b",
+      "rev_count": 2908,
+      "rev_date": "2026-05-05T12:12:15Z",
+      "scrape_date": "2026-05-05T12:30:29.707450Z",
       "stabilities": [
         "unstable"
       ],
       "unfree": false,
-      "version": "0.2.8",
+      "version": "0.2.9",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/hh60f8agqvk7pzrjzrb4cvj28mfc36sz-claude-managed-0.2.8"
+        "out": "/nix/store/drs45xh59fvmfj3a1dm114i48p72ij9x-claude-managed-0.2.9"
       },
       "system": "x86_64-linux",
       "group": "claude-managed",


### PR DESCRIPTION
## Summary

Adds a Flox package `claude-code-plugin-impeccable` that wraps the upstream [pbakaus/impeccable](https://github.com/pbakaus/impeccable) Claude Code plugin (skill-v3.0.7, Apache 2.0), bundles its Node.js + git runtime, and ships everything Claude Code needs to load and trust it under a Flox-managed install.

Pulls in two ancillary changes that were necessary for the impeccable plugin to actually work end-to-end under `flox/claude`:

- **`claude-managed` 0.2.8 → 0.2.9** — the `claude` wrapper at `$CLAUDE_CONFIG_DIR/bin/claude` now discovers plugins at exec time from `$CLAUDE_CONFIG_DIR/plugins/*/` instead of baking them in at `setup-hook` time. This means plugins added later via `claude-managed plugins add <abspath>` (e.g. a locally-built package not yet in the env's share dir) are picked up automatically.
- **`claude/` and `claude-demo/` lockfile refresh** — both consumer envs are bumped to `claude-managed 0.2.9` and `claude-code 2.1.128`.

## Commits

1. **`feat(impeccable): add claude-code-plugin-impeccable package`** — barebones derivation that fetches `pbakaus/impeccable@skill-v3.0.7` via `fetchFromGitHub`, installs only the `plugin/` subtree (the source pointed at by upstream's `.claude-plugin/marketplace.json`) under `share/claude-code/plugins/impeccable/`. `upgrade.sh` follows the claude-seo pattern, adapted for the `skill-v` tag prefix upstream uses.
2. **`feat(impeccable): bundle nodejs + git into the plugin`** — wraps `nodejs` with `makeBinaryWrapper` so it sees `git` and itself on `PATH`, then patches every `#!/usr/bin/env node` shebang under the staged plugin tree (`cleanup-deprecated.mjs`, `pin.mjs`) to point at the wrapped node. `git` is the only external command the scripts shell out to (`scripts/is-generated.mjs` runs `git check-ignore`); `nodejs` is also kept on `PATH` so `npx` can find a working `node`. `makeBinaryWrapper` is used because Darwin's shebang-chain handling is unreliable for shell-script wrappers under stripped environments.
3. **`feat(impeccable): rewrite upstream paths in markdown to ${CLAUDE_PLUGIN_ROOT}`** — upstream's markdown is shared across all harnesses (`.claude/`, `.cursor/`, `.gemini/`, `.kiro/`, etc.), so it embeds `node .claude/skills/impeccable/scripts/<X>` references in the user-install layout. In a Flox-managed plugin install the same files live under `${CLAUDE_PLUGIN_ROOT}/skills/impeccable/scripts/`. Walks every staged markdown file and rewrites that one prefix in-place.
4. **`feat(impeccable): emit installed_plugins.json so claude-managed trusts the plugin`** — drops a v2-format `installed_plugins.json` next to the plugin so `claude-managed plugins add` merges an entry into `$CLAUDE_CONFIG_DIR/plugins/installed_plugins.json`. Without it the symlink is created but Claude Code lists the plugin as untrusted and refuses to load its skill / commands.
5. **`feat(impeccable): record real upstream commit SHA in installed_plugins.json`** — `installed_plugins.json` carries a `gitCommitSha` field per entry; resolve the upstream `skill-vX.Y.Z` tag to its commit SHA at upgrade time, store it alongside `srcHash` in `hashes.json`, and interpolate it so `/plugin` shows the actual upstream commit instead of a placeholder.
6. **`feat(claude-managed): discover plugins at exec time, not at hook time`** — the `claude` wrapper used to bake in `--plugin-dir` flags only for plugins discovered under `$FLOX_ENV/share/claude-code/plugins/` at `setup-hook` time. Plugins added later via `claude-managed plugins add <abspath>` were registered in `$CLAUDE_CONFIG_DIR/plugins/` but the wrapper never knew about them. Switch the wrapper to iterate `$CLAUDE_CONFIG_DIR/plugins/*/` at exec time, and emit the wrapper unconditionally. Bump `0.2.8 → 0.2.9`.
7. **`feat(impeccable): bundle node + npx inside the plugin tree`** — Claude's `Bash(node ${CLAUDE_PLUGIN_ROOT}/skills/...)` invocations were failing with `command not found: node` because `flox/claude` doesn't ship `nodejs` (and shouldn't have to, just because this plugin is installed). Move the wrapped node from `$out/bin` into `$PLUGIN_DIR/bin/`, symlink `npx` next to it, and extend the markdown rewriter to prefix bare `node ${CLAUDE_PLUGIN_ROOT}/...` and `npx impeccable ...` invocations with `${CLAUDE_PLUGIN_ROOT}/bin/`. The npx rewrite also touches the `Bash(npx impeccable *)` allowed-tools entry — that's intentional, since the expanded form is what Claude actually invokes.
8. **`chore(claude,claude-demo): upgrade claude-managed to 0.2.9`** — refresh the consumer env lockfiles. `claude-demo`'s lock had to be force-regenerated (`rm + flox activate -d`) because it pulls `claude-managed` in transitively via `[include]` of `../claude`, and neither `flox upgrade` nor `flox include upgrade` propagate an included env's lockfile bumps when its `manifest.toml` is unchanged.

## Closure size

The full Node.js bundle stays moderate. On `aarch64-darwin`:

| Metric | Value |
| ------ | ----- |
| Output path (this derivation only) | 924 KB |
| **Full runtime closure (all transitive deps)** | **1.6 GB** |
| Number of store paths in closure | 139 |

Largest contributors are the LLVM 21 + clang 21 + cctools-darwin chain (~2.4 GB combined, pulled in by `nodejs`'s build-time deps; could potentially be trimmed by binary-stripping in a follow-up). The Node.js binary itself plus its direct runtime closure is small.

## Notes for the reviewer

- **`claude` itself is intentionally NOT in the wrapped runtime PATH** — it is provided by the consumer's `flox/claude-code` package.
- **Only the `plugin/` subdirectory** of the upstream repo is shipped. The top-level `.claude/`, `.cursor/`, `.gemini/`, `.kiro/`, `.opencode/`, etc. mirrors are skipped — they're per-harness copies that don't apply to a Claude Code plugin install.
- **`installPath` in `installed_plugins.json` is left empty** — `claude-managed`'s `patchEntries` (`internal/plugins/plugins.go:108`) unconditionally overwrites it with the symlink path inside `$CLAUDE_CONFIG_DIR/plugins/<name>` on `plugins add`, so any value we ship is discarded. Empty matches what `typescript-lsp` does.
- **`claude-managed` change is unconditional** — every consumer of `flox/claude-managed` will see the new wrapper on next env upgrade. The wrapper is harmless when no plugins are present (the runtime loop is a no-op against an empty/absent dir).
- **No environment is added or modified** beyond the lockfile bump for `claude/` and `claude-demo/`. A follow-up could install `claude-code-plugin-impeccable` directly into `claude-demo/` to make impeccable available out-of-the-box.

## Local testing (pre-publish)

After this lands and `flox/claude-code-plugin-impeccable` is published to the Flox catalog, the standard path is to add the package to `claude/.flox/env/manifest.toml` and let `setup-hook` discover it. Pre-publish, build it locally and let the runtime-discovery wrapper from commit 6 pick it up:

```bash
git fetch origin feature/skills/impeccable
git checkout feature/skills/impeccable
flox build claude-code-plugin-impeccable

flox activate -d claude/
claude-managed plugins add "$(realpath ./result-claude-code-plugin-impeccable/share/claude-code/plugins/impeccable)"
claude-managed plugins list   # → ✓ impeccable

claude
# /plugin → impeccable 3.0.7
# /impeccable:impeccable audit  (or any sub-command)
```

Cleanup:

```bash
claude-managed plugins remove impeccable
```

## Test plan

- [x] `nix-instantiate --parse default.nix` succeeds
- [x] `flox build claude-code-plugin-impeccable` succeeds locally on `aarch64-darwin`
- [x] Plugin layout: `.claude-plugin/plugin.json` reports `impeccable 3.0.7`, all 36 skill `reference/*.md` files present, all 22 `scripts/*.mjs|*.js` files present
- [x] `bash upgrade.sh` is a no-op on the pinned version
- [x] Wrapped node is a Mach-O / ELF binary (not a shell script)
- [x] Smoke test under stripped env (`env -i PATH=/usr/bin:/bin`): wrapped node reports `v24.14.0`, finds `git 2.53.0` via `execSync`, `pin.mjs --help` runs via patched shebang, `is-generated.mjs` imports cleanly
- [x] Markdown rewriter rewrites `.claude/skills/...` and `node ${CLAUDE_PLUGIN_ROOT}/...` and `npx impeccable` references; `grep -r '\.claude/skills/impeccable' $out` returns no matches
- [x] `installed_plugins.json` is valid JSON v2 format with the real upstream `gitCommitSha`
- [x] `go test ./...` in `.flox/pkgs/claude-managed/` passes (all 6 packages)
- [x] `claude-managed setup-hook` emits the runtime-iterating wrapper; the wrapper picks up plugin symlinks from `$CLAUDE_CONFIG_DIR/plugins/` and passes one `--plugin-dir` per plugin to `$FLOX_ENV/bin/claude`
- [x] End-to-end: `flox activate -d claude/` → `claude-managed plugins add <impeccable-abspath>` → `claude-managed plugins list` shows `✓ impeccable` with no warnings; `which claude` resolves to the wrapper; dry-run shows `claude --plugin-dir .../impeccable --version`
- [x] The exact command Claude was running (`node ${CLAUDE_PLUGIN_ROOT}/skills/impeccable/scripts/load-context.mjs`, expanded) succeeds and prints the loader's JSON output
- [x] `flox publish -o flox claude-managed --system <sys>` for all four systems (done)
- [x] `flox upgrade -d claude/` and `rm + flox activate -d claude-demo/` regenerate locks at `claude-managed 0.2.9` (done)
- [ ] `flox publish -o flox claude-code-plugin-impeccable --system <sys>` for all four systems (manual, after merge)