### PR TITLE
ci: summary waits for package builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,6 +439,7 @@ jobs:
           PKGS_TOTAL: >-
             ${{ needs.wait-for-packages.outputs.total_workflows }}
         run: |
+          set -euo pipefail
           fail=0
           if [ "$ENVS_RESULT" != "success" ]; then
             echo "wait-for-environments did not succeed: $ENVS_RESULT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   wait-for-environments:
-    name: "Wait"
+    name: "Wait Envs"
     runs-on: "ubuntu-latest"
     timeout-minutes: 120
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,87 @@ jobs:
     timeout-minutes: 120
 
     outputs:
-      any_failed: "${{ steps.wait.outputs.any_failed }}"
-      failed_workflows: "${{ steps.wait.outputs.failed_workflows }}"
-      total_workflows: "${{ steps.wait.outputs.total_workflows }}"
-      successful_envs: "${{ steps.wait.outputs.successful_envs }}"
-      pr_number: "${{ steps.wait.outputs.pr_number }}"
-      pr_author: "${{ steps.wait.outputs.pr_author }}"
+      any_failed: >-
+        ${{ steps.wait.outputs.any_failed
+            || steps.short_circuit.outputs.any_failed }}
+      failed_workflows: >-
+        ${{ steps.wait.outputs.failed_workflows
+            || steps.short_circuit.outputs.failed_workflows }}
+      total_workflows: >-
+        ${{ steps.wait.outputs.total_workflows
+            || steps.short_circuit.outputs.total_workflows }}
+      successful_envs: >-
+        ${{ steps.wait.outputs.successful_envs
+            || steps.short_circuit.outputs.successful_envs }}
+      pr_number: >-
+        ${{ steps.wait.outputs.pr_number
+            || steps.short_circuit.outputs.pr_number }}
+      pr_author: >-
+        ${{ steps.wait.outputs.pr_author
+            || steps.short_circuit.outputs.pr_author }}
 
     steps:
+      - name: "Checkout"
+        if: github.event_name == 'pull_request'
+              || github.event_name == 'push'
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
+        with:
+          fetch-depth: 0
+
+      - name: "Decide if polling is needed"
+        id: "decide"
+        if: github.event_name == 'pull_request'
+              || github.event_name == 'push'
+        env:
+          EVENT: "${{ github.event_name }}"
+          BASE_SHA: "${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA: "${{ github.event.pull_request.head.sha
+                       || github.sha }}"
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "pull_request" ]; then
+            BASE="$BASE_SHA"
+            HEAD="$HEAD_SHA"
+          else
+            BASE="HEAD~1"
+            HEAD="HEAD"
+          fi
+          changed="$(git diff --name-only "$BASE" "$HEAD")"
+          should_poll="$(echo "$changed" \
+            | scripts/wait-should-poll.sh envs)"
+          echo "should_poll=$should_poll" >> "$GITHUB_OUTPUT"
+          echo "Changed files:"
+          echo "$changed" | sed 's/^/  /'
+          echo "should_poll=$should_poll"
+
+      - name: "Short-circuit (no env paths changed)"
+        id: "short_circuit"
+        if: >-
+          (github.event_name == 'pull_request'
+            || github.event_name == 'push')
+          && steps.decide.outputs.should_poll == 'false'
+        env:
+          PR_NUMBER: >-
+            ${{ github.event.pull_request.number || 0 }}
+          PR_AUTHOR: >-
+            ${{ github.event.pull_request.user.login || '' }}
+        run: |
+          {
+            echo "any_failed=false"
+            echo "failed_workflows="
+            echo "total_workflows=0"
+            echo "successful_envs=[]"
+            echo "pr_number=$PR_NUMBER"
+            echo "pr_author=$PR_AUTHOR"
+          } >> "$GITHUB_OUTPUT"
+          echo "No env paths changed — short-circuiting."
+
       - name: "Wait for all CI: * workflows"
         id: "wait"
+        if: >-
+          github.event_name == 'merge_group'
+          || github.event_name == 'workflow_dispatch'
+          || steps.decide.outputs.should_poll == 'true'
         uses: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3" # v9.0.0
         with:
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,21 +416,50 @@ jobs:
     name: "Summary"
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
-    needs: ["wait-for-environments"]
+    needs: ["wait-for-environments", "wait-for-packages"]
     if: always()
 
     steps:
       - name: "Check result"
