### PR TITLE
ci: floxbot merges via bypass, skipping auto-merge review wait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,13 +473,10 @@ jobs:
     name: "Auto Merge"
     runs-on: "ubuntu-latest"
     timeout-minutes: 5
-    needs: ["wait-for-environments", "wait-for-packages"]
+    needs: ["wait-for-environments", "wait-for-packages", "result"]
     if: >-
       github.event_name == 'pull_request'
-      && needs.wait-for-environments.result == 'success'
-      && needs.wait-for-packages.result == 'success'
-      && needs.wait-for-environments.outputs.any_failed == 'false'
-      && needs.wait-for-packages.outputs.any_failed == 'false'
+      && needs.result.result == 'success'
       && needs.wait-for-environments.outputs.pr_author == 'floxbot'
       && (needs.wait-for-environments.outputs.total_workflows != '0'
       || needs.wait-for-packages.outputs.total_workflows != '0')
@@ -492,7 +489,7 @@ jobs:
           GITHUB_TOKEN: >-
             ${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}
         run: |
-          gh pr merge --auto --merge "$PR_NUMBER" \
+          gh pr merge --rebase "$PR_NUMBER" \
             --repo "${{ github.repository }}"
 
   report-failure:


### PR DESCRIPTION
## Summary

Floxbot PRs sit for hours waiting for human review even though branch protection grants floxbot bypass. The current `auto-merge` job calls `gh pr merge --auto`, and GitHub's auto-merge feature waits for **all** branch protection rules — it does not honor the bypass list. The bypass only kicks in on a **direct** merge.

This PR changes `auto-merge` to:

- `needs:` the `result` (Summary) job, so we know all required checks passed before attempting the merge.
- Use `gh pr merge --rebase` (no `--auto`). With floxbot's token, the bypass merges immediately without waiting for review.
- Drop the explicit any_failed / result checks on the wait jobs — they're already covered by `result.result == 'success'`.
- Use `--rebase` (the only allowed merge method per repo settings; was incorrectly `--merge` before, which probably worked by luck because `--auto` defers method selection).

## Why not auto-approve via github-actions bot?

That approach was tried twice (PRs #1503, #1647) and reverted both times. It also requires enabling `Settings > Actions > General > Allow GitHub Actions to create and approve pull requests` (currently off). Direct merge with bypass is one moving part instead of two.

## Test plan

- [ ] After merge, observe a floxbot upgrade PR auto-merge within a few minutes of CI completing
- [ ] Open a non-floxbot PR — `Auto Merge` job stays `skipping`, manual review is still required