### PR TITLE
fix(codex): fail-fast in upgrade.sh when cargoHash unavailable

### DIFF
--- a/.flox/pkgs/codex/upgrade.sh
+++ b/.flox/pkgs/codex/upgrade.sh
@@ -41,12 +41,20 @@ git clone --depth 1 --branch "rust-v${latest_version}" \
   https://github.com/openai/codex.git "$workdir/codex"
 
 cargo_hash=$(
-  nix run nixpkgs#nix-prefetch -- \
-    fetchCargoVendor \
-    --src "$workdir/codex" \
-    --source-root "source/codex-rs" 2>/dev/null \
-  || echo "MANUAL_UPDATE_NEEDED"
+  nix --extra-experimental-features "nix-command flakes" \
+    run nixpkgs#nix-prefetch -- \
+      fetchCargoVendor \
+      --src "$workdir/codex" \
+      --source-root "source/codex-rs" \
+      --option extra-experimental-features "nix-command flakes"
 )
+
+if [[ "$cargo_hash" != sha256-* ]]; then
+  echo "ERROR: cargoHash computation produced unexpected output:" >&2
+  echo "       '$cargo_hash'" >&2
+  echo "       refusing to write a broken hashes.json" >&2
+  exit 1
+fi
 echo "  cargoHash: $cargo_hash"
 
 # Read current v8 and livekit values (these change less often)


### PR DESCRIPTION
## Summary

Stops the codex upgrade workflow from opening unbuildable PRs (most recently #1713) when `nix-prefetch fetchCargoVendor` fails.

## Background

`.flox/pkgs/codex/upgrade.sh` had a silent fallback that wrote the literal string `MANUAL_UPDATE_NEEDED` into `hashes.json` whenever the cargoHash computation failed:

\`\`\`bash
cargo_hash=$(
  nix run nixpkgs#nix-prefetch -- fetchCargoVendor \
    --src "\$workdir/codex" \
    --source-root "source/codex-rs" 2>/dev/null \
  || echo "MANUAL_UPDATE_NEEDED"
)
\`\`\`

The CI workflow then committed that junk and opened a PR that could not be evaluated by Nix:

\`\`\`
error: hash 'MANUAL_UPDATE_NEEDED' does not include a type, nor is the type otherwise known from context
\`\`\`

This has happened **three times** so far:

| Tag bump | Result |
| -------- | ------ |
| 0.121.0 → 0.123.0-alpha.6 | fixed in `02cd3a8` (prerelease filter) |
| 0.122.0 → 0.123.0 | reverted in `f8e639e` (crates.io 403s) |
| 0.128.0 → 0.129.0 | currently broken in #1713 |

Commit `8d8af5d` (the previous manual fix) noted the underlying cause: *"likely missing flakes experimental feature in CI"*. The current change addresses that.

## Changes

- Drop `2>/dev/null` so the actual nix-prefetch error appears in workflow logs.
- Drop the `|| echo "MANUAL_UPDATE_NEEDED"` fallback so the script fails loudly.
- Pass `extra-experimental-features=nix-command,flakes` to both the outer `nix run` and the inner `nix-prefetch` evaluator. Without the inner `--option`, nix-prefetch's `prelude.nix` aborts with "experimental Nix feature 'flakes' is disabled".
- Validate that the result starts with `sha256-` before writing `hashes.json` and exit non-zero otherwise. `set -euo pipefail` does not catch a failed command substitution, so the explicit guard is required.

## Test plan

- [ ] Trigger the `Upgrade Packages` workflow with `package=codex` and confirm the job either produces a real `sha256-...` cargoHash or fails the workflow step (no broken PR opened).
- [ ] Verify the existing `eval.json` build step succeeds against the regenerated hashes.

## Follow-up

PR #1713 still needs its `cargoHash` replaced with a real value before it can merge — either by re-running the upgrade workflow after this lands, or by manually computing it the way `8d8af5d` did for 0.128.0.