### PR TITLE
feat(huggingface): add huggingface-hub package + env + demo

### DIFF
--- a/.flox/pkgs/huggingface-hub/default.nix
+++ b/.flox/pkgs/huggingface-hub/default.nix
@@ -1,0 +1,20 @@
+{
+  lib,
+  fetchFromGitHub,
+  python3Packages,
+}:
+
+let
+  data = builtins.fromJSON (builtins.readFile ./hashes.json);
+in
+python3Packages.toPythonApplication (
+  python3Packages.huggingface-hub.overridePythonAttrs (old: {
+    version = data.version;
+    src = fetchFromGitHub {
+      owner = "huggingface";
+      repo = "huggingface_hub";
+      tag = "v${data.version}";
+      hash = data.srcHash;
+    };
+  })
+)

--- a/.flox/pkgs/huggingface-hub/hashes.json
+++ b/.flox/pkgs/huggingface-hub/hashes.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.14.0",
+  "srcHash": "sha256-WfPBz0vcKSjg1hS90b/O1xpAJeArhEV02/gdduGvqFA="
+}

--- a/.flox/pkgs/huggingface-hub/publish.json
+++ b/.flox/pkgs/huggingface-hub/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/huggingface-hub/upgrade.sh
+++ b/.flox/pkgs/huggingface-hub/upgrade.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="huggingface"
+REPO="huggingface_hub"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+
+# Latest stable (non-prerelease, non-draft) release tag.
+# Releases are tagged `v<x.y.z>`; strip the leading `v`.
+latest_version=$(
+  curl -sfL \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/$OWNER/$REPO/releases/latest" \
+  | jq -r '.tag_name' \
+  | sed 's/^v//'
+)
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating $REPO from $current_version to $latest_version"
+
+# Prefetch source from GitHub. Matches what `fetchFromGitHub`
+# produces: GitHub's archive tarball, unpacked and hashed.
+src_url="https://github.com/$OWNER/$REPO/archive/refs/tags/v${latest_version}.tar.gz"
+src_raw=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$src_raw")
+
+echo "  srcHash: $src_hash"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg h "$src_hash" \
+  '{version: $v, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.github/workflows/ci_huggingface.yml
+++ b/.github/workflows/ci_huggingface.yml
@@ -1,0 +1,38 @@
+name: "CI: huggingface"
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "huggingface/**"
+      - "huggingface-demo/**"
+      - ".flox/pkgs/huggingface-hub/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "scripts/**"
+      - ".github/workflows/environment.yml"
+      - ".github/workflows/ci_huggingface.yml"
+  pull_request:
+    paths:
+      - "huggingface/**"
+      - "huggingface-demo/**"
+      - ".flox/pkgs/huggingface-hub/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "scripts/**"
+      - ".github/workflows/environment.yml"
+      - ".github/workflows/ci_huggingface.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: "read"
+  packages: "write"
+  attestations: "write"
+  id-token: "write"
+
+jobs:
+  run:
+    uses: "./.github/workflows/environment.yml"
+    with:
+      environment: "huggingface"
+    secrets: inherit

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -58,8 +58,6 @@ jobs:
             echo ""
             git diff --stat -- "*/manifest.lock"
             echo ""
-            git diff -- "*/manifest.lock"
-            echo ""
             echo "Run 'flox edit -f' on the env and"
             echo "'flox include upgrade' on the demo,"
             echo "then commit the updated lockfiles."

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -58,6 +58,8 @@ jobs:
             echo ""
             git diff --stat -- "*/manifest.lock"
             echo ""
+            git diff -- "*/manifest.lock"
+            echo ""
             echo "Run 'flox edit -f' on the env and"
             echo "'flox include upgrade' on the demo,"
             echo "then commit the updated lockfiles."

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Most environments follow a dual-layer pattern:
 
 | Environment | Description | Links |
 | ----------- | ----------- | ----- |
