### PR TITLE
feat(claude-code-plugin-superpowers): package obra/superpowers v5.1.0

### DIFF
--- a/.flox/pkgs/claude-code-plugin-superpowers/default.nix
+++ b/.flox/pkgs/claude-code-plugin-superpowers/default.nix
@@ -1,0 +1,135 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nodejs,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash commitSha;
+in
+stdenv.mkDerivation {
+  pname = "claude-code-plugin-superpowers";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "obra";
+    repo = "superpowers";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    PLUGIN_DIR="$out/share/claude-code/plugins/superpowers"
+    mkdir -p "$PLUGIN_DIR"
+
+    # Upstream ships the Claude Code plugin source at the repo root —
+    # `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
+    # both reference `./` as the plugin source. Copy the whole tree, then
+    # strip per-harness mirrors and repo-only metadata that Claude Code
+    # would otherwise attempt to load or surface as plugin content.
+    cp -r "$src"/. "$PLUGIN_DIR/"
+    chmod -R u+w "$PLUGIN_DIR"
+
+    rm -rf "$PLUGIN_DIR/.codex-plugin" \
+           "$PLUGIN_DIR/.cursor-plugin" \
+           "$PLUGIN_DIR/.opencode" \
+           "$PLUGIN_DIR/.github" \
+           "$PLUGIN_DIR/.gitignore" \
+           "$PLUGIN_DIR/.gitattributes" \
+           "$PLUGIN_DIR/.version-bump.json" \
+           "$PLUGIN_DIR/AGENTS.md" \
+           "$PLUGIN_DIR/CLAUDE.md" \
+           "$PLUGIN_DIR/GEMINI.md" \
+           "$PLUGIN_DIR/gemini-extension.json" \
+           "$PLUGIN_DIR/package.json" \
+           "$PLUGIN_DIR/scripts" \
+           "$PLUGIN_DIR/tests"
+
+    # Bundle node so the brainstorming visual companion (server.cjs) and
+    # render-graphs.js resolve a runtime without requiring the consumer's
+    # flox env to install nodejs. Plain symlink — no makeBinaryWrapper,
+    # no PATH prefix — because superpowers' Node code is stdlib-only:
+    # server.cjs uses crypto/http/fs and never shells out; render-graphs.js
+    # shells to `dot` (graphviz), which we deliberately leave to the
+    # consumer.
+    mkdir -p "$PLUGIN_DIR/bin"
+    ln -s "${nodejs}/bin/node" "$PLUGIN_DIR/bin/node"
+
+    # Repoint every #!/usr/bin/env node shebang at the bundled node.
+    # Marks files executable so the kernel honors the shebang when
+    # Claude Code invokes them.
+    while IFS= read -r f; do
+      head -1 "$f" | grep -q '/usr/bin/env node' || continue
+      substituteInPlace "$f" --replace-fail \
+        '#!/usr/bin/env node' "#!$PLUGIN_DIR/bin/node"
+      chmod +x "$f"
+    done < <(find "$PLUGIN_DIR" -type f \
+              \( -name '*.cjs' -o -name '*.js' -o -name '*.mjs' \))
+
+    # The brainstorm server is started from start-server.sh via two
+    # `node server.cjs` invocations (foreground + nohup background).
+    # Rewrite both to use the bundled node by absolute path. The script
+    # defines SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)" at the top, so
+    # $SCRIPT_DIR/../../../bin/node resolves to $PLUGIN_DIR/bin/node.
+    # --replace-fail makes upstream renames trip the build instead of
+    # silently shipping a broken script.
+    substituteInPlace \
+      "$PLUGIN_DIR/skills/brainstorming/scripts/start-server.sh" \
+      --replace-fail \
+      'node server.cjs' \
+      '"$SCRIPT_DIR/../../../bin/node" server.cjs'
+
+    # Make hook entry points executable. session-start has a bash
+    # shebang (auto-patched by fixupPhase). run-hook.cmd is a
+    # shebang-less polyglot — Claude Code invokes it via /bin/sh, which
+    # falls back to interpreting it as a shell script when exec hits
+    # ENOEXEC.
+    chmod +x "$PLUGIN_DIR/hooks/session-start" \
+             "$PLUGIN_DIR/hooks/run-hook.cmd"
+
+    # Drop installed_plugins.json so claude-managed registers the plugin
+    # in $CLAUDE_CONFIG_DIR/plugins/installed_plugins.json at activation.
+    # installPath is patched to the real symlink target by
+    # `claude-managed plugins add`. v2 is the schema claude-managed
+    # >=0.2.8 reads.
+    cat > "$PLUGIN_DIR/installed_plugins.json" <<JSON
+    {
+      "plugins": {
+        "superpowers@flox": [
+          {
+            "installPath": "",
+            "scope": "project",
+            "version": "${version}",
+            "gitCommitSha": "${commitSha}"
+          }
+        ]
+      },
+      "version": 2
+    }
+    JSON
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Superpowers plugin for Claude Code (14 skills + SessionStart "
+      + "hook) with Node.js bundled for the brainstorming visual "
+      + "companion.";
+    homepage = "https://github.com/obra/superpowers";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/claude-code-plugin-superpowers/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-superpowers/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "5.1.0",
+  "srcHash": "sha256-3E3rO6hR87JUfS3XV1Eaoz6SDWOftleWvN9UPNFEMjw=",
+  "commitSha": "ecbd610fce16d5faabcea997f17031129589b572"
+}

--- a/.flox/pkgs/claude-code-plugin-superpowers/publish.json
+++ b/.flox/pkgs/claude-code-plugin-superpowers/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/claude-code-plugin-superpowers/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-superpowers/upgrade.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_tag=$(curl -sf \
+  https://api.github.com/repos/obra/superpowers/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating claude-code-plugin-superpowers from $current_version to $latest_version"
+
+src_url="https://github.com/obra/superpowers/archive/refs/tags/v${latest_version}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+# Resolve the tag to its commit SHA — Claude Code's installed_plugins.json
+# records gitCommitSha per entry, and shipping the real SHA lets users
+# reproduce or audit exactly which upstream commit they have.
+commit_sha=$(git ls-remote https://github.com/obra/superpowers.git \
+  "refs/tags/v${latest_version}" | awk '{print $1}')
+if [ -z "$commit_sha" ]; then
+  echo "ERROR: could not resolve v${latest_version} to a commit SHA"
+  exit 1
+fi
+echo "  commitSha: $commit_sha"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg c "$commit_sha" \
+  '{version: $v, srcHash: $s, commitSha: $c}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"


### PR DESCRIPTION
## Summary

- Adds `claude-code-plugin-superpowers`, a flox derivation packaging
  [obra/superpowers](https://github.com/obra/superpowers) v5.1.0 as a Claude Code plugin tree at `\$out/share/claude-code/plugins/superpowers/`.
- Bundles `nodejs` as a plain symlink at `\$PLUGIN_DIR/bin/node` so the
  brainstorming visual companion (`server.cjs`) and `render-graphs.js`
  resolve without requiring the consumer's flox env to install nodejs.
  Patches `start-server.sh`'s two `node server.cjs` invocations to the
  bundled-node absolute path via `substituteInPlace --replace-fail`.
- Strips per-harness mirrors (`.codex-plugin/`, `.cursor-plugin/`,
  `.opencode/`), repo metadata (`.github/`, `.version-bump.json`),
  other-harness configs (`AGENTS.md`, `GEMINI.md`, `gemini-extension.json`),
  the npm `package.json` (which points at `.opencode/`), and maintainer-only
  `scripts/` + `tests/`.
- Emits an `installed_plugins.json` (v2 schema) carrying the upstream tag's
  commit SHA so `claude-managed plugins add` registers and trusts the
  plugin at activation.
- `upgrade.sh` follows the impeccable pattern: polls
  `releases/latest`, prefetches + SRI-converts, resolves the tag
  to a commit SHA. Auto-discovered by `.github/workflows/upgrade_pkgs.yml`.

Follows the same shape as `claude-code-plugin-impeccable` /
`claude-code-plugin-claude-seo` / `claude-code-plugin-typescript-lsp`.
No demo env wiring and no per-package `test.sh`, matching the
established convention from those branches.

## Test Plan

- [x] `flox build claude-code-plugin-superpowers` succeeds on this branch
- [x] Output at `result-.../share/claude-code/plugins/superpowers/`
      has `.claude-plugin/`, `bin/node` symlink, all 14 skills, hooks/,
      patched `start-server.sh`, and a valid `installed_plugins.json`
- [x] `bash .flox/pkgs/claude-code-plugin-superpowers/upgrade.sh` reports
      "Already up to date" against the locked v5.1.0
- [x] `claude-managed plugins add` registers the plugin (exit 0,
      empty stderr); `claude-managed doctor` reports "All valid."
- [x] Full `claude-managed setup-hook` activation eval: exit 0, stderr
      empty, stdout empty
- [x] `SessionStart` hook (via `run-hook.cmd` and direct): exit 0,
      well-formed `hookSpecificOutput.additionalContext` JSON
- [x] Brainstorm `start-server.sh` boots the visual-companion HTTP
      server on a random port, `GET / -> 200 OK`, `stop-server.sh`
      shuts it down cleanly
- [ ] CI build matrix (4 systems) green