### PR TITLE
ci: floxbot auto-merge via approver App

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,24 @@ jobs:
       || needs.wait-for-packages.outputs.total_workflows != '0')
 
     steps:
+      - name: "Mint approver App token"
+        id: "approver_token"
+        uses: "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349" # v2.2.2
+        with:
+          app-id: "${{ secrets.MANAGED_FLOXENVS_APPROVER_APP_ID }}"
+          private-key: "${{ secrets.MANAGED_FLOXENVS_APPROVER_PRIVATE_KEY }}"
+
+      - name: "Approve PR"
+        env:
+          PR_NUMBER: >-
+            ${{ needs.wait-for-environments.outputs.pr_number }}
+          GITHUB_TOKEN: "${{ steps.approver_token.outputs.token }}"
+        run: |
+          gh pr review "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --approve \
+            --body "Approved by automated approver: all required CI checks are green for floxbot PR."
+
       - name: "Merge PR"
         env:
           PR_NUMBER: >-
@@ -489,7 +507,7 @@ jobs:
           GITHUB_TOKEN: >-
             ${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}
         run: |
-          gh pr merge --rebase "$PR_NUMBER" \
+          gh pr merge --auto --merge "$PR_NUMBER" \
             --repo "${{ github.repository }}"
 
   report-failure:


### PR DESCRIPTION
## Summary

Floxbot PRs sit waiting for human review because the merge queue
on `main` waits for **all** branch protection rules to be
*satisfied* (not bypassed), and floxbot can't approve its own PR.
The org-level "Allow Actions to create and approve pull requests"
setting is off, so `github-actions[bot]` can't approve either.

This PR adds two steps to the `auto-merge` job:

1. **Mint approver App token** — uses `actions/create-github-app-token@v2.2.2` to mint an installation token from the new `floxbot-pr-approver` GitHub App (flox org).
2. **Approve PR** — calls `gh pr review --approve` with that token. App approvals are a distinct principal from `github-actions[bot]` and are not subject to the org-level Actions-approve setting.

The Merge PR step is unchanged except `--rebase` → `--auto --merge`. The merge queue rejects explicit strategy flags; auto-merge defers to the queue's configured method.

## Why a custom App and not `${{ github.token }}`?

The org disables Actions approval. A custom App's installation token is a separate identity. This is the documented Renovate pattern (`renovate-approve-bot`), recommended by the Renovate maintainer in [renovatebot/renovate#28156](https://github.com/renovatebot/renovate/discussions/28156) for exactly this scenario.

## Dependencies

- App registered in flox org as `floxbot-pr-approver` (App ID 3673484)
- Installed on `flox/floxenvs` only
- Permissions: `pull_requests: write`, `contents: read`, `metadata: read`
- Secrets synced via [flox/deltaops#685](https://github.com/flox/deltaops/pull/685):
  - `MANAGED_FLOXENVS_APPROVER_APP_ID`
  - `MANAGED_FLOXENVS_APPROVER_PRIVATE_KEY`

## Test plan

- [ ] **On this PR (opened by @garbas):** `Auto Merge` job is **skipped** (`pr_author == 'floxbot'` guard). No rogue approval submitted by the App.
- [ ] **After merge:** wait for next scheduled floxbot PR (`upgrade_pkgs.yml` runs every 6h). Confirm:
  - App submits an approving review (visible in PR reviews)
  - PR enters merge queue automatically
  - PR merges without any human action
- [ ] **Negative path:** if a floxbot PR has a failing CI, Summary fails → Auto Merge's `result.result == 'success'` guard fails → no rogue approval, no merge.

## Rollback

Single revert commit restores the previous `--rebase` behavior. Without this workflow, the App is dormant. Optionally uninstall the App from the repo afterward.