### PR TITLE
Revert "ci: floxbot auto-merge via approver App"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,24 +482,6 @@ jobs:
       || needs.wait-for-packages.outputs.total_workflows != '0')
 
     steps:
-      - name: "Mint approver App token"
-        id: "approver_token"
-        uses: "actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349" # v2.2.2
-        with:
-          app-id: "${{ secrets.MANAGED_FLOXENVS_APPROVER_APP_ID }}"
-          private-key: "${{ secrets.MANAGED_FLOXENVS_APPROVER_PRIVATE_KEY }}"
-
-      - name: "Approve PR"
-        env:
-          PR_NUMBER: >-
-            ${{ needs.wait-for-environments.outputs.pr_number }}
-          GITHUB_TOKEN: "${{ steps.approver_token.outputs.token }}"
-        run: |
-          gh pr review "$PR_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --approve \
-            --body "Approved by automated approver: all required CI checks are green for floxbot PR."
-
       - name: "Merge PR"
         env:
           PR_NUMBER: >-
@@ -507,7 +489,7 @@ jobs:
           GITHUB_TOKEN: >-
             ${{ secrets.MANAGED_FLOXBOT_GITHUB_ACCESS_TOKEN_REPO_SCOPE }}
         run: |
-          gh pr merge --auto --merge "$PR_NUMBER" \
+          gh pr merge --rebase "$PR_NUMBER" \
             --repo "${{ github.repository }}"
 
   report-failure:


### PR DESCRIPTION
## Summary

Reverts #1758. The custom GitHub App approach doesn't work for our setup: **GitHub Apps' approving reviews don't count toward required reviews**, regardless of the App's permissions. The App submitted an APPROVED review on #1757 but \`reviewDecision\` stayed \`REVIEW_REQUIRED\`, and the merge queue refused to enqueue.

See [GitHub community #167357](https://github.com/orgs/community/discussions/167357) — bypass list and App permissions don't change this.

This restores the previous state (broken \`--rebase\` and all). A follow-up PR will implement the working approach: a service-account user with PAT-based approval.

## Companion revert

Pair with: flox/deltaops revert to remove the now-unused \`MANAGED_FLOXENVS_APPROVER_*\` secrets from the sync.

## Test plan

- [ ] Merge this revert
- [ ] Floxbot PRs return to current state (CI runs, Auto Merge attempts \`gh pr merge --rebase\` which the queue rejects, manual review still required) — i.e., no worse than before #1758