### PR TITLE
feat(skills-taste-skill): package github.com/Leonxlnx/taste-skill skills

### DIFF
--- a/.flox/pkgs/skills-taste-skill/default.nix
+++ b/.flox/pkgs/skills-taste-skill/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+let
+  data = builtins.fromJSON (builtins.readFile ./hashes.json);
+
+  src = fetchFromGitHub {
+    owner = "Leonxlnx";
+    repo = "taste-skill";
+    rev = data.rev;
+    hash = data.srcHash;
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "skills-taste-skill";
+  version = data.version;
+  inherit src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # The upstream repo bundles a collection of skills under
+    # `skills/<name>/SKILL.md`. Install each one as its own
+    # discoverable skill for both Claude Code and OpenCode.
+    for base in \
+      "$out/share/claude-code/skills" \
+      "$out/share/opencode/skills"; do
+      mkdir -p "$base"
+      for sub in "$src"/skills/*/; do
+        name="$(basename "$sub")"
+        if [ -f "$sub/SKILL.md" ]; then
+          mkdir -p "$base/$name"
+          cp -r "$sub"/. "$base/$name/"
+        fi
+      done
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Taste-Skill bundle for Claude Code and OpenCode "
+      + "— gives AI good taste and stops generic-slop output.";
+    homepage = "https://github.com/Leonxlnx/taste-skill";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/skills-taste-skill/hashes.json
+++ b/.flox/pkgs/skills-taste-skill/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "0+unstable-2026-05-06.c807516",
+  "rev": "c8075169cd63d1430bbf492dd4ddd478ea9fa4da",
+  "srcHash": "sha256-3eMEDbGd/JwxXjvHbVhd8ZOCTtpjR1WhzuNWdBCFroc="
+}

--- a/.flox/pkgs/skills-taste-skill/publish.json
+++ b/.flox/pkgs/skills-taste-skill/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/skills-taste-skill/upgrade.sh
+++ b/.flox/pkgs/skills-taste-skill/upgrade.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="Leonxlnx"
+REPO="taste-skill"
+BRANCH="main"
+
+current_version=$(jq -r '.version // ""' "$HASHES_FILE")
+
+# Resolve current HEAD on main to a full SHA.
+rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/heads/$BRANCH" | awk '{print $1}')
+
+if [ -z "$rev" ]; then
+  echo "Failed to resolve $BRANCH on $OWNER/$REPO" >&2
+  exit 1
+fi
+
+short_sha="${rev:0:7}"
+
+# Committer date (YYYY-MM-DD) via the GitHub commits API.
+commit_json=$(curl -sfL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
+commit_date=$(echo "$commit_json" \
+  | jq -r '.commit.committer.date' \
+  | cut -c1-10)
+
+# Upstream doesn't ship a version field in any SKILL.md frontmatter,
+# so synthesize a date+sha pseudo-version.
+new_version="0+unstable-${commit_date}.${short_sha}"
+
+echo "Current: $current_version"
+echo "Latest:  $new_version"
+
+if [ "$current_version" = "$new_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating skills-taste-skill to $new_version"
+
+# Prefetch the source tarball and compute SRI hash.
+sha256_base32=$(nix-prefetch-url --unpack \
+  "https://github.com/$OWNER/$REPO/archive/$rev.tar.gz")
+sri_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$sha256_base32")
+
+jq -n \
+  --arg v "$new_version" \
+  --arg r "$rev" \
+  --arg h "$sri_hash" \
+  '{version: $v, rev: $r, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Wrote $HASHES_FILE:"
+cat "$HASHES_FILE"


### PR DESCRIPTION
## Summary

- Adds `.flox/pkgs/skills-taste-skill/` — a custom nix package mirroring the `skills-humanizer` layout
- Installs the 12 skills bundled in [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) (`brandkit`, `brutalist-skill`, `gpt-tasteskill`, `image-to-code-skill`, `imagegen-frontend-mobile`, `imagegen-frontend-web`, `minimalist-skill`, `output-skill`, `redesign-skill`, `soft-skill`, `stitch-skill`, `taste-skill`) into `share/claude-code/skills/<name>` and `share/opencode/skills/<name>`
- Pinned to upstream commit `c8075169` (2026-05-06); `upgrade.sh` synthesizes a `0+unstable-<date>.<sha>` version because upstream `SKILL.md` files have no `version:` frontmatter

## Test plan

- [x] `nix-build -E '(import <nixpkgs> {}).callPackage ./.flox/pkgs/skills-taste-skill/default.nix {}'` builds locally on aarch64-darwin
- [x] Verified install layout — 12 skill directories present under both `share/claude-code/skills/` and `share/opencode/skills/`
- [ ] `ci_pkgs.yml` builds on all 4 systems
- [ ] Manual `flox publish -o flox skills-taste-skill --system <system>` after merge