### PR TITLE
fix(claude-managed): stop flagging valid skills as broken

### DIFF
--- a/.flox/pkgs/claude-managed/README.md
+++ b/.flox/pkgs/claude-managed/README.md
@@ -1,8 +1,8 @@
 # claude-managed
 
-A zero-dependency Go binary that assembles Claude Code
-configuration from Flox package fragments and emits
-eval-able shell code.
+A small Go binary that assembles Claude Code configuration
+from Flox package fragments and emits eval-able shell code.
+Depends only on `gopkg.in/yaml.v3` for frontmatter parsing.
 
 ## Usage
 
@@ -84,28 +84,38 @@ symlink health with validation results inline.
 ### doctor
 
 Validates frontmatter and structure of all discovered
-rules, skills, and agents. Checks performed:
+rules, skills, and agents. Issues are split into errors
+(skill is broken) and warnings (skill works but is
+unusual); `doctor` exits non-zero only on errors.
 
 **Rules** (`rules/*.md`):
 
-- File is readable
-- Frontmatter keys are recognized (only `paths` allowed)
+- File is readable (error if not)
+- Unknown frontmatter keys produce a warning
+  (only `paths` is recognized)
 
 **Skills** (`skills/*/SKILL.md`):
 
-- SKILL.md exists and is readable
-- Frontmatter keys are recognized
-- `name` is kebab-case, max 64 characters
-- `effort` is one of: low, medium, high, max
+- SKILL.md exists and is readable (error if not)
+- If frontmatter is present, `name` and `description`
+  are required (error if missing)
+- `name` is kebab-case, ≤64 characters (error)
+- `description` ≤1024 characters (warning if exceeded)
+- `compatibility` ≤500 characters (warning if exceeded)
+- `effort` is one of: low, medium, high, max (error)
+- Frontmatter keys are recognized as either
+  agentskills.io spec keys or Claude Code extensions
+  (warning otherwise; the `metadata:` mapping is the
+  spec-recommended home for non-standard fields)
 
 **Agents** (`agents/*.md`):
 
-- File is readable
-- Frontmatter keys are recognized
+- File is readable (error if not)
 - No forbidden keys (`hooks`, `mcpServers`,
-  `permissionMode` — security restriction)
-- `effort` is one of: low, medium, high, max
-- `isolation` is `worktree` (only valid value)
+  `permissionMode` — security restriction, error)
+- `effort` is one of: low, medium, high, max (error)
+- `isolation` is `worktree` (only valid value, error)
+- Unknown frontmatter keys produce a warning
 
 ### rules/skills/agents add
 
@@ -299,7 +309,7 @@ If `CLAUDE_MANAGED_DIR` is not set, defaults to
 
 ## Architecture
 
-```
+```text
 main.go                     CLI entry point, env var
                             resolution, command dispatch
 internal/
@@ -325,6 +335,21 @@ e2e/                        Bats E2E test suite
 ```bash
 flox build claude-managed
 ```
+
+### Updating dependencies
+
+Bumping or adding a Go dependency requires regenerating
+the `vendorHash` in `default.nix`:
+
+1. Edit `go.mod` (e.g. `go get example.com/pkg@vX.Y.Z`)
+2. Run `go mod tidy` to refresh `go.sum`
+3. Set `vendorHash` to a placeholder
+   (`sha256-AAAA...AAA=`) and run `nix-build`
+4. Copy the `got: sha256-...` line from the failure into
+   `vendorHash` and rebuild
+
+Tests cover the parser and validators. Re-run
+`go test ./...` after touching `internal/doctor/`.
 
 ## Testing
 
@@ -365,7 +390,7 @@ tests inside `flox activate`. Tests `FLOX_ENV` and
 
 ### Test structure
 
-```
+```text
 e2e/
   test_helper/
     common.bash          mode detection, fixture helpers