+        env:
+          ENVS_RESULT: >-
+            ${{ needs.wait-for-environments.result }}
+          PKGS_RESULT: >-
+            ${{ needs.wait-for-packages.result }}
+          ENVS_FAILED: >-
+            ${{ needs.wait-for-environments.outputs.any_failed }}
+          PKGS_FAILED: >-
+            ${{ needs.wait-for-packages.outputs.any_failed }}
+          ENVS_FAILED_LIST: >-
+            ${{ needs.wait-for-environments.outputs.failed_workflows }}
+          PKGS_FAILED_LIST: >-
+            ${{ needs.wait-for-packages.outputs.failed_workflows }}
+          ENVS_TOTAL: >-
+            ${{ needs.wait-for-environments.outputs.total_workflows }}
+          PKGS_TOTAL: >-
+            ${{ needs.wait-for-packages.outputs.total_workflows }}
         run: |
-          if [ "${{ needs.wait-for-environments.result }}" != "success" ]; then
-            echo "wait-for-environments failed"
+          fail=0
+          if [ "$ENVS_RESULT" != "success" ]; then
+            echo "wait-for-environments did not succeed: $ENVS_RESULT"
+            fail=1
+          fi
+          if [ "$PKGS_RESULT" != "success" ]; then
+            echo "wait-for-packages did not succeed: $PKGS_RESULT"
+            fail=1
+          fi
+          if [ "$ENVS_FAILED" = "true" ]; then
+            echo "Failed env workflows: $ENVS_FAILED_LIST"
+            fail=1
+          fi
+          if [ "$PKGS_FAILED" = "true" ]; then
+            echo "Failed pkg workflows: $PKGS_FAILED_LIST"
+            fail=1
+          fi
+          if [ "$fail" -eq 1 ]; then
             exit 1
           fi
-          if [ "${{ needs.wait-for-environments.outputs.any_failed }}" = "true" ]; then
-            echo "Failed workflows: ${{ needs.wait-for-environments.outputs.failed_workflows }}"
-            exit 1
-          fi
-          echo "All ${{ needs.wait-for-environments.outputs.total_workflows }} environment workflows passed"
+          echo "Envs: ${ENVS_TOTAL} passed, Pkgs: ${PKGS_TOTAL} passed"
 
   auto-merge:
     name: "Auto Merge"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,7 +460,14 @@ jobs:
           if [ "$fail" -eq 1 ]; then
             exit 1
           fi
-          echo "Envs: ${ENVS_TOTAL} passed, Pkgs: ${PKGS_TOTAL} passed"
+          fmt() {
+            if [ "$2" = "0" ]; then
+              echo "$1: skipped (no relevant changes)"
+            else
+              echo "$1: $2 passed"
+            fi
+          }
+          echo "$(fmt Envs "$ENVS_TOTAL") | $(fmt Pkgs "$PKGS_TOTAL")"
 
   auto-merge:
     name: "Auto Merge"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,16 +38,18 @@ jobs:
 
     steps:
       - name: "Checkout"
-        if: github.event_name == 'pull_request'
-              || github.event_name == 'push'
+        if: >-
+          github.event_name == 'pull_request'
+          || github.event_name == 'push'
         uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
         with:
           fetch-depth: 0
 
       - name: "Decide if polling is needed"
         id: "decide"
-        if: github.event_name == 'pull_request'
-              || github.event_name == 'push'
+        if: >-
+          github.event_name == 'pull_request'
+          || github.event_name == 'push'
         env:
           EVENT: "${{ github.event_name }}"
           BASE_SHA: "${{ github.event.pull_request.base.sha }}"
@@ -74,7 +76,7 @@ jobs:
         id: "short_circuit"
         if: >-
           (github.event_name == 'pull_request'
-            || github.event_name == 'push')
+          || github.event_name == 'push')
           && steps.decide.outputs.should_poll == 'false'
         env:
           PR_NUMBER: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             BASE="HEAD~1"
             HEAD="HEAD"
           fi
-          changed="$(git diff --name-only "$BASE" "$HEAD")"
+          changed="$(git diff --name-only "$BASE...$HEAD")"
           should_poll="$(echo "$changed" \
             | scripts/wait-should-poll.sh envs)"
           echo "should_poll=$should_poll" >> "$GITHUB_OUTPUT"
@@ -283,7 +283,7 @@ jobs:
             BASE="HEAD~1"
             HEAD="HEAD"
           fi
