### PR TITLE
feat(skills-frontend-design): package anthropics/skills frontend-design skill

### DIFF
--- a/.flox/pkgs/skills-frontend-design/default.nix
+++ b/.flox/pkgs/skills-frontend-design/default.nix
@@ -1,0 +1,54 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+let
+  data = builtins.fromJSON (builtins.readFile ./hashes.json);
+
+  src = fetchFromGitHub {
+    owner = "anthropics";
+    repo = "skills";
+    rev = data.rev;
+    hash = data.srcHash;
+  };
+
+  skillSubdir = "skills/frontend-design";
+in
+stdenvNoCC.mkDerivation {
+  pname = "skills-frontend-design";
+  version = data.version;
+  inherit src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    for dest in \
+      "$out/share/claude-code/skills/frontend-design" \
+      "$out/share/opencode/skills/frontend-design"; do
+      mkdir -p "$dest"
+      cp -r "$src/${skillSubdir}"/. "$dest/"
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Frontend-design skill for Claude Code and OpenCode "
+      + "— creates distinctive, production-grade frontend interfaces.";
+    homepage =
+      "https://github.com/anthropics/skills/tree/main/skills/frontend-design";
+    license = lib.licenses.asl20;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/skills-frontend-design/hashes.json
+++ b/.flox/pkgs/skills-frontend-design/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "unstable-2026-05-06.d211d43",
+  "rev": "d211d437443a7b2496a3dad9575e7dddd724c585",
+  "srcHash": "sha256-5NGI0gojBGoXXus8CPhIrigyWSEYJg8gnCzWYl6PsLA="
+}

--- a/.flox/pkgs/skills-frontend-design/publish.json
+++ b/.flox/pkgs/skills-frontend-design/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/skills-frontend-design/upgrade.sh
+++ b/.flox/pkgs/skills-frontend-design/upgrade.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="anthropics"
+REPO="skills"
+BRANCH="main"
+
+current_version=$(jq -r '.version // ""' "$HASHES_FILE")
+
+# Resolve current HEAD on main to a full SHA.
+rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/heads/$BRANCH" | awk '{print $1}')
+
+if [ -z "$rev" ]; then
+  echo "Failed to resolve $BRANCH on $OWNER/$REPO" >&2
+  exit 1
+fi
+
+short_sha="${rev:0:7}"
+
+# Committer date (YYYY-MM-DD) via the GitHub commits API.
+commit_json=$(curl -sfL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
+commit_date=$(echo "$commit_json" \
+  | jq -r '.commit.committer.date' \
+  | cut -c1-10)
+
+# Upstream SKILL.md has no frontmatter `version:` field — version
+# the package solely on the upstream commit date + short SHA.
+new_version="unstable-${commit_date}.${short_sha}"
+
+echo "Current: $current_version"
+echo "Latest:  $new_version"
+
+if [ "$current_version" = "$new_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating skills-frontend-design to $new_version"
+
+# Prefetch the source tarball and compute SRI hash.
+sha256_base32=$(nix-prefetch-url --unpack \
+  "https://github.com/$OWNER/$REPO/archive/$rev.tar.gz")
+sri_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$sha256_base32")
+
+jq -n \
+  --arg v "$new_version" \
+  --arg r "$rev" \
+  --arg h "$sri_hash" \
+  '{version: $v, rev: $r, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Wrote $HASHES_FILE:"
+cat "$HASHES_FILE"


### PR DESCRIPTION
## Summary

- Adds `.flox/pkgs/skills-frontend-design/` packaging the
  [frontend-design](https://github.com/anthropics/skills/tree/main/skills/frontend-design)
  Claude Code skill.
- Installs to both `share/claude-code/skills/frontend-design/` and
  `share/opencode/skills/frontend-design/` (matches the dual-harness
  layout from #1687).
- Sourced from `anthropics/skills` (Apache-2.0), not the
  `anthropics/claude-code` copy of the same skill (which ships under
  proprietary "All rights reserved" Commercial ToS).
- `upgrade.sh` tracks `main` HEAD; version string format
  `unstable-<YYYY-MM-DD>.<short-sha>` (upstream `SKILL.md` has no
  frontmatter `version:` field, so the
  `<frontmatter-version>+unstable-...` format from #1687 doesn't apply).
- No CI changes — `ci_pkgs.yml` and `upgrade_pkgs.yml`
  auto-discover the new package.

## Test plan

- [x] `flox build skills-frontend-design` succeeds locally on aarch64-darwin
- [x] Both `share/claude-code/skills/frontend-design/SKILL.md` and
      `share/opencode/skills/frontend-design/SKILL.md` exist in the build output
- [x] `upgrade.sh` is idempotent on an up-to-date `hashes.json`
- [x] `upgrade.sh` detects a manually-rewound `rev` and converges
- [x] CI green on this PR