--- a/.flox/pkgs/claude-managed/default.nix
+++ b/.flox/pkgs/claude-managed/default.nix
@@ -5,15 +5,14 @@
 
 buildGoModule {
   pname = "claude-managed";
-  version = "0.2.9";
+  version = "0.3.0";
 
   src = ./.;
 
-  vendorHash = null;
+  vendorHash = "sha256-g+yaVIx4jxpAQ/+WrGKxhVeliYx7nLQe/zsGpxV4Fn4=";
 
   meta = {
-    description =
-      "Flox-native config management for Claude Code CLI";
+    description = "Flox-native config management for Claude Code CLI";
     license = lib.licenses.mit;
     platforms = lib.platforms.unix;
     mainProgram = "claude-managed";

--- a/.flox/pkgs/claude-managed/go.mod
+++ b/.flox/pkgs/claude-managed/go.mod
@@ -1,3 +1,5 @@
 module flox.dev/claude-managed
 
 go 1.26.1
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/.flox/pkgs/claude-managed/go.sum
+++ b/.flox/pkgs/claude-managed/go.sum
@@ -1,0 +1,4 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/.flox/pkgs/claude-managed/internal/doctor/doctor.go
+++ b/.flox/pkgs/claude-managed/internal/doctor/doctor.go
@@ -8,18 +8,38 @@ import (
 	"regexp"
 	"strings"
 
+	"gopkg.in/yaml.v3"
+
 	"flox.dev/claude-managed/internal/discover"
 )
 
+// Severity classifies an Issue. Errors mean the fragment is broken;
+// warnings flag noteworthy state (unknown keys, exceeded length limits)
+// without failing the fragment.
+type Severity int
+
+const (
+	SeverityError Severity = iota
+	SeverityWarning
+)
+
 type Issue struct {
-	Type    string // "rules", "skills", "agents"
-	Name    string // fragment name
-	Path    string // file path
-	Message string
+	Type     string // "rules", "skills", "agents"
+	Name     string // fragment name
+	Path     string // file path
+	Message  string
+	Severity Severity
 }
 
+// IsError reports whether the issue blocks the fragment from loading.
+func (i Issue) IsError() bool { return i.Severity == SeverityError }
+
 func (i Issue) String() string {
-	return fmt.Sprintf("[%s/%s] %s (%s)", i.Type, i.Name, i.Message, i.Path)
+	prefix := "ERROR"
+	if i.Severity == SeverityWarning {
+		prefix = "WARN"
+	}
+	return fmt.Sprintf("[%s/%s] %s: %s (%s)", i.Type, i.Name, prefix, i.Message, i.Path)
 }
 
 // CheckResult holds the outcome of a doctor check.
@@ -35,39 +55,66 @@ type CheckedFragment struct {
 	OK   bool
 }
 
+// Errors returns only the error-severity issues.
+func (cr *CheckResult) Errors() []Issue {
+	var out []Issue
+	for _, i := range cr.Issues {
+		if i.IsError() {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// Warnings returns only the warning-severity issues.
+func (cr *CheckResult) Warnings() []Issue {
+	var out []Issue
+	for _, i := range cr.Issues {
+		if !i.IsError() {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
 // Check validates all fragments and returns detailed results.
 func Check(frags *discover.Result) *CheckResult {
 	r := &CheckResult{}
 
 	for _, f := range frags.Rules {
 		issues := validateRule(f)
-		ok := len(issues) == 0
 		r.Issues = append(r.Issues, issues...)
-		r.Checked = append(r.Checked, CheckedFragment{Type: "rules", Name: f.Name, OK: ok})
+		r.Checked = append(r.Checked, CheckedFragment{Type: "rules", Name: f.Name, OK: !hasError(issues)})
 	}
 
 	for _, f := range frags.Skills {
 		issues := validateSkill(f)
-		ok := len(issues) == 0
 		r.Issues = append(r.Issues, issues...)
-		r.Checked = append(r.Checked, CheckedFragment{Type: "skills", Name: f.Name, OK: ok})
+		r.Checked = append(r.Checked, CheckedFragment{Type: "skills", Name: f.Name, OK: !hasError(issues)})
 	}
 
 	for _, f := range frags.Agents {
 		issues := validateAgent(f)
-		ok := len(issues) == 0
 		r.Issues = append(r.Issues, issues...)
-		r.Checked = append(r.Checked, CheckedFragment{Type: "agents", Name: f.Name, OK: ok})
+		r.Checked = append(r.Checked, CheckedFragment{Type: "agents", Name: f.Name, OK: !hasError(issues)})
 	}
 
 	for _, f := range frags.Plugins {
 		issues := validatePlugin(f)
-		ok := len(issues) == 0
 		r.Issues = append(r.Issues, issues...)
-		r.Checked = append(r.Checked, CheckedFragment{Type: "plugins", Name: f.Name, OK: ok})
+		r.Checked = append(r.Checked, CheckedFragment{Type: "plugins", Name: f.Name, OK: !hasError(issues)})
 	}
 
 	return r
+}
+
+func hasError(issues []Issue) bool {
+	for _, i := range issues {
+		if i.IsError() {
+			return true
+		}
+	}
+	return false
 }
 
 // Known frontmatter keys per fragment type.
@@ -76,14 +123,27 @@ var (
 		"paths": true,
 	}
 
-	skillKeys = map[string]bool{
-		"name":                     true,
-		"description":              true,
+	// specSkillKeys is the closed set of top-level keys defined by the
+	// agentskills.io open standard. Source:
+	//   https://agentskills.io/specification
+	specSkillKeys = map[string]bool{
+		"name":          true,
+		"description":   true,
+		"license":       true,
+		"compatibility": true,
+		"metadata":      true,
+		"allowed-tools": true,
+	}
+
+	// ccExtensionKeys are vendor extensions added by Claude Code on top
+	// of the agentskills.io spec. Source:
+	//   https://code.claude.com/docs/en/skills
+	ccExtensionKeys = map[string]bool{
 		"when_to_use":              true,
 		"argument-hint":            true,
+		"arguments":                true,
 		"disable-model-invocation": true,
 		"user-invocable":           true,
-		"allowed-tools":            true,
 		"model":                    true,
 		"effort":                   true,
 		"context":                  true,
@@ -117,25 +177,41 @@ var (
 	kebabRe = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
 )
 
+// Spec-defined length limits (agentskills.io).
+const (
+	maxDescriptionLen   = 1024
+	maxCompatibilityLen = 500
+	maxNameLen          = 64
+)
+
 func validateRule(f discover.Fragment) []Issue {
 	data, err := os.ReadFile(f.Path)
 	if err != nil {
-		return []Issue{{Type: "rules", Name: f.Name, Path: f.Path, Message: "file not readable"}}
+		return []Issue{{Type: "rules", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: "file not readable"}}
 	}
 
 	var issues []Issue
 
 	if !strings.HasSuffix(f.Path, ".md") {
-		issues = append(issues, Issue{Type: "rules", Name: f.Name, Path: f.Path, Message: "must be a .md file"})
+		issues = append(issues, Issue{Type: "rules", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: "must be a .md file"})
 	}
 
-	fm := parseFrontmatter(string(data))
-	if fm != nil {
-		for key := range fm {
-			if !ruleKeys[key] {
-				issues = append(issues, Issue{Type: "rules", Name: f.Name, Path: f.Path,
-					Message: fmt.Sprintf("unknown frontmatter key %q (expected: paths)", key)})
-			}
+	fm, err := parseFrontmatter(string(data))
+	if err != nil {
+		issues = append(issues, Issue{Type: "rules", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: "frontmatter: invalid YAML: " + err.Error()})
+		return issues
+	}
+	if fm == nil {
+		return issues
+	}
+	for key := range fm {
+		if !ruleKeys[key] {
+			issues = append(issues, Issue{Type: "rules", Name: f.Name, Path: f.Path,
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("unknown frontmatter key %q (expected: paths)", key)})
 		}
 	}
 
@@ -145,45 +221,82 @@ func validateRule(f discover.Fragment) []Issue {
 func validateSkill(f discover.Fragment) []Issue {
 	data, err := os.ReadFile(f.Path)
 	if err != nil {
-		return []Issue{{Type: "skills", Name: f.Name, Path: f.Path, Message: "SKILL.md not readable"}}
+		return []Issue{{Type: "skills", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: "SKILL.md not readable"}}
 	}
 
 	var issues []Issue
 
-	// SKILL.md must exist in a directory named after the skill.
 	if filepath.Base(f.Path) != "SKILL.md" {
-		issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path, Message: "skill entry point must be SKILL.md"})
+		issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: "skill entry point must be SKILL.md"})
 	}
 
-	fm := parseFrontmatter(string(data))
-	if fm != nil {
-		for key := range fm {
-			if !skillKeys[key] {
-				issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
-					Message: fmt.Sprintf("unknown frontmatter key %q", key)})
-			}
-		}
+	fm, err := parseFrontmatter(string(data))
+	if err != nil {
+		issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: "frontmatter: invalid YAML: " + err.Error()})
+		return issues
+	}
+	if fm == nil {
+		return issues
+	}
 
-		// name must be kebab-case, max 64 chars.
-		if name, ok := fm["name"]; ok {
-			if len(name) > 64 {
-				issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
-					Message: fmt.Sprintf("name %q exceeds 64 characters", name)})
-			}
-			if !kebabRe.MatchString(name) {
-				issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
-					Message: fmt.Sprintf("name %q must be kebab-case", name)})
-			}
+	for key := range fm {
+		if specSkillKeys[key] || ccExtensionKeys[key] {
+			continue
 		}
+		issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
+			Severity: SeverityWarning,
+			Message: fmt.Sprintf(
+				"unknown frontmatter key %q — agentskills.io recommends nesting non-standard fields under \"metadata:\"",
+				key)})
+	}
 
-		// effort must be a known value.
-		if effort, ok := fm["effort"]; ok {
-			switch effort {
-			case "low", "medium", "high", "max":
-			default:
-				issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
-					Message: fmt.Sprintf("effort %q must be low|medium|high|max", effort)})
-			}
+	// name: required, kebab-case, ≤64 chars.
+	name, hasName := stringField(fm, "name")
+	if !hasName {
+		issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: `missing required frontmatter key "name"`})
+	} else {
+		if len(name) > maxNameLen {
+			issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("name %q exceeds %d characters", name, maxNameLen)})
+		}
+		if !kebabRe.MatchString(name) {
+			issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("name %q must be kebab-case", name)})
+		}
+	}
+
+	// description: required, ≤1024 chars (warning if exceeded).
+	desc, hasDesc := stringField(fm, "description")
+	if !hasDesc {
+		issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: `missing required frontmatter key "description"`})
+	} else if len(desc) > maxDescriptionLen {
+		issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("description is %d characters, agentskills.io recommends ≤%d", len(desc), maxDescriptionLen)})
+	}
+
+	// compatibility: ≤500 chars (warning if exceeded).
+	if compat, ok := stringField(fm, "compatibility"); ok && len(compat) > maxCompatibilityLen {
+		issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("compatibility is %d characters, agentskills.io recommends ≤%d", len(compat), maxCompatibilityLen)})
+	}
+
+	// effort: must be a known value.
+	if effort, ok := stringField(fm, "effort"); ok {
+		switch effort {
+		case "low", "medium", "high", "max":
+		default:
+			issues = append(issues, Issue{Type: "skills", Name: f.Name, Path: f.Path,
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("effort %q must be low|medium|high|max", effort)})
 		}
 	}
 