-          changed="$(git diff --name-only "$BASE" "$HEAD")"
+          changed="$(git diff --name-only "$BASE...$HEAD")"
           should_poll="$(echo "$changed" \
             | scripts/wait-should-poll.sh packages)"
           echo "should_poll=$should_poll" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,12 +466,16 @@ jobs:
     name: "Auto Merge"
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
-    needs: ["wait-for-environments"]
+    needs: ["wait-for-environments", "wait-for-packages"]
     if: >-
       github.event_name == 'pull_request'
+      && needs.wait-for-environments.result == 'success'
+      && needs.wait-for-packages.result == 'success'
       && needs.wait-for-environments.outputs.any_failed == 'false'
+      && needs.wait-for-packages.outputs.any_failed == 'false'
       && needs.wait-for-environments.outputs.pr_author == 'floxbot'
-      && needs.wait-for-environments.outputs.total_workflows != '0'
+      && (needs.wait-for-environments.outputs.total_workflows != '0'
+      || needs.wait-for-packages.outputs.total_workflows != '0')
 
     steps:
       - name: "Merge PR"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,179 @@ jobs:
 
             core.setFailed('Timed out waiting for environment workflows');
 
+  wait-for-packages:
+    name: "Wait Pkgs"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 120
+
+    outputs:
+      any_failed: >-
+        ${{ steps.wait.outputs.any_failed
+            || steps.short_circuit.outputs.any_failed }}
+      failed_workflows: >-
+        ${{ steps.wait.outputs.failed_workflows
+            || steps.short_circuit.outputs.failed_workflows }}
+      total_workflows: >-
+        ${{ steps.wait.outputs.total_workflows
+            || steps.short_circuit.outputs.total_workflows }}
+
+    steps:
+      - name: "Checkout"
+        if: >-
+          github.event_name == 'pull_request'
+          || github.event_name == 'push'
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
+        with:
+          fetch-depth: 0
+
+      - name: "Decide if polling is needed"
+        id: "decide"
+        if: >-
+          github.event_name == 'pull_request'
+          || github.event_name == 'push'
+        env:
+          EVENT: "${{ github.event_name }}"
+          BASE_SHA: "${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA: "${{ github.event.pull_request.head.sha
+                       || github.sha }}"
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "pull_request" ]; then
+            BASE="$BASE_SHA"
+            HEAD="$HEAD_SHA"
+          else
+            BASE="HEAD~1"
+            HEAD="HEAD"
+          fi
+          changed="$(git diff --name-only "$BASE" "$HEAD")"
+          should_poll="$(echo "$changed" \
+            | scripts/wait-should-poll.sh packages)"
+          echo "should_poll=$should_poll" >> "$GITHUB_OUTPUT"
+          echo "Changed files:"
+          echo "$changed" | sed 's/^/  /'
+          echo "should_poll=$should_poll"
+
+      - name: "Short-circuit (no pkg paths changed)"
+        id: "short_circuit"
+        if: >-
+          (github.event_name == 'pull_request'
+          || github.event_name == 'push')
+          && steps.decide.outputs.should_poll == 'false'
+        run: |
+          {
+            echo "any_failed=false"
+            echo "failed_workflows="
+            echo "total_workflows=0"
+          } >> "$GITHUB_OUTPUT"
+          echo "No package paths changed — short-circuiting."
+
+      - name: "Wait for CI Packages workflow"
+        id: "wait"
+        if: >-
+          github.event_name == 'merge_group'
+          || github.event_name == 'workflow_dispatch'
+          || steps.decide.outputs.should_poll == 'true'
+        uses: "actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3" # v9.0.0
+        with:
+          script: |
+            const isPR = context.eventName === 'pull_request';
+            const sha = isPR
+              ? context.payload.pull_request.head.sha
+              : context.sha;
+
+            core.info(`SHA: ${sha} (${isPR ? 'PR head' : 'push'})`);
+            core.info(`Event: ${context.eventName}`);
+
+            // Merge queue: no pkg workflow runs, pass immediately
+            if (context.eventName === 'merge_group') {
+              core.info('Merge queue — no pkg workflow to wait for');
+              core.setOutput('any_failed', 'false');
+              core.setOutput('failed_workflows', '');
+              core.setOutput('total_workflows', '0');
+              return;
+            }
+
+            core.info('Waiting 30s for CI Packages to register...');
+            await new Promise(r => setTimeout(r, 30000));
+
+            const maxAttempts = 1400;  // ~2 hours at 5s
+            const interval = 5000;
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+              const runs = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head_sha: sha,
+                per_page: 100,
+              });
+
+              const pkgRuns = runs.data.workflow_runs.filter(
+                r => r.name === 'CI Packages'
+              );
+
+              if (pkgRuns.length === 0) {
+                if (attempt <= 12) {
+                  core.info(
+                    `Attempt ${attempt}: CI Packages not found yet, waiting...`
+                  );
+                  await new Promise(r => setTimeout(r, interval));
+                  continue;
+                }
+                core.info('No CI Packages run triggered for this SHA');
+                core.setOutput('any_failed', 'false');
+                core.setOutput('failed_workflows', '');
+                core.setOutput('total_workflows', '0');
+                return;
+              }
+
+              const pending = pkgRuns.filter(
+                r => r.status !== 'completed'
+              );
+              const failed = pkgRuns.filter(
+                r => r.status === 'completed'
+                  && r.conclusion !== 'success'
+                  && r.conclusion !== 'skipped'
+              );
+
+              if (attempt % 12 === 1) {
+                core.info(
+                  `[${Math.floor(attempt * 5 / 60)}m] ` +
+                  `${pkgRuns.length} CI Packages: ` +
+                  `${pkgRuns.length - pending.length} complete, ` +
+                  `${pending.length} pending, ` +
+                  `${failed.length} failed`
+                );
+                for (const run of pkgRuns) {
+                  core.info(
+                    `  ${run.name}: ${run.status}` +
+                    (run.conclusion ? ` (${run.conclusion})` : '')
+                  );
+                }
+              }
+
+              if (pending.length === 0) {
+                core.info(
+                  `All ${pkgRuns.length} CI Packages runs complete!`
+                );
+                const failedNames = failed.map(r => r.name).join(', ');
+                if (failed.length > 0) {
+                  core.info(`Failed: ${failedNames}`);
+                }
+                core.setOutput(
+                  'any_failed', (failed.length > 0).toString()
+                );
+                core.setOutput('failed_workflows', failedNames);
+                core.setOutput(
+                  'total_workflows', pkgRuns.length.toString()
+                );
+                return;
+              }
+
+              await new Promise(r => setTimeout(r, interval));
+            }
+
+            core.setFailed('Timed out waiting for CI Packages');
+
   result:
     name: "Summary"
     runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,10 +492,11 @@ jobs:
     name: "Report Failure"
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
-    needs: ["wait-for-environments"]
+    needs: ["wait-for-environments", "wait-for-packages"]
     if: >-
-      needs.wait-for-environments.outputs.any_failed == 'true'
-      && github.ref_name == 'main'
+      github.ref_name == 'main'
+      && (needs.wait-for-environments.outputs.any_failed == 'true'
+      || needs.wait-for-packages.outputs.any_failed == 'true')
 
     steps:
       - name: "Slack Notification"
@@ -510,10 +511,14 @@ jobs:
           SLACK_COLOR: "#ff2800"
           SLACK_LINK_NAMES: true
           SLACK_MESSAGE: >-
-            Failed:
+            Envs failed:
             ${{ needs.wait-for-environments.outputs.failed_workflows }}
-            | Workflows:
+            | Pkgs failed:
+            ${{ needs.wait-for-packages.outputs.failed_workflows }}
+            | Env total:
             ${{ needs.wait-for-environments.outputs.total_workflows }}
+            | Pkg total:
+            ${{ needs.wait-for-packages.outputs.total_workflows }}
 
   containerize:
     name: "Containerize '${{ matrix.env }}'"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,6 +221,10 @@ jobs:
     secrets: inherit
 ```
 
+No change to `ci.yml` or `scripts/wait-should-poll.sh` is
+required — the wait job derives env names from
+`ci_<name>.yml` filenames automatically.
+
 ### Step 4: Update README.md
 
 Add the environment to the root README.md table with
@@ -262,6 +266,23 @@ Tests run on remote builders via SSH over Tailscale.
 On Linux, tests are isolated in user + network + PID
 namespaces using `pasta` (from passt project) for
 network connectivity. See `flake.nix` for details.
+
+### Wait-job path filters
+
+The `wait-for-environments` and `wait-for-packages` jobs
+in `ci.yml` short-circuit when `git diff` shows no relevant
+paths changed. Their path patterns live in
+`scripts/wait-should-poll.sh` and **must stay in sync** with
+the `on.paths` triggers in `ci_pkgs.yml` and each
+`ci_<name>.yml`. When editing trigger paths, also update
+the helper.
+
+Env names are derived automatically from `ci_<name>.yml`
+filenames, so adding a new env workflow needs no change to
+`ci.yml` or the helper. Adding new shared paths to env
+workflow triggers (e.g. a new top-level directory like
+`scripts/`) requires updating
+`scripts/wait-should-poll.sh`.
 
 ### FloxHub target org
 

--- a/scripts/test/wait-should-poll.test.sh
+++ b/scripts/test/wait-should-poll.test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Tests for scripts/wait-should-poll.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/../wait-should-poll.sh"
+
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+# Build a temp dir that looks like the repo root so the
+# helper can discover env names from ci_*.yml files.
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+mkdir -p "$TMP/.github/workflows"
+# Mock env workflows
+for env in redis postgresql go; do
+  touch "$TMP/.github/workflows/ci_$env.yml"
+done
+touch "$TMP/.github/workflows/ci_pkgs.yml"
+touch "$TMP/.github/workflows/ci.yml"
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    PASS=$((PASS + 1))
+    echo "ok - $label"
+  else
+    FAIL=$((FAIL + 1))
+    FAILED_TESTS+=("$label: expected=$expected actual=$actual")
+    echo "FAIL - $label (expected=$expected actual=$actual)"
+  fi
+}
+
+run() {
+  # $1 = mode, stdin = changed paths
+  ( cd "$TMP" && "$HELPER" "$1" )
+}
+
+# ── packages mode ──
+assert_eq "pkgs: pkg change → true" "true" \
+  "$(printf '.flox/pkgs/foo/default.nix\n' | run packages)"
+assert_eq "pkgs: env change → false" "false" \
+  "$(printf 'redis/test.sh\n' | run packages)"
+assert_eq "pkgs: flake.lock → false" "false" \
+  "$(printf 'flake.lock\n' | run packages)"
+assert_eq "pkgs: empty → false" "false" \
+  "$(printf '' | run packages)"
+assert_eq "pkgs: ci_pkgs.yml only → false" "false" \
+  "$(printf '.github/workflows/ci_pkgs.yml\n' | run packages)"
+assert_eq "pkgs: .flox/env/ only → false" "false" \
+  "$(printf '.flox/env/manifest.toml\n' | run packages)"
+assert_eq "pkgs: combined → true" "true" \
+  "$(printf 'redis/test.sh\n.flox/pkgs/x/default.nix\n' \
+    | run packages)"
+
+# ── envs mode ──
+assert_eq "envs: env dir → true" "true" \
+  "$(printf 'redis/test.sh\n' | run envs)"
+assert_eq "envs: env-demo dir → true" "true" \
+  "$(printf 'redis-demo/test.sh\n' | run envs)"
+assert_eq "envs: flake.nix → true" "true" \
+  "$(printf 'flake.nix\n' | run envs)"
+assert_eq "envs: flake.lock → true" "true" \
+  "$(printf 'flake.lock\n' | run envs)"
+assert_eq "envs: scripts/ → true" "true" \
+  "$(printf 'scripts/discover-envs.sh\n' | run envs)"
+assert_eq "envs: environment.yml → true" "true" \
+  "$(printf '.github/workflows/environment.yml\n' \
+    | run envs)"
+assert_eq "envs: ci_redis.yml → true" "true" \
+  "$(printf '.github/workflows/ci_redis.yml\n' | run envs)"
+assert_eq "envs: ci_pkgs.yml → false" "false" \
+  "$(printf '.github/workflows/ci_pkgs.yml\n' | run envs)"
+assert_eq "envs: ci.yml only → false" "false" \
+  "$(printf '.github/workflows/ci.yml\n' | run envs)"
+assert_eq "envs: pkg change only → false" "false" \
+  "$(printf '.flox/pkgs/x/default.nix\n' | run envs)"
+assert_eq "envs: docs only → false" "false" \
+  "$(printf 'README.md\n' | run envs)"
+assert_eq "envs: empty → false" "false" \
+  "$(printf '' | run envs)"
+
+# ── invalid mode ──
+out="$(printf '' | run invalid 2>&1)" || true
+case "$out" in
+  *unknown*|*usage*|*Usage*) ok=true ;;
+  *) ok=false ;;
+esac
+if [ "$ok" = "true" ]; then
+  PASS=$((PASS + 1))
+  echo "ok - invalid mode prints usage/unknown"
+else
+  FAIL=$((FAIL + 1))
+  FAILED_TESTS+=("invalid mode: got '$out'")
+  echo "FAIL - invalid mode"
+fi
+
+echo
+echo "Passed: $PASS  Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  for t in "${FAILED_TESTS[@]}"; do echo "  - $t"; done
+  exit 1
+fi

--- a/scripts/wait-should-poll.sh
+++ b/scripts/wait-should-poll.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+#
+# Decide whether a wait job needs to poll, based on which
+# files changed. Reads newline-separated paths from stdin.
+# Prints "true" if polling is needed, "false" otherwise.
+#
+# Usage:
+#   git diff --name-only BASE HEAD | wait-should-poll.sh envs
+#   git diff --name-only BASE HEAD | wait-should-poll.sh packages
+#
+# Run from the repository root, or from a directory whose
+# .github/workflows/ contains the ci_<name>.yml files (the
+# envs mode discovers env names from those filenames).
+set -euo pipefail
+
+mode="${1:-}"
+
+case "$mode" in
+  envs|packages) ;;
+  *)
+    echo "usage: $0 <envs|packages>" >&2
+    echo "unknown mode: '$mode'" >&2
+    exit 2
+    ;;
+esac
+
+# Read changed paths from stdin into an array (drop blanks).
+changed=()
+while IFS= read -r line; do
+  [ -n "$line" ] && changed+=("$line")
+done
+
+if [ "${#changed[@]}" -eq 0 ]; then
+  echo "false"
+  exit 0
+fi
+
+if [ "$mode" = "packages" ]; then
+  for p in "${changed[@]}"; do
+    case "$p" in
+      .flox/pkgs/*) echo "true"; exit 0 ;;
+    esac
+  done
+  echo "false"
+  exit 0
+fi
+
+# envs mode: derive env names from ci_<name>.yml filenames.
+envs=()
+for f in .github/workflows/ci_*.yml; do
+  base="$(basename "$f" .yml)"
+  name="${base#ci_}"
+  if [ "$name" != "pkgs" ]; then
+    envs+=("$name")
+  fi
+done
+
+for p in "${changed[@]}"; do
+  case "$p" in
+    flake.nix|flake.lock) echo "true"; exit 0 ;;
+    scripts/*) echo "true"; exit 0 ;;
+    .github/workflows/environment.yml) echo "true"; exit 0 ;;
+    .github/workflows/ci_pkgs.yml) ;;
+    .github/workflows/ci_*.yml) echo "true"; exit 0 ;;
+    *)
+      for env in "${envs[@]}"; do
+        case "$p" in
+          "$env"/*|"$env"-demo/*) echo "true"; exit 0 ;;
+        esac
+      done
+      ;;
+  esac
+done
+
+echo "false"


### PR DESCRIPTION
## Summary

Make CI's Summary, auto-merge, and report-failure jobs wait for both env workflows AND the `CI Packages` workflow, with a git-diff short-circuit so PRs touching neither side skip the wait.

- New `scripts/wait-should-poll.sh` helper (20 unit tests) decides whether to poll based on changed paths
- New `wait-for-packages` job in `ci.yml` mirrors `wait-for-environments` but filters `r.name === 'CI Packages'`
- `wait-for-environments` short-circuits on env-irrelevant diffs (e.g., `.flox/pkgs/`-only PRs)
- `result` (Summary) now requires both wait jobs to succeed
- `auto-merge` requires both wait jobs to pass and at least one to have run
- `report-failure` fires on either side's failure on main, with both lists in Slack
- AGENTS.md documents the path-filter sync invariant

Spec: [.plans/2026-05-05-ci-summary-waits-for-pkgs-design.md](https://github.com/flox/floxenvs/blob/feature/envs/automerge-prs/.plans/2026-05-05-ci-summary-waits-for-pkgs-design.md) (not committed; in worktree only)

## Test plan

- [ ] On this PR (workflows + scripts + docs only): `Wait` polls (env-relevant paths changed), `Wait Pkgs` short-circuits, `Summary` passes
- [ ] Throwaway branch with only `.flox/pkgs/<x>/` change: `Wait` short-circuits, `Wait Pkgs` polls
- [ ] Combined env + pkg branch: both poll, `Summary` waits for both
- [ ] Docs-only branch: both short-circuit, `Summary` passes immediately