+| huggingface | Hugging Face Hub CLI | [floxhub](https://hub.flox.dev/flox/huggingface) · [docs](huggingface/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/huggingface-latest) |
+| _└ huggingface-demo_ | | [floxhub](https://hub.flox.dev/flox/huggingface-demo) · [docs](huggingface-demo/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/huggingface-demo-latest) |
 | langchain | LangChain + Ollama | [floxhub](https://hub.flox.dev/flox/langchain) · [docs](langchain/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/langchain-latest) |
 | _└ langchain-demo_ | | [floxhub](https://hub.flox.dev/flox/langchain-demo) · [docs](langchain-demo/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/langchain-demo-latest) |
 | verba | Verba RAG app | [floxhub](https://hub.flox.dev/flox/verba) · [docs](verba/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/verba-latest) |

--- a/huggingface-demo/.flox/.gitignore
+++ b/huggingface-demo/.flox/.gitignore
@@ -1,0 +1,4 @@
+run/
+cache/
+lib/
+log/

--- a/huggingface-demo/.flox/env.json
+++ b/huggingface-demo/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "huggingface-demo",
+  "version": 1
+}

--- a/huggingface-demo/.flox/env/manifest.lock
+++ b/huggingface-demo/.flox/env/manifest.lock
@@ -154,7 +154,7 @@
       "rev": "f3d8d611bb1904a2920115fab32734956b694479",
       "rev_count": 3160,
       "rev_date": "2026-05-11T07:17:09Z",
-      "scrape_date": "2026-05-11T10:25:31.942122Z",
+      "scrape_date": "2026-05-11T10:31:51.960818Z",
       "stabilities": [
         "unstable"
       ],
@@ -184,7 +184,7 @@
       "rev": "f3d8d611bb1904a2920115fab32734956b694479",
       "rev_count": 3160,
       "rev_date": "2026-05-11T07:17:09Z",
-      "scrape_date": "2026-05-11T10:25:31.942124Z",
+      "scrape_date": "2026-05-11T10:31:51.960820Z",
       "stabilities": [
         "unstable"
       ],
@@ -214,7 +214,7 @@
       "rev": "f3d8d611bb1904a2920115fab32734956b694479",
       "rev_count": 3160,
       "rev_date": "2026-05-11T07:17:09Z",
-      "scrape_date": "2026-05-11T10:25:31.942125Z",
+      "scrape_date": "2026-05-11T10:31:51.960821Z",
       "stabilities": [
         "unstable"
       ],
@@ -244,7 +244,7 @@
       "rev": "f3d8d611bb1904a2920115fab32734956b694479",
       "rev_count": 3160,
       "rev_date": "2026-05-11T07:17:09Z",
-      "scrape_date": "2026-05-11T10:25:31.942126Z",
+      "scrape_date": "2026-05-11T10:31:51.960822Z",
       "stabilities": [
         "unstable"
       ],

--- a/huggingface-demo/.flox/env/manifest.lock
+++ b/huggingface-demo/.flox/env/manifest.lock
@@ -1,0 +1,312 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "schema-version": "1.10.0",
+    "install": {
+      "gum": {
+        "pkg-path": "gum",
+        "pkg-group": "demo-tools"
+      },
+      "huggingface-hub": {
+        "pkg-path": "flox/huggingface-hub",
+        "pkg-group": "huggingface"
+      }
+    },
+    "vars": {
+      "HF_HOME": ""
+    },
+    "hook": {
+      "on-activate": "HF_HOME=\"$FLOX_ENV_CACHE/huggingface\"\nexport HF_HOME\nmkdir -p \"$HF_HOME\"\n\nif [[ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]]; then\n  gum style --border double --margin '1 2' \\\n    --padding '1 4' \\\n    'Hugging Face Hub CLI' '' \\\n    'Authenticate (optional):' \\\n    '  hf auth login' '' \\\n    'Download a file:' \\\n    '  hf download <repo_id> <filename>' '' \\\n    'Inspect the cache:' \\\n    \"  hf cache scan\" '' \\\n    \"Cache root: $HF_HOME\"\nfi\n"
+    },
+    "options": {}
+  },
+  "packages": [
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/3if65h5mjjgjwgvd18srmm35cn3w6xs8-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=549bd84d6279f9852cae6225e372cc67fb91a4c1",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+      "rev_count": 992384,
+      "rev_date": "2026-05-05T04:14:16Z",
+      "scrape_date": "2026-05-06T08:07:16.869646Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ba53aq5kpjm2qb817qgxswy2hvnkxnyj-gum-0.17.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/ka558hvp8n0vhw8lzwsw66zw3g3lavzd-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=549bd84d6279f9852cae6225e372cc67fb91a4c1",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+      "rev_count": 992384,
+      "rev_date": "2026-05-05T04:14:16Z",
+      "scrape_date": "2026-05-06T08:43:47.052239Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/3hlyv3x7jjn5364f08jw0bic3zddqhxc-gum-0.17.0"
+      },
+      "system": "aarch64-linux",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/z2rm91h36jx1ym7gpl3avxqqxc407pn2-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=549bd84d6279f9852cae6225e372cc67fb91a4c1",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+      "rev_count": 992384,
+      "rev_date": "2026-05-05T04:14:16Z",
+      "scrape_date": "2026-05-06T09:16:10.806200Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/qkwxvmldb9a8nmqq6aqqd47gj3pxwx42-gum-0.17.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/835d9xq5q9w2hv6dzlsc3yjbh44kmpjn-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=549bd84d6279f9852cae6225e372cc67fb91a4c1",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+      "rev_count": 992384,
+      "rev_date": "2026-05-05T04:14:16Z",
+      "scrape_date": "2026-05-06T09:52:25.957928Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/c149nbx8xh8knvply95623gnwqds19xr-gum-0.17.0"
+      },
+      "system": "x86_64-linux",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "huggingface-hub",
+      "broken": false,
+      "derivation": "/nix/store/hfa9cjq3m5glxpfw9kwxs6bsydipx6ks-python3.13-huggingface-hub-1.14.0.drv",
+      "description": "Download and publish models and other files on the huggingface.co hub",
+      "install_id": "huggingface-hub",
+      "license": "Apache-2.0",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=f3d8d611bb1904a2920115fab32734956b694479",
+      "name": "huggingface-hub-1.14.0",
+      "pname": "huggingface-hub",
+      "rev": "f3d8d611bb1904a2920115fab32734956b694479",
+      "rev_count": 3160,
+      "rev_date": "2026-05-11T07:17:09Z",
+      "scrape_date": "2026-05-11T07:25:10.789932Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.14.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dist": "/nix/store/889ccibnav97bc90iqaxiazpfbc9p4nl-python3.13-huggingface-hub-1.14.0-dist",
+        "out": "/nix/store/wm6az2xfdvrmn1clgd49hma4gvrmqj3p-python3.13-huggingface-hub-1.14.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "huggingface",
+      "priority": 5
+    },
+    {
+      "attr_path": "huggingface-hub",
+      "broken": false,
+      "derivation": "/nix/store/yvkvq4nr78zqc1ajkxb2sr1lhhgdz7fc-python3.13-huggingface-hub-1.14.0.drv",
+      "description": "Download and publish models and other files on the huggingface.co hub",
+      "install_id": "huggingface-hub",
+      "license": "Apache-2.0",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=f3d8d611bb1904a2920115fab32734956b694479",
+      "name": "huggingface-hub-1.14.0",
+      "pname": "huggingface-hub",
+      "rev": "f3d8d611bb1904a2920115fab32734956b694479",
+      "rev_count": 3160,
+      "rev_date": "2026-05-11T07:17:09Z",
+      "scrape_date": "2026-05-11T07:25:10.789939Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.14.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dist": "/nix/store/s6sn7wg200sfpp56b6zbzybyw2q3c1wm-python3.13-huggingface-hub-1.14.0-dist",
+        "out": "/nix/store/flw42jd9xn5qq9mrfabia7jd306ja9nj-python3.13-huggingface-hub-1.14.0"
+      },
+      "system": "aarch64-linux",
+      "group": "huggingface",
+      "priority": 5
+    },
+    {
+      "attr_path": "huggingface-hub",
+      "broken": false,
+      "derivation": "/nix/store/6yawkc0wnckkfr83mjaq6xyiwi56s63g-python3.13-huggingface-hub-1.14.0.drv",
+      "description": "Download and publish models and other files on the huggingface.co hub",
+      "install_id": "huggingface-hub",
+      "license": "Apache-2.0",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=f3d8d611bb1904a2920115fab32734956b694479",
+      "name": "huggingface-hub-1.14.0",
+      "pname": "huggingface-hub",
+      "rev": "f3d8d611bb1904a2920115fab32734956b694479",
+      "rev_count": 3160,
+      "rev_date": "2026-05-11T07:17:09Z",
+      "scrape_date": "2026-05-11T07:25:10.789939Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.14.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dist": "/nix/store/mn2d3v4njps3ld1awmiaz2bvqjaba0rx-python3.13-huggingface-hub-1.14.0-dist",
+        "out": "/nix/store/730x54lhv8b02hp163ky2l2zhq6hgkgs-python3.13-huggingface-hub-1.14.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "huggingface",
+      "priority": 5
+    },
+    {
+      "attr_path": "huggingface-hub",
+      "broken": false,
+      "derivation": "/nix/store/17xfmz5c7dg01v1y8yqswhyxvj71jw2q-python3.13-huggingface-hub-1.14.0.drv",
+      "description": "Download and publish models and other files on the huggingface.co hub",
+      "install_id": "huggingface-hub",
+      "license": "Apache-2.0",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=f3d8d611bb1904a2920115fab32734956b694479",
+      "name": "huggingface-hub-1.14.0",
+      "pname": "huggingface-hub",
+      "rev": "f3d8d611bb1904a2920115fab32734956b694479",
+      "rev_count": 3160,
+      "rev_date": "2026-05-11T07:17:09Z",
+      "scrape_date": "2026-05-11T07:25:10.789940Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.14.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dist": "/nix/store/vh6qh7y1i14hx78kik6ih6g6926zwlvv-python3.13-huggingface-hub-1.14.0-dist",
+        "out": "/nix/store/hw1cbiv9nrcm9vfgc1g67b2pafajggri-python3.13-huggingface-hub-1.14.0"
+      },
+      "system": "x86_64-linux",
+      "group": "huggingface",
+      "priority": 5
+    }
+  ],
+  "compose": {
+    "composer": {
+      "schema-version": "1.10.0",
+      "install": {
+        "gum": {
+          "pkg-path": "gum",
+          "pkg-group": "demo-tools"
+        }
+      },
+      "hook": {
+        "on-activate": "if [[ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]]; then\n  gum style --border double --margin '1 2' \\\n    --padding '1 4' \\\n    'Hugging Face Hub CLI' '' \\\n    'Authenticate (optional):' \\\n    '  hf auth login' '' \\\n    'Download a file:' \\\n    '  hf download <repo_id> <filename>' '' \\\n    'Inspect the cache:' \\\n    \"  hf cache scan\" '' \\\n    \"Cache root: $HF_HOME\"\nfi\n"
+      },
+      "options": {},
+      "include": {
+        "environments": [
+          {
+            "dir": "../huggingface"
+          }
+        ]
+      }
+    },
+    "include": [
+      {
+        "manifest": {
+          "schema-version": "1.10.0",
+          "install": {
+            "huggingface-hub": {
+              "pkg-path": "flox/huggingface-hub",
+              "pkg-group": "huggingface"
+            }
+          },
+          "vars": {
+            "HF_HOME": ""
+          },
+          "hook": {
+            "on-activate": "HF_HOME=\"$FLOX_ENV_CACHE/huggingface\"\nexport HF_HOME\nmkdir -p \"$HF_HOME\"\n"
+          },
+          "options": {}
+        },
+        "name": "huggingface",
+        "descriptor": {
+          "dir": "../huggingface"
+        }
+      }
+    ],
+    "warnings": []
+  }
+}