@@ -193,45 +306,54 @@ func validateSkill(f discover.Fragment) []Issue {
 func validateAgent(f discover.Fragment) []Issue {
 	data, err := os.ReadFile(f.Path)
 	if err != nil {
-		return []Issue{{Type: "agents", Name: f.Name, Path: f.Path, Message: "file not readable"}}
+		return []Issue{{Type: "agents", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: "file not readable"}}
 	}
 
 	var issues []Issue
 
 	if !strings.HasSuffix(f.Path, ".md") {
-		issues = append(issues, Issue{Type: "agents", Name: f.Name, Path: f.Path, Message: "must be a .md file"})
+		issues = append(issues, Issue{Type: "agents", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: "must be a .md file"})
 	}
 
-	fm := parseFrontmatter(string(data))
-	if fm != nil {
-		for key := range fm {
-			lower := strings.ToLower(key)
-			if agentDisallowed[lower] {
-				issues = append(issues, Issue{Type: "agents", Name: f.Name, Path: f.Path,
-					Message: fmt.Sprintf("forbidden frontmatter key %q (security restriction)", key)})
-			} else if !agentKeys[lower] {
-				issues = append(issues, Issue{Type: "agents", Name: f.Name, Path: f.Path,
-					Message: fmt.Sprintf("unknown frontmatter key %q", key)})
-			}
-		}
+	fm, err := parseFrontmatter(string(data))
+	if err != nil {
+		issues = append(issues, Issue{Type: "agents", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: "frontmatter: invalid YAML: " + err.Error()})
+		return issues
+	}
+	if fm == nil {
+		return issues
+	}
 
-		// effort must be a known value.
-		if effort, ok := fm["effort"]; ok {
-			switch effort {
-			case "low", "medium", "high", "max":
-			default:
-				issues = append(issues, Issue{Type: "agents", Name: f.Name, Path: f.Path,
-					Message: fmt.Sprintf("effort %q must be low|medium|high|max", effort)})
-			}
+	for key := range fm {
+		lower := strings.ToLower(key)
+		if agentDisallowed[lower] {
+			issues = append(issues, Issue{Type: "agents", Name: f.Name, Path: f.Path,
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("forbidden frontmatter key %q (security restriction)", key)})
+		} else if !agentKeys[lower] {
+			issues = append(issues, Issue{Type: "agents", Name: f.Name, Path: f.Path,
+				Severity: SeverityWarning,
+				Message:  fmt.Sprintf("unknown frontmatter key %q", key)})
 		}
+	}
 
-		// isolation only supports "worktree".
-		if iso, ok := fm["isolation"]; ok {
-			if iso != "worktree" {
-				issues = append(issues, Issue{Type: "agents", Name: f.Name, Path: f.Path,
-					Message: fmt.Sprintf("isolation %q must be \"worktree\"", iso)})
-			}
+	if effort, ok := stringField(fm, "effort"); ok {
+		switch effort {
+		case "low", "medium", "high", "max":
+		default:
+			issues = append(issues, Issue{Type: "agents", Name: f.Name, Path: f.Path,
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("effort %q must be low|medium|high|max", effort)})
 		}
+	}
+
+	if iso, ok := stringField(fm, "isolation"); ok && iso != "worktree" {
+		issues = append(issues, Issue{Type: "agents", Name: f.Name, Path: f.Path,
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("isolation %q must be \"worktree\"", iso)})
 	}
 
 	return issues
@@ -241,30 +363,28 @@ func validatePlugin(f discover.Fragment) []Issue {
 	var issues []Issue
 
 	if _, err := os.Stat(f.Path); err != nil {
-		return []Issue{{Type: "plugins", Name: f.Name,
-			Path: f.Path, Message: "directory not readable"}}
+		return []Issue{{Type: "plugins", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: "directory not readable"}}
 	}
 
-	// check .claude-plugin/plugin.json if present
 	pluginJSON := filepath.Join(f.Path, ".claude-plugin", "plugin.json")
 	if data, err := os.ReadFile(pluginJSON); err == nil {
 		var obj map[string]interface{}
 		if err := json.Unmarshal(data, &obj); err != nil {
-			issues = append(issues, Issue{Type: "plugins", Name: f.Name,
-				Path: pluginJSON, Message: "plugin.json: invalid JSON"})
+			issues = append(issues, Issue{Type: "plugins", Name: f.Name, Path: pluginJSON,
+				Severity: SeverityError, Message: "plugin.json: invalid JSON"})
 		} else {
 			name, ok := obj["name"]
 			if !ok {
-				issues = append(issues, Issue{Type: "plugins", Name: f.Name,
-					Path: pluginJSON, Message: "plugin.json: missing \"name\" field"})
+				issues = append(issues, Issue{Type: "plugins", Name: f.Name, Path: pluginJSON,
+					Severity: SeverityError, Message: "plugin.json: missing \"name\" field"})
 			} else if _, isStr := name.(string); !isStr {
-				issues = append(issues, Issue{Type: "plugins", Name: f.Name,
-					Path: pluginJSON, Message: "plugin.json: \"name\" must be a string"})
+				issues = append(issues, Issue{Type: "plugins", Name: f.Name, Path: pluginJSON,
+					Severity: SeverityError, Message: "plugin.json: \"name\" must be a string"})
 			}
 		}
 	}
 
-	// at least one recognized component
 	components := []string{".lsp.json", ".mcp.json", "skills", "agents", "hooks", "commands", "bin"}
 	hasComponent := false
 	for _, c := range components {
@@ -274,73 +394,70 @@ func validatePlugin(f discover.Fragment) []Issue {
 		}
 	}
 	if !hasComponent {
-		issues = append(issues, Issue{Type: "plugins", Name: f.Name,
-			Path: f.Path, Message: "no recognized components found"})
+		issues = append(issues, Issue{Type: "plugins", Name: f.Name, Path: f.Path,
+			Severity: SeverityError, Message: "no recognized components found"})
 	}
 
-	// validate installed_plugins.json if present
 	ipPath := filepath.Join(f.Path, "installed_plugins.json")
 	if data, err := os.ReadFile(ipPath); err == nil {
 		var obj map[string]interface{}
 		if err := json.Unmarshal(data, &obj); err != nil {
-			issues = append(issues, Issue{Type: "plugins", Name: f.Name,
-				Path: ipPath, Message: "installed_plugins.json: invalid JSON"})
+			issues = append(issues, Issue{Type: "plugins", Name: f.Name, Path: ipPath,
+				Severity: SeverityError, Message: "installed_plugins.json: invalid JSON"})
 		}
 	}
 
-	// validate known_marketplaces.json if present
 	kmPath := filepath.Join(f.Path, "known_marketplaces.json")
 	if data, err := os.ReadFile(kmPath); err == nil {
 		var obj map[string]interface{}
 		if err := json.Unmarshal(data, &obj); err != nil {
-			issues = append(issues, Issue{Type: "plugins", Name: f.Name,
-				Path: kmPath, Message: "known_marketplaces.json: invalid JSON"})
+			issues = append(issues, Issue{Type: "plugins", Name: f.Name, Path: kmPath,
+				Severity: SeverityError, Message: "known_marketplaces.json: invalid JSON"})
 		}
 	}
 
 	return issues
 }
 
+// stringField returns the string value at key (if present and a string).
+func stringField(fm map[string]any, key string) (string, bool) {
+	v, ok := fm[key]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}
+
 // ParseFrontmatterForTest is exported for testing only.
 var ParseFrontmatterForTest = parseFrontmatter
 
-// parseFrontmatter extracts YAML frontmatter key-value pairs from
-// markdown content. Returns nil if no frontmatter block is found.
-// Only handles simple "key: value" lines (no nested YAML).
-func parseFrontmatter(content string) map[string]string {
+// parseFrontmatter extracts the YAML mapping at the top of a markdown
+// document. Returns (nil, nil) when no frontmatter block is present or
+// when the closing `---` is missing. Returns an error only on YAML
+// parse failure inside an otherwise well-formed `---`-delimited block.
+func parseFrontmatter(content string) (map[string]any, error) {
 	content = strings.TrimSpace(content)
 	if !strings.HasPrefix(content, "---") {
-		return nil
+		return nil, nil
 	}
-
-	end := strings.Index(content[3:], "\n---")
+	rest := content[3:]
+	// Require the opener to terminate with a newline (or be the only line).
+	if !strings.HasPrefix(rest, "\n") && rest != "" {
+		return nil, nil
+	}
+	end := strings.Index(rest, "\n---")
 	if end < 0 {
-		return nil
+		return nil, nil
 	}
+	block := rest[:end]
 
-	block := content[3 : 3+end]
-	result := make(map[string]string)
-
-	for _, line := range strings.Split(block, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		// Skip list items (e.g. "  - value" under a key).
-		if strings.HasPrefix(line, "-") || strings.HasPrefix(line, "  -") {
-			continue
-		}
-		idx := strings.Index(line, ":")
-		if idx < 0 {
-			continue
-		}
-		key := strings.TrimSpace(line[:idx])
-		val := strings.TrimSpace(line[idx+1:])
-		val = strings.Trim(val, "\"'")
-		if key != "" {
-			result[key] = val
-		}
+	var fm map[string]any
+	if err := yaml.Unmarshal([]byte(block), &fm); err != nil {
+		return nil, err
 	}
-
-	return result
+	return fm, nil
 }

--- a/.flox/pkgs/claude-managed/internal/doctor/doctor_test.go
+++ b/.flox/pkgs/claude-managed/internal/doctor/doctor_test.go
@@ -15,8 +15,8 @@ func TestCheck_ValidFixtures(t *testing.T) {
 		Rules: []discover.Fragment{{Name: "alpha", Path: filepath.Join("..", "testdata", "share", "claude-code", "rules", "alpha.md")}},
 	}
 	result := doctor.Check(frags)
-	if len(result.Issues) != 0 {
-		t.Errorf("expected no issues, got: %v", result.Issues)
+	if len(result.Errors()) != 0 {
+		t.Errorf("expected no errors, got: %v", result.Errors())
 	}
 	if len(result.Checked) != 1 {
 		t.Errorf("expected 1 checked fragment, got %d", len(result.Checked))
@@ -28,8 +28,8 @@ func TestCheck_MissingFile(t *testing.T) {
 		Rules: []discover.Fragment{{Name: "missing", Path: "/nonexistent/file.md"}},
 	}
 	result := doctor.Check(frags)
-	if len(result.Issues) == 0 {
-		t.Error("expected issue for missing file")
+	if len(result.Errors()) == 0 {
+		t.Error("expected error for missing file")
 	}
 	if len(result.Checked) != 1 || result.Checked[0].OK {
 		t.Error("expected checked fragment marked as not OK")
@@ -42,12 +42,37 @@ func TestCheck_MissingSkill(t *testing.T) {
 		Skills: []discover.Fragment{{Name: "broken", Path: filepath.Join(dir, "SKILL.md")}},
 	}
 	result := doctor.Check(frags)
-	if len(result.Issues) == 0 {
-		t.Error("expected issue for missing SKILL.md")
+	if len(result.Errors()) == 0 {
+		t.Error("expected error for missing SKILL.md")
 	}
 }
 
-func TestCheck_ValidSkill(t *testing.T) {
+func TestCheck_SkillRequiresNameAndDescription(t *testing.T) {
+	dir := t.TempDir()
+	skillFile := filepath.Join(dir, "SKILL.md")
+	// Frontmatter present but missing both name and description.
+	os.WriteFile(skillFile, []byte("---\nlicense: MIT\n---\n# Skill\n"), 0644)
+
+	frags := &discover.Result{
+		Skills: []discover.Fragment{{Name: "incomplete", Path: skillFile}},
+	}
+	result := doctor.Check(frags)
+	wantMissing := []string{`"name"`, `"description"`}
+	for _, want := range wantMissing {
+		found := false
+		for _, issue := range result.Errors() {
+			if strings.Contains(issue.Message, "missing required frontmatter key") &&
+				strings.Contains(issue.Message, want) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected error about missing required key %s, got: %v", want, result.Errors())
+		}
+	}
+}
+
+func TestCheck_SkillNoFrontmatterIsLenient(t *testing.T) {
 	dir := t.TempDir()
 	skillFile := filepath.Join(dir, "SKILL.md")
 	os.WriteFile(skillFile, []byte("# Skill\nDo things.\n"), 0644)
@@ -57,24 +82,73 @@ func TestCheck_ValidSkill(t *testing.T) {
 	}
 	result := doctor.Check(frags)
 	if len(result.Issues) != 0 {
-		t.Errorf("expected no issues, got: %v", result.Issues)
+		t.Errorf("expected no issues for skill without frontmatter, got: %v", result.Issues)
 	}
-	if len(result.Checked) != 1 || !result.Checked[0].OK {
+	if !result.Checked[0].OK {
 		t.Error("expected checked fragment marked as OK")
 	}
 }
 
-func TestCheck_SkillWithValidFrontmatter(t *testing.T) {
+func TestCheck_SkillSpecConformant(t *testing.T) {
 	dir := t.TempDir()
 	skillFile := filepath.Join(dir, "SKILL.md")
-	os.WriteFile(skillFile, []byte("---\nname: my-skill\ndescription: does things\n---\n# Skill\n"), 0644)
+	os.WriteFile(skillFile, []byte("---\nname: my-skill\ndescription: does things\nlicense: MIT\ncompatibility: claude-code opencode\nmetadata:\n  version: \"1.0\"\n---\n# Skill\n"), 0644)
 
 	frags := &discover.Result{
 		Skills: []discover.Fragment{{Name: "my-skill", Path: skillFile}},
 	}
 	result := doctor.Check(frags)
 	if len(result.Issues) != 0 {
-		t.Errorf("expected no issues, got: %v", result.Issues)
+		t.Errorf("expected no issues for spec-conformant skill, got: %v", result.Issues)
+	}
+}
+
+func TestCheck_SkillHumanizerStyle(t *testing.T) {
+	// Reproduces blader/humanizer's frontmatter: block-scalar description,
+	// top-level version (non-spec), license, compatibility, allowed-tools list.
+	skillBody := `---
+name: humanizer
+version: 2.5.1
+description: |
+  Remove signs of AI-generated writing from text. Use when editing or reviewing
+  text to make it sound more natural and human-written. Based on Wikipedia's
+  comprehensive "Signs of AI writing" guide. Detects and fixes patterns including:
+  inflated symbolism, promotional language, superficial -ing analyses, vague
+  attributions, em dash overuse, rule of three, AI vocabulary words, passive
+  voice, negative parallelisms, and filler phrases.
+license: MIT
+compatibility: claude-code opencode
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+---
+# Humanizer
+`
+	dir := t.TempDir()
+	skillFile := filepath.Join(dir, "SKILL.md")
+	os.WriteFile(skillFile, []byte(skillBody), 0644)
+
+	frags := &discover.Result{
+		Skills: []discover.Fragment{{Name: "humanizer", Path: skillFile}},
+	}
+	result := doctor.Check(frags)
+
+	if len(result.Errors()) != 0 {
+		t.Errorf("expected no errors for humanizer-style skill, got: %v", result.Errors())
+	}
+	if !result.Checked[0].OK {
+		t.Error("expected humanizer to be marked OK (warnings only)")
+	}
+
+	// Exactly one warning, about the non-spec top-level "version" key.
+	warnings := result.Warnings()
+	if len(warnings) != 1 {
+		t.Fatalf("expected exactly 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	if !strings.Contains(warnings[0].Message, `"version"`) ||
+		!strings.Contains(warnings[0].Message, "metadata") {
+		t.Errorf("expected pedagogical warning about version+metadata, got: %q", warnings[0].Message)
 	}
 }
 
@@ -82,60 +156,90 @@ func TestCheck_SkillNameTooLong(t *testing.T) {
 	dir := t.TempDir()
 	skillFile := filepath.Join(dir, "SKILL.md")
 	longName := "a-very-long-skill-name-that-exceeds-the-sixty-four-character-limit-by-far"
-	os.WriteFile(skillFile, []byte("---\nname: "+longName+"\n---\n# Skill\n"), 0644)
+	os.WriteFile(skillFile, []byte("---\nname: "+longName+"\ndescription: x\n---\n# Skill\n"), 0644)
 
 	frags := &discover.Result{
 		Skills: []discover.Fragment{{Name: "long", Path: skillFile}},
 	}
 	result := doctor.Check(frags)
 	found := false
-	for _, issue := range result.Issues {
-		if issue.Message != "" && len(longName) > 64 {
+	for _, issue := range result.Errors() {
+		if strings.Contains(issue.Message, "exceeds 64") {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected issue for skill name exceeding 64 chars")
+		t.Errorf("expected error for skill name exceeding 64 chars, got: %v", result.Issues)
 	}
 }
 
 func TestCheck_SkillNameNotKebab(t *testing.T) {
 	dir := t.TempDir()
 	skillFile := filepath.Join(dir, "SKILL.md")
-	os.WriteFile(skillFile, []byte("---\nname: MySkill\n---\n# Skill\n"), 0644)
+	os.WriteFile(skillFile, []byte("---\nname: MySkill\ndescription: x\n---\n# Skill\n"), 0644)
 
 	frags := &discover.Result{
 		Skills: []discover.Fragment{{Name: "bad-name", Path: skillFile}},
 	}
 	result := doctor.Check(frags)
 	found := false
-	for _, issue := range result.Issues {
-		if contains(issue.Message, "kebab-case") {
+	for _, issue := range result.Errors() {
+		if strings.Contains(issue.Message, "kebab-case") {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected issue for non-kebab-case name")
+		t.Error("expected error for non-kebab-case name")
 	}
 }
 
-func TestCheck_SkillUnknownKey(t *testing.T) {
+func TestCheck_SkillUnknownKeyIsWarning(t *testing.T) {
 	dir := t.TempDir()
 	skillFile := filepath.Join(dir, "SKILL.md")
-	os.WriteFile(skillFile, []byte("---\nname: ok\nfoo: bar\n---\n# Skill\n"), 0644)
+	os.WriteFile(skillFile, []byte("---\nname: ok\ndescription: x\nfoo: bar\n---\n# Skill\n"), 0644)
 
 	frags := &discover.Result{
 		Skills: []discover.Fragment{{Name: "unknown-key", Path: skillFile}},
 	}
 	result := doctor.Check(frags)
+	if len(result.Errors()) != 0 {
+		t.Errorf("unknown skill key should not be an error, got: %v", result.Errors())
+	}
 	found := false
-	for _, issue := range result.Issues {
-		if contains(issue.Message, "unknown frontmatter key") {
+	for _, issue := range result.Warnings() {
+		if strings.Contains(issue.Message, "unknown frontmatter key") {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected issue for unknown frontmatter key")
+		t.Error("expected warning for unknown frontmatter key")
+	}
+	if !result.Checked[0].OK {
+		t.Error("warnings alone should not flip OK to false")
+	}
+}
+
+func TestCheck_SkillDescriptionTooLong(t *testing.T) {
+	dir := t.TempDir()
+	skillFile := filepath.Join(dir, "SKILL.md")
+	longDesc := strings.Repeat("a", 1500)
+	os.WriteFile(skillFile, []byte("---\nname: ok\ndescription: "+longDesc+"\n---\n# Skill\n"), 0644)
+
+	frags := &discover.Result{
+		Skills: []discover.Fragment{{Name: "long-desc", Path: skillFile}},
+	}
+	result := doctor.Check(frags)
+	if len(result.Errors()) != 0 {
+		t.Errorf("description over 1024 chars should be a warning, not an error, got: %v", result.Errors())
+	}
+	found := false
+	for _, issue := range result.Warnings() {
+		if strings.Contains(issue.Message, "description") && strings.Contains(issue.Message, "1024") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected warning about description length")
 	}
 }
 
@@ -153,7 +257,7 @@ func TestCheck_RuleWithPaths(t *testing.T) {
 	}
 }
 
-func TestCheck_RuleUnknownKey(t *testing.T) {
+func TestCheck_RuleUnknownKeyIsWarning(t *testing.T) {
 	dir := t.TempDir()
 	ruleFile := filepath.Join(dir, "bad.md")
 	os.WriteFile(ruleFile, []byte("---\nfoo: bar\n---\n# Rules\n"), 0644)
@@ -162,14 +266,17 @@ func TestCheck_RuleUnknownKey(t *testing.T) {
 		Rules: []discover.Fragment{{Name: "bad", Path: ruleFile}},
 	}
 	result := doctor.Check(frags)
+	if len(result.Errors()) != 0 {
+		t.Errorf("unknown rule key should be a warning, got errors: %v", result.Errors())
+	}
 	found := false
-	for _, issue := range result.Issues {
-		if contains(issue.Message, "unknown frontmatter key") {
+	for _, issue := range result.Warnings() {
+		if strings.Contains(issue.Message, "unknown frontmatter key") {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected issue for unknown frontmatter key in rule")
+		t.Error("expected warning for unknown frontmatter key in rule")
 	}
 }
 
@@ -183,13 +290,13 @@ func TestCheck_AgentForbiddenKey(t *testing.T) {
 	}
 	result := doctor.Check(frags)
 	found := false
-	for _, issue := range result.Issues {
-		if contains(issue.Message, "forbidden") {
+	for _, issue := range result.Errors() {
+		if strings.Contains(issue.Message, "forbidden") {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected issue for forbidden agent key")
+		t.Error("expected error for forbidden agent key")
 	}
 }
 
@@ -217,13 +324,13 @@ func TestCheck_AgentInvalidEffort(t *testing.T) {
 	}
 	result := doctor.Check(frags)
 	found := false
-	for _, issue := range result.Issues {
-		if contains(issue.Message, "effort") {
+	for _, issue := range result.Errors() {
+		if strings.Contains(issue.Message, "effort") {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected issue for invalid effort value")
+		t.Error("expected error for invalid effort value")
 	}
 }
 
@@ -237,13 +344,13 @@ func TestCheck_AgentInvalidIsolation(t *testing.T) {
 	}
 	result := doctor.Check(frags)
 	found := false
-	for _, issue := range result.Issues {
-		if contains(issue.Message, "isolation") {
+	for _, issue := range result.Errors() {
+		if strings.Contains(issue.Message, "isolation") {
 			found = true
 		}
 	}
 	if !found {
-		t.Error("expected issue for invalid isolation value")
+		t.Error("expected error for invalid isolation value")
 	}
 }
 
@@ -261,13 +368,35 @@ func TestCheck_NoFrontmatter(t *testing.T) {
 	}
 }
 
+func TestCheck_SkillInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	skillFile := filepath.Join(dir, "SKILL.md")
+	// Tab in frontmatter is illegal YAML indentation.
+	os.WriteFile(skillFile, []byte("---\nname: foo\n\tbroken: indent\n---\n"), 0644)
+
+	frags := &discover.Result{
+		Skills: []discover.Fragment{{Name: "broken", Path: skillFile}},
+	}
+	result := doctor.Check(frags)
+	found := false
+	for _, issue := range result.Errors() {
+		if strings.Contains(issue.Message, "invalid YAML") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error about invalid YAML, got: %v", result.Issues)
+	}
+}
+
 func TestParseFrontmatter(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		wantNil bool
-		wantKey string
-		wantVal string
+		name      string
+		input     string
+		wantNil   bool
+		wantErr   bool
+		wantKeys  []string
+		notExpect []string // keys that must NOT appear (regression tests)
 	}{
 		{
 			name:    "no frontmatter",
@@ -275,27 +404,81 @@ func TestParseFrontmatter(t *testing.T) {
 			wantNil: true,
 		},
 		{
-			name:    "simple frontmatter",
-			input:   "---\nname: test\n---\n# Hello",
-			wantKey: "name",
-			wantVal: "test",
+			name:     "simple frontmatter",
+			input:    "---\nname: test\n---\n# Hello",
+			wantKeys: []string{"name"},
 		},
 		{
-			name:    "quoted value",
-			input:   "---\nname: \"my-skill\"\n---\n# Hello",
-			wantKey: "name",
-			wantVal: "my-skill",
+			name:     "quoted value with colon",
+			input:    "---\nname: \"foo: bar\"\n---\n# Hello",
+			wantKeys: []string{"name"},
 		},
 		{
 			name:    "unclosed frontmatter",
 			input:   "---\nname: test\n# Hello",
 			wantNil: true,
 		},
+		{
+			name: "block scalar description",
+			input: `---
+name: humanizer
+description: |
+  Multi-line text.
+  More text including: a colon mid-line.
+  Yet more text.
+---
+# Body`,
+			wantKeys:  []string{"name", "description"},
+			notExpect: []string{"More text including"},
+		},
+		{
+			name: "folded scalar",
+			input: `---
+description: >
+  Folded text spans
+  multiple lines.
+---`,
+			wantKeys: []string{"description"},
+		},
+		{
+			name: "list value",
+			input: `---
+allowed-tools:
+  - Read
+  - Write
+---`,
+			wantKeys:  []string{"allowed-tools"},
+			notExpect: []string{"Read", "Write"},
+		},
+		{
+			name: "nested mapping",
+			input: `---
+metadata:
+  version: "1.0"
+  author: someone
+---`,
+			wantKeys:  []string{"metadata"},
+			notExpect: []string{"version", "author"},
+		},
+		{
+			name:    "tab indent invalid",
+			input:   "---\nname: foo\n\tbroken: 1\n---",
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := doctor.ParseFrontmatterForTest(tt.input)
+			result, err := doctor.ParseFrontmatterForTest(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 			if tt.wantNil {
 				if result != nil {
 					t.Errorf("expected nil, got %v", result)
@@ -305,11 +488,26 @@ func TestParseFrontmatter(t *testing.T) {
 			if result == nil {
 				t.Fatal("expected non-nil result")
 			}
-			if result[tt.wantKey] != tt.wantVal {
-				t.Errorf("expected %s=%q, got %q", tt.wantKey, tt.wantVal, result[tt.wantKey])
+			for _, key := range tt.wantKeys {
+				if _, ok := result[key]; !ok {
+					t.Errorf("expected key %q, got keys %v", key, mapKeys(result))
+				}
+			}
+			for _, key := range tt.notExpect {
+				if _, ok := result[key]; ok {
+					t.Errorf("unexpected key %q (block scalar / list / nested leaked into top-level)", key)
+				}
 			}
 		})
 	}
+}
+
+func mapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
 }
 
 func TestValidatePlugin_Valid(t *testing.T) {
@@ -421,17 +619,4 @@ func TestValidatePlugin_BadInstalledPluginsJSON(t *testing.T) {
 	if !found {
 		t.Error("expected invalid JSON issue for installed_plugins.json")
 	}
-}
-
-func contains(s, sub string) bool {
-	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsStr(s, sub))
-}
-
-func containsStr(s, sub string) bool {
-	for i := 0; i <= len(s)-len(sub); i++ {
-		if s[i:i+len(sub)] == sub {
-			return true
-		}
-	}
-	return false
 }

--- a/.flox/pkgs/claude-managed/main.go
+++ b/.flox/pkgs/claude-managed/main.go
@@ -15,7 +15,7 @@ import (
 	"flox.dev/claude-managed/internal/symlinks"
 )
 
-const version = "0.2.9"
+const version = "0.3.0"
 
 // ANSI color helpers
 func ansi(code, s string) string { return "\033[" + code + "m" + s + "\033[0m" }
@@ -189,7 +189,11 @@ func runSetup(shareDir, configDir, mode string, warn io.Writer) error {
 	if mode == "hook" {
 		result := doctor.Check(frags)
 		for _, issue := range result.Issues {
-			fmt.Fprintf(warn, yellow("WARN:")+" %s\n", issue)
+			label := yellow("WARN:")
+			if issue.IsError() {
+				label = red("ERROR:")
+			}
+			fmt.Fprintf(warn, "%s %s\n", label, issue)
 		}
 	}
 
@@ -271,14 +275,17 @@ func runStatus(shareDir, configDir, projectDir string, managed bool) error {
 				}
 			}
 			key := subdir + "/" + f.Name
-			if issues, ok := issuesByName[key]; ok {
+			issues := issuesByName[key]
+			if hasIssueError(issues) {
 				status = red("✗")
-				fmt.Printf("    %s %s\n", status, f.Name)
-				for _, issue := range issues {
+			}
+			fmt.Printf("    %s %s\n", status, f.Name)
+			for _, issue := range issues {
+				if issue.IsError() {
 					fmt.Printf("      %s\n", red(issue.Message))
+				} else {
+					fmt.Printf("      %s %s\n", yellow("⚠"), issue.Message)
 				}
-			} else {
-				fmt.Printf("    %s %s\n", status, f.Name)
 			}
 		}
 	}
@@ -316,13 +323,18 @@ func runDoctor(shareDir string) error {
 		}
 		for _, f := range items {
 			key := typeName + "/" + f.Name
-			if issues, ok := issuesByKey[key]; ok {
-				fmt.Printf("    %s %s\n", red("✗"), f.Name)
-				for _, issue := range issues {
+			issues := issuesByKey[key]
+			marker := green("✓")
+			if hasIssueError(issues) {
+				marker = red("✗")
+			}
+			fmt.Printf("    %s %s\n", marker, f.Name)
+			for _, issue := range issues {
+				if issue.IsError() {
 					fmt.Printf("      %s\n", red(issue.Message))
+				} else {
+					fmt.Printf("      %s %s\n", yellow("⚠"), issue.Message)
 				}
-			} else {
-				fmt.Printf("    %s %s\n", green("✓"), f.Name)
 			}
 		}
 	}
@@ -334,12 +346,28 @@ func runDoctor(shareDir string) error {
 
 	fmt.Println()
 
-	if len(result.Issues) == 0 {
+	errCount := len(result.Errors())
+	warnCount := len(result.Warnings())
+
+	switch {
+	case errCount == 0 && warnCount == 0:
 		fmt.Println(green("All valid."))
 		return nil
+	case errCount == 0:
+		fmt.Println(yellow(fmt.Sprintf("%d warning(s), no errors.", warnCount)))
+		return nil
+	default:
+		return fmt.Errorf("%d error(s), %d warning(s)", errCount, warnCount)
 	}
+}
 
-	return fmt.Errorf("%d issue(s) found", len(result.Issues))
+func hasIssueError(issues []doctor.Issue) bool {
+	for _, i := range issues {
+		if i.IsError() {
+			return true
+		}
+	}
+	return false
 }
 
 func runSymlinkList(label, configDir, subdir string) error {

--- a/.flox/pkgs/claude-managed/main_test.go
+++ b/.flox/pkgs/claude-managed/main_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestRunSetup_HookWarnsOnInvalidFrontmatter(t *testing.T) {
+func TestRunSetup_HookWarnsOnUnknownRuleKey(t *testing.T) {
 	dir := t.TempDir()
 
 	// create share/claude-code/rules/ with a rule that has an unknown key
@@ -27,6 +27,26 @@ func TestRunSetup_HookWarnsOnInvalidFrontmatter(t *testing.T) {
 	}
 	if !strings.Contains(warn.String(), "unknown frontmatter key") {
 		t.Errorf("expected 'unknown frontmatter key' in warning, got: %q", warn.String())
+	}
+}
+
+func TestRunSetup_HookErrorsOnMissingSkillName(t *testing.T) {
+	dir := t.TempDir()
+
+	// skill with frontmatter but no name → error severity
+	skillDir := filepath.Join(dir, "skills", "broken")
+	os.MkdirAll(skillDir, 0755)
+	os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
+		[]byte("---\ndescription: x\n---\n# Skill\n"), 0644)
+
+	var warn bytes.Buffer
+	err := runSetup(dir, "/tmp/config", "hook", &warn)
+	if err != nil {
+		t.Fatalf("runSetup failed: %v", err)
+	}
+
+	if !strings.Contains(warn.String(), "ERROR") {
+		t.Errorf("expected ERROR prefix for missing name, got: %q", warn.String())
 	}
 }
 


### PR DESCRIPTION
## Why this fix is needed

When a user activates a flox environment that includes a packaged skill, `claude-managed` runs validation. Today, it reports legitimate, working skills as broken — flooding stderr with warnings on every activate and showing `✗ skill-name` in `claude-managed status`.

Concrete repro: install the `skills-humanizer` package and activate. You get this every time:

```text
$ claude-managed status
  Skills
    ✗ humanizer
      unknown frontmatter key "comprehensive \"Signs of AI writing\" guide. ..."
      unknown frontmatter key "license"
      unknown frontmatter key "compatibility"
      unknown frontmatter key "version"

$ flox activate
WARN: [skills/humanizer] unknown frontmatter key ...    (× 4 lines)
```

The humanizer skill works fine in Claude Code. None of those four warnings reflect a real problem with the skill — they're bugs in the validator. The user-visible cost is loud, untrustworthy validation that trains people to ignore `claude-managed` output, which then hides the warnings that *do* matter.

## Three root causes

1. **Parser bug.** `internal/doctor/doctor.go`'s `parseFrontmatter` is a hand-rolled regex/string-split that doesn't understand YAML block scalars. Indented continuation lines under `description: |` containing `:` are misread as new top-level keys — that's the first phantom warning above (`"comprehensive \"Signs of AI writing\" guide..."`).
2. **Allowlist gap.** The skill allowlist has Claude Code's vendor extensions (`when_to_use`, `model`, `effort`, …) but is missing the [agentskills.io](https://agentskills.io/specification) spec-base keys `license`, `compatibility`, and `metadata`. So spec-conformant skills get flagged as broken.
3. **Severity bug.** Any unknown key flips a skill to `✗`. There is no warning level — typos and benign metadata are treated identically. `version` belongs under `metadata:` per spec, but flagging it shouldn't disable the skill.

This PR fixes all three, replacing the earlier workaround that patched humanizer's `SKILL.md` at install time. The validator was wrong, not the skill — the fix is now in the right place.

## After

```text
$ claude-managed doctor
  Skills
    ✓ humanizer
      ⚠ unknown frontmatter key "version" — agentskills.io recommends
        nesting non-standard fields under "metadata:"

1 warning(s), no errors.
$ echo $?
0
```

Skill is `✓`. The one remaining warning is genuine (`version` at top-level isn't in the spec) and pedagogical (it tells the skill author what to do). Exit code is 0; the warning doesn't fail activation or CI.

## Changes

- **Parser** — replaced with `gopkg.in/yaml.v3`. Only runtime dep; ~500 KB vendored, zero transitive. `parseFrontmatter` now returns `(map[string]any, error)`.
- **Two-layer allowlist** — `specSkillKeys` (the six top-level keys from agentskills.io) and `ccExtensionKeys` (Claude Code's documented extensions). Each layer has a comment citing its source so the next reader knows where to add new keys.
- **Severity model** — `Issue` gains a `Severity` field (`Error|Warning`). Errors render as `✗ name` in red. Warnings render as `⚠ message` lines beneath a still-green `✓ name`. `runDoctor` exits 0 on warnings-only, non-zero on any error.
- **Pedagogical warning text** — unknown top-level keys point reviewers / skill authors to the spec's recommended home (`metadata:`) for non-standard fields.
- **Required fields** — when a frontmatter block is present, `name` and `description` are now errors if missing. No-frontmatter skills stay lenient.
- **Length limits** — `description` >1024 chars and `compatibility` >500 chars are warnings (per spec), not errors.
- **README** — new section on `vendorHash` regeneration; doctor section rewritten to match new severity behavior.

## Severity matrix

| Concern                                              | Severity |
| ---------------------------------------------------- | -------- |
| Missing `name` / `description` (when frontmatter present) | Error    |
| `name` not kebab-case / >64 chars                    | Error    |
| `effort` not in `low\|medium\|high\|max`             | Error    |
| `isolation` ≠ `worktree` (agents)                    | Error    |
| Forbidden agent key (`hooks`, `mcpServers`, …)       | Error    |
| Invalid YAML in frontmatter                          | Error    |
| Unknown top-level key                                | Warning  |
| `description` >1024 / `compatibility` >500           | Warning  |

## Test plan

- [x] `go test ./...` passes
- [x] `nix-build` of `claude-managed` and `skills-humanizer` succeeds
- [x] `claude-managed doctor` against the built `skills-humanizer` shows `✓ humanizer` plus one pedagogical `⚠`, exits 0
- [x] New tests cover: block scalars, folded scalars, list values, nested mappings, quoted-colon values, invalid YAML, missing required fields, humanizer-style frontmatter, severity gating
- [ ] CI green on all four target systems

## Notes

- Bumps `claude-managed` to **0.3.0** because the accepted-key set widens and severity is new behavior — fragments that previously showed `✗` may now show `✓ ⚠`.
- Does not switch to `goccy/go-yaml`: ~4.5 MB vendored vs ~500 KB for `yaml.v3`, and a larger refactor than warranted for an 18-key schema. Reachable in a future PR if the schema grows.
- Does not publish a JSON Schema: agentskills.io's reference (`skills-ref`) is itself a hand-rolled `ALLOWED_FIELDS` set, not a schema file. We would be inventing a third source of truth.