--- a/huggingface-demo/.flox/env/manifest.lock
+++ b/huggingface-demo/.flox/env/manifest.lock
@@ -16,7 +16,7 @@
       "HF_HOME": ""
     },
     "hook": {
-      "on-activate": "HF_HOME=\"$FLOX_ENV_CACHE/huggingface\"\nexport HF_HOME\nmkdir -p \"$HF_HOME\"\n\nif [[ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]]; then\n  gum style --border double --margin '1 2' \\\n    --padding '1 4' \\\n    'Hugging Face Hub CLI' '' \\\n    'Authenticate (optional):' \\\n    '  hf auth login' '' \\\n    'Download a file:' \\\n    '  hf download <repo_id> <filename>' '' \\\n    'Inspect the cache:' \\\n    \"  hf cache scan\" '' \\\n    \"Cache root: $HF_HOME\"\nfi\n"
+      "on-activate": "HF_HOME=\"$FLOX_ENV_CACHE/huggingface\"\nexport HF_HOME\nmkdir -p \"$HF_HOME\"\n\nif [[ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]]; then\n  if [[ \"${HF_XET_HIGH_PERFORMANCE:-0}\" == \"1\" ]]; then\n    perf_line=\"High-perf mode: ON (HF_XET_HIGH_PERFORMANCE=1)\"\n  else\n    perf_line=\"Faster transfers: export HF_XET_HIGH_PERFORMANCE=1\"\n  fi\n  gum style --border double --margin '1 2' \\\n    --padding '1 4' \\\n    'Hugging Face Hub CLI' '' \\\n    'Authenticate (optional):' \\\n    '  hf auth login' \\\n    '  https://huggingface.co/settings/tokens' '' \\\n    'Download a file:' \\\n    '  hf download <repo_id> <filename>' '' \\\n    'Inspect the cache:' \\\n    '  hf cache scan' '' \\\n    \"Cache root: $HF_HOME\" \\\n    \"$perf_line\"\nfi\n"
     },
     "options": {}
   },
@@ -272,7 +272,7 @@
         }
       },
       "hook": {
-        "on-activate": "if [[ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]]; then\n  gum style --border double --margin '1 2' \\\n    --padding '1 4' \\\n    'Hugging Face Hub CLI' '' \\\n    'Authenticate (optional):' \\\n    '  hf auth login' '' \\\n    'Download a file:' \\\n    '  hf download <repo_id> <filename>' '' \\\n    'Inspect the cache:' \\\n    \"  hf cache scan\" '' \\\n    \"Cache root: $HF_HOME\"\nfi\n"
+        "on-activate": "if [[ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]]; then\n  if [[ \"${HF_XET_HIGH_PERFORMANCE:-0}\" == \"1\" ]]; then\n    perf_line=\"High-perf mode: ON (HF_XET_HIGH_PERFORMANCE=1)\"\n  else\n    perf_line=\"Faster transfers: export HF_XET_HIGH_PERFORMANCE=1\"\n  fi\n  gum style --border double --margin '1 2' \\\n    --padding '1 4' \\\n    'Hugging Face Hub CLI' '' \\\n    'Authenticate (optional):' \\\n    '  hf auth login' \\\n    '  https://huggingface.co/settings/tokens' '' \\\n    'Download a file:' \\\n    '  hf download <repo_id> <filename>' '' \\\n    'Inspect the cache:' \\\n    '  hf cache scan' '' \\\n    \"Cache root: $HF_HOME\" \\\n    \"$perf_line\"\nfi\n"
       },
       "options": {},
       "include": {

--- a/huggingface-demo/.flox/env/manifest.lock
+++ b/huggingface-demo/.flox/env/manifest.lock
@@ -1,7 +1,7 @@
 {
   "lockfile-version": 1,
   "manifest": {
-    "schema-version": "1.10.0",
+    "schema-version": "1.11.0",
     "install": {
       "gum": {
         "pkg-path": "gum",
@@ -264,7 +264,7 @@
   ],
   "compose": {
     "composer": {
-      "schema-version": "1.10.0",
+      "schema-version": "1.11.0",
       "install": {
         "gum": {
           "pkg-path": "gum",
@@ -286,7 +286,7 @@
     "include": [
       {
         "manifest": {
-          "schema-version": "1.10.0",
+          "schema-version": "1.11.0",
           "install": {
             "huggingface-hub": {
               "pkg-path": "flox/huggingface-hub",

--- a/huggingface-demo/.flox/env/manifest.lock
+++ b/huggingface-demo/.flox/env/manifest.lock
@@ -154,7 +154,7 @@
       "rev": "f3d8d611bb1904a2920115fab32734956b694479",
       "rev_count": 3160,
       "rev_date": "2026-05-11T07:17:09Z",
-      "scrape_date": "2026-05-11T07:25:10.789932Z",
+      "scrape_date": "2026-05-11T10:25:31.942122Z",
       "stabilities": [
         "unstable"
       ],
@@ -184,7 +184,7 @@
       "rev": "f3d8d611bb1904a2920115fab32734956b694479",
       "rev_count": 3160,
       "rev_date": "2026-05-11T07:17:09Z",
-      "scrape_date": "2026-05-11T07:25:10.789939Z",
+      "scrape_date": "2026-05-11T10:25:31.942124Z",
       "stabilities": [
         "unstable"
       ],
@@ -214,7 +214,7 @@
       "rev": "f3d8d611bb1904a2920115fab32734956b694479",
       "rev_count": 3160,
       "rev_date": "2026-05-11T07:17:09Z",
-      "scrape_date": "2026-05-11T07:25:10.789939Z",
+      "scrape_date": "2026-05-11T10:25:31.942125Z",
       "stabilities": [
         "unstable"
       ],
@@ -244,7 +244,7 @@
       "rev": "f3d8d611bb1904a2920115fab32734956b694479",
       "rev_count": 3160,
       "rev_date": "2026-05-11T07:17:09Z",
-      "scrape_date": "2026-05-11T07:25:10.789940Z",
+      "scrape_date": "2026-05-11T10:25:31.942126Z",
       "stabilities": [
         "unstable"
       ],

--- a/huggingface-demo/.flox/env/manifest.toml
+++ b/huggingface-demo/.flox/env/manifest.toml
@@ -1,0 +1,28 @@
+schema-version = "1.10.0"
+
+[include]
+environments = [
+  { dir = "../huggingface" }
+]
+
+# gum is a demo-only tool for styled terminal output.
+
+[install]
+gum.pkg-path = "gum"
+gum.pkg-group = "demo-tools"
+
+[hook]
+on-activate = '''
+if [[ "${FLOX_ENVS_TESTING:-}" != "1" ]]; then
+  gum style --border double --margin '1 2' \
+    --padding '1 4' \
+    'Hugging Face Hub CLI' '' \
+    'Authenticate (optional):' \
+    '  hf auth login' '' \
+    'Download a file:' \
+    '  hf download <repo_id> <filename>' '' \
+    'Inspect the cache:' \
+    "  hf cache scan" '' \
+    "Cache root: $HF_HOME"
+fi
+'''

--- a/huggingface-demo/.flox/env/manifest.toml
+++ b/huggingface-demo/.flox/env/manifest.toml
@@ -14,15 +14,22 @@ gum.pkg-group = "demo-tools"
 [hook]
 on-activate = '''
 if [[ "${FLOX_ENVS_TESTING:-}" != "1" ]]; then
+  if [[ "${HF_XET_HIGH_PERFORMANCE:-0}" == "1" ]]; then
+    perf_line="High-perf mode: ON (HF_XET_HIGH_PERFORMANCE=1)"
+  else
+    perf_line="Faster transfers: export HF_XET_HIGH_PERFORMANCE=1"
+  fi
   gum style --border double --margin '1 2' \
     --padding '1 4' \
     'Hugging Face Hub CLI' '' \
     'Authenticate (optional):' \
-    '  hf auth login' '' \
+    '  hf auth login' \
+    '  https://huggingface.co/settings/tokens' '' \
     'Download a file:' \
     '  hf download <repo_id> <filename>' '' \
     'Inspect the cache:' \
-    "  hf cache scan" '' \
-    "Cache root: $HF_HOME"
+    '  hf cache scan' '' \
+    "Cache root: $HF_HOME" \
+    "$perf_line"
 fi
 '''

--- a/huggingface-demo/.flox/env/manifest.toml
+++ b/huggingface-demo/.flox/env/manifest.toml
@@ -1,4 +1,4 @@
-schema-version = "1.10.0"
+schema-version = "1.11.0"
 
 [include]
 environments = [

--- a/huggingface-demo/README.md
+++ b/huggingface-demo/README.md
@@ -47,6 +47,21 @@ hf cache scan
 hf upload <your-username>/<repo> ./path/to/file
 ```
 
+### 5. Crank up transfer speed (opt-in)
+
+`hf-xet` already accelerates every download by default.
+For multi-GB models, saturate bandwidth and CPU cores:
+
+```bash
+export HF_XET_HIGH_PERFORMANCE=1
+hf download meta-llama/Llama-3.2-1B-Instruct
+```
+
+The activation banner reflects whether high-perf mode
+is on. The legacy `HF_HUB_ENABLE_HF_TRANSFER` flag is
+deprecated and no longer functional in `huggingface_hub`
+v1.x — `hf-xet` replaced it.
+
 ## What is included
 
 | Package | Description |

--- a/huggingface-demo/README.md
+++ b/huggingface-demo/README.md
@@ -1,0 +1,63 @@
+# huggingface-demo
+
+Interactive demo for the
+[Hugging Face Hub](https://huggingface.co/) CLI. Adds
+[`gum`](https://github.com/charmbracelet/gum) on top of
+the minimal [huggingface](../huggingface/) environment so
+the activation hook prints a styled cheat sheet.
+
+## Quick start
+
+```bash
+flox activate -r flox/huggingface-demo
+```
+
+## Walkthrough
+
+### 1. Authenticate (optional, only needed for private
+repos or higher rate limits)
+
+```bash
+hf auth login
+```
+
+You will be prompted for a token from
+<https://huggingface.co/settings/tokens>.
+
+### 2. Download a public file
+
+```bash
+hf download hf-internal-testing/tiny-random-gpt2 \
+  config.json
+```
+
+Files land under `$HF_HOME` (defaults to
+`$FLOX_ENV_CACHE/huggingface` inside this environment),
+keyed by repo and revision.
+
+### 3. Inspect the cache
+
+```bash
+hf cache scan
+```
+
+### 4. Upload a file (requires authentication)
+
+```bash
+hf upload <your-username>/<repo> ./path/to/file
+```
+
+## What is included
+
+| Package | Description |
+| ------- | ----------- |
+| `hf` | Main Hugging Face Hub CLI |
+| `huggingface-cli` | Legacy alias kept for compatibility |
+| `tiny-agents` | Minimal agent runtime |
+| `gum` | Styled terminal UI (demo only) |
+
+## See also
+
+- [huggingface](../huggingface/) — minimal layer for
+  `[include]` composition
+- [Hub docs](https://huggingface.co/docs/huggingface_hub)

--- a/huggingface-demo/test.sh
+++ b/huggingface-demo/test.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+command_exists() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' command not found."
+    return 1
+  fi
+  echo ">>> '$1' command exists"
+}
+
+# ── Required commands ─────────────────────────────────
+command_exists hf
+command_exists huggingface-cli
+command_exists tiny-agents
+command_exists gum
+
+echo ">>> hf version: $(hf version)"
+echo ">>> gum version: $(gum --version)"
+
+# ── Cache directory ───────────────────────────────────
+if [ -z "${HF_HOME:-}" ]; then
+  echo "Error: HF_HOME not set."
+  exit 1
+fi
+echo ">>> HF_HOME=$HF_HOME"
+
+if [ ! -d "$HF_HOME" ]; then
+  echo "Error: HF_HOME directory does not exist: $HF_HOME"
+  exit 1
+fi
+echo ">>> HF_HOME directory exists"
+
+# ── Hub query (offline-safe metadata check) ───────────
+echo ">>> downloading a small file from a public model..."
+hf download hf-internal-testing/tiny-random-gpt2 \
+  config.json --quiet
+echo ">>> downloaded config.json from tiny-random-gpt2"
+
+echo ">>> huggingface-demo environment is working"

--- a/huggingface/.flox/.gitignore
+++ b/huggingface/.flox/.gitignore
@@ -1,0 +1,4 @@
+run/
+cache/
+lib/
+log/

--- a/huggingface/.flox/env.json
+++ b/huggingface/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "huggingface",
+  "version": 1
+}

--- a/huggingface/.flox/env/manifest.lock
+++ b/huggingface/.flox/env/manifest.lock
@@ -1,0 +1,141 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "schema-version": "1.10.0",
+    "install": {
+      "huggingface-hub": {
+        "pkg-path": "flox/huggingface-hub",
+        "pkg-group": "huggingface"
+      }
+    },
+    "vars": {
+      "HF_HOME": ""
+    },
+    "hook": {
+      "on-activate": "HF_HOME=\"$FLOX_ENV_CACHE/huggingface\"\nexport HF_HOME\nmkdir -p \"$HF_HOME\"\n"
+    },
+    "options": {}
+  },
+  "packages": [
+    {
+      "attr_path": "huggingface-hub",
+      "broken": false,
+      "derivation": "/nix/store/hfa9cjq3m5glxpfw9kwxs6bsydipx6ks-python3.13-huggingface-hub-1.14.0.drv",
+      "description": "Download and publish models and other files on the huggingface.co hub",
+      "install_id": "huggingface-hub",
+      "license": "Apache-2.0",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=f3d8d611bb1904a2920115fab32734956b694479",
+      "name": "huggingface-hub-1.14.0",
+      "pname": "huggingface-hub",
+      "rev": "f3d8d611bb1904a2920115fab32734956b694479",
+      "rev_count": 3160,
+      "rev_date": "2026-05-11T07:17:09Z",
+      "scrape_date": "2026-05-11T07:24:04.438Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.14.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dist": "/nix/store/889ccibnav97bc90iqaxiazpfbc9p4nl-python3.13-huggingface-hub-1.14.0-dist",
+        "out": "/nix/store/wm6az2xfdvrmn1clgd49hma4gvrmqj3p-python3.13-huggingface-hub-1.14.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "huggingface",
+      "priority": 5
+    },
+    {
+      "attr_path": "huggingface-hub",
+      "broken": false,
+      "derivation": "/nix/store/yvkvq4nr78zqc1ajkxb2sr1lhhgdz7fc-python3.13-huggingface-hub-1.14.0.drv",
+      "description": "Download and publish models and other files on the huggingface.co hub",
+      "install_id": "huggingface-hub",
+      "license": "Apache-2.0",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=f3d8d611bb1904a2920115fab32734956b694479",
+      "name": "huggingface-hub-1.14.0",
+      "pname": "huggingface-hub",
+      "rev": "f3d8d611bb1904a2920115fab32734956b694479",
+      "rev_count": 3160,
+      "rev_date": "2026-05-11T07:17:09Z",
+      "scrape_date": "2026-05-11T07:24:04.438004Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.14.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dist": "/nix/store/s6sn7wg200sfpp56b6zbzybyw2q3c1wm-python3.13-huggingface-hub-1.14.0-dist",
+        "out": "/nix/store/flw42jd9xn5qq9mrfabia7jd306ja9nj-python3.13-huggingface-hub-1.14.0"
+      },
+      "system": "aarch64-linux",
+      "group": "huggingface",
+      "priority": 5
+    },
+    {
+      "attr_path": "huggingface-hub",
+      "broken": false,
+      "derivation": "/nix/store/6yawkc0wnckkfr83mjaq6xyiwi56s63g-python3.13-huggingface-hub-1.14.0.drv",
+      "description": "Download and publish models and other files on the huggingface.co hub",
+      "install_id": "huggingface-hub",
+      "license": "Apache-2.0",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=f3d8d611bb1904a2920115fab32734956b694479",
+      "name": "huggingface-hub-1.14.0",
+      "pname": "huggingface-hub",
+      "rev": "f3d8d611bb1904a2920115fab32734956b694479",
+      "rev_count": 3160,
+      "rev_date": "2026-05-11T07:17:09Z",
+      "scrape_date": "2026-05-11T07:24:04.438004Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.14.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dist": "/nix/store/mn2d3v4njps3ld1awmiaz2bvqjaba0rx-python3.13-huggingface-hub-1.14.0-dist",
+        "out": "/nix/store/730x54lhv8b02hp163ky2l2zhq6hgkgs-python3.13-huggingface-hub-1.14.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "huggingface",
+      "priority": 5
+    },
+    {
+      "attr_path": "huggingface-hub",
+      "broken": false,
+      "derivation": "/nix/store/17xfmz5c7dg01v1y8yqswhyxvj71jw2q-python3.13-huggingface-hub-1.14.0.drv",
+      "description": "Download and publish models and other files on the huggingface.co hub",
+      "install_id": "huggingface-hub",
+      "license": "Apache-2.0",
+      "locked_url": "ssh://git@github.com/flox/floxenvs.git?rev=f3d8d611bb1904a2920115fab32734956b694479",
+      "name": "huggingface-hub-1.14.0",
+      "pname": "huggingface-hub",
+      "rev": "f3d8d611bb1904a2920115fab32734956b694479",
+      "rev_count": 3160,
+      "rev_date": "2026-05-11T07:17:09Z",
+      "scrape_date": "2026-05-11T07:24:04.438005Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.14.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "dist": "/nix/store/vh6qh7y1i14hx78kik6ih6g6926zwlvv-python3.13-huggingface-hub-1.14.0-dist",
+        "out": "/nix/store/hw1cbiv9nrcm9vfgc1g67b2pafajggri-python3.13-huggingface-hub-1.14.0"
+      },
+      "system": "x86_64-linux",
+      "group": "huggingface",
+      "priority": 5
+    }
+  ]
+}

--- a/huggingface/.flox/env/manifest.lock
+++ b/huggingface/.flox/env/manifest.lock
@@ -1,7 +1,7 @@
 {
   "lockfile-version": 1,
   "manifest": {
-    "schema-version": "1.10.0",
+    "schema-version": "1.11.0",
     "install": {
       "huggingface-hub": {
         "pkg-path": "flox/huggingface-hub",

--- a/huggingface/.flox/env/manifest.toml
+++ b/huggingface/.flox/env/manifest.toml
@@ -1,0 +1,28 @@
+schema-version = "1.10.0"
+
+# Minimal Hugging Face Hub environment for use with [include].
+#
+# Include it in your own manifest:
+#
+#   [include]
+#   environments = ["flox/huggingface"]
+#
+# Provides the `hf` CLI (plus `huggingface-cli` and
+# `tiny-agents`) and redirects the Hugging Face cache to
+# `$FLOX_ENV_CACHE/huggingface` so models and datasets
+# persist across activations without polluting `~/.cache`.
+
+[install]
+huggingface-hub.pkg-path = "flox/huggingface-hub"
+huggingface-hub.pkg-group = "huggingface"
+
+[vars]
+# Anchor every HF path under a per-env cache root.
+HF_HOME = ""
+
+[hook]
+on-activate = '''
+HF_HOME="$FLOX_ENV_CACHE/huggingface"
+export HF_HOME
+mkdir -p "$HF_HOME"
+'''

--- a/huggingface/.flox/env/manifest.toml
+++ b/huggingface/.flox/env/manifest.toml
@@ -1,4 +1,4 @@
-schema-version = "1.10.0"
+schema-version = "1.11.0"
 
 # Minimal Hugging Face Hub environment for use with [include].
 #

--- a/huggingface/README.md
+++ b/huggingface/README.md
@@ -37,6 +37,23 @@ persist across activations without polluting
 `~/.cache/huggingface`. Override `HF_HOME` in your own
 manifest to point elsewhere.
 
+## High-performance transfers (opt-in)
+
+The bundled `hf-xet` binary already accelerates every
+download via chunk-based deduplication — no flag needed.
+For multi-GB models you can additionally saturate
+bandwidth and use all CPU cores by setting
+`HF_XET_HIGH_PERFORMANCE=1`:
+
+```toml
+[vars]
+HF_XET_HIGH_PERFORMANCE = "1"
+```
+
+Note: the legacy `HF_HUB_ENABLE_HF_TRANSFER=1` is
+deprecated in `huggingface_hub` v1.x — `hf-xet` replaced
+`hf_transfer` entirely.
+
 ## Common commands
 
 ```bash

--- a/huggingface/README.md
+++ b/huggingface/README.md
@@ -1,0 +1,52 @@
+# huggingface
+
+Minimal [Hugging Face Hub](https://huggingface.co/) CLI
+environment for downloading models, datasets, and Spaces
+artifacts.
+
+## Quick start
+
+Activate directly:
+
+```bash
+flox activate -r flox/huggingface
+```
+
+## Include in your project
+
+Add to your `manifest.toml`:
+
+```toml
+[include]
+environments = ["flox/huggingface"]
+```
+
+## What is included
+
+| Command | Description |
+| ------- | ----------- |
+| `hf` | Main Hugging Face Hub CLI |
+| `huggingface-cli` | Legacy alias kept for compatibility |
+| `tiny-agents` | Minimal agent runtime built on `hf` |
+
+## Cache layout
+
+The environment sets `HF_HOME` to
+`$FLOX_ENV_CACHE/huggingface` so models and datasets
+persist across activations without polluting
+`~/.cache/huggingface`. Override `HF_HOME` in your own
+manifest to point elsewhere.
+
+## Common commands
+
+```bash
+hf auth login                           # store a token
+hf download <repo_id> [<filename>]      # fetch files
+hf upload   <repo_id> <local_path>      # push files
+hf cache scan                           # inspect cache
+```
+
+## See also
+
+For an interactive walkthrough, see
+[huggingface-demo](../huggingface-demo/).

--- a/huggingface/test.sh
+++ b/huggingface/test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+command_exists() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' command not found."
+    return 1
+  fi
+  echo ">>> '$1' command exists"
+}
+
+# ── Required commands ─────────────────────────────────
+command_exists hf
+command_exists huggingface-cli
+command_exists tiny-agents
+
+echo ">>> hf version: $(hf version)"
+
+# ── Cache directory ───────────────────────────────────
+if [ -z "${HF_HOME:-}" ]; then
+  echo "Error: HF_HOME not set."
+  exit 1
+fi
+echo ">>> HF_HOME=$HF_HOME"
+
+if [ ! -d "$HF_HOME" ]; then
+  echo "Error: HF_HOME directory does not exist: $HF_HOME"
+  exit 1
+fi
+echo ">>> HF_HOME directory exists"
+
+# ── Hub query (offline-safe metadata check) ───────────
+echo ">>> querying hub for a small public model..."
+hf download hf-internal-testing/tiny-random-gpt2 \
+  config.json --quiet
+echo ">>> downloaded config.json from tiny-random-gpt2"
+
+echo ">>> huggingface environment is working"


### PR DESCRIPTION
## Summary

- New custom package `flox/huggingface-hub` (v1.14.0) — overrides nixpkgs's `python3Packages.huggingface-hub` and wraps it via `toPythonApplication`, exposing `hf`, `huggingface-cli`, and `tiny-agents` as standalone binaries. Already published to FloxHub for all 4 systems.
- New minimal environment `huggingface/` for `[include]` composition. Sets `HF_HOME` to `$FLOX_ENV_CACHE/huggingface` so models persist per-env without polluting `~/.cache/huggingface`.
- New demo environment `huggingface-demo/` adds `gum` with a styled cheat-sheet banner.
- `upgrade.sh` tracks `https://github.com/huggingface/huggingface_hub/releases/latest` (2-field `hashes.json`: version + srcHash).

## Out of scope (follow-up)

- Service(s) for declarative prefetch of models/datasets/buckets. Discussed offline — likely a `hf-fetch` command using `process-compose` TUI rather than `[services]` since downloads are one-shot, not daemons.
- Auth-status warning on activate + gum-styled login walkthrough in demo.

## Test plan

- [x] `flox build huggingface-hub` succeeds on aarch64-darwin
- [x] `flox publish` succeeds for all 4 systems (`aarch64-darwin`, `aarch64-linux`, `x86_64-darwin`, `x86_64-linux`)
- [x] `huggingface/test.sh` passes locally (downloads `tiny-random-gpt2/config.json` from live Hub)
- [x] `huggingface-demo/test.sh` passes locally
- [ ] CI green on PR