### PR TITLE
chore(ci): make pre-commit yamllint + actionlint pass repo-wide

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,17 @@
 version: 2
 updates:
 
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-  labels:
-    - "team-developer-support"
-  open-pull-requests-limit: 1
-  commit-message:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - "team-developer-support"
+    open-pull-requests-limit: 1
+    commit-message:
       prefix: "chore"
       include: "scope"
-  groups:
-    all:
-      patterns:
-        - "*"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -13,11 +13,8 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-    - name: Add team  label automatically to new issues and PRs
-      uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
-
-      with:
-        github_token: "${{ secrets.GITHUB_TOKEN }}"
-        labels: "team-content"
-
-
+      - name: Add team  label automatically to new issues and PRs
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          labels: "team-content"

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -86,20 +86,21 @@ jobs:
               else . end
           ' "$LOCK")
           MATRIX=$(echo "$SYSTEMS" | jq -c '{system: .}')
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
           # Detect services
           SVC=$(jq -r '
             .manifest.services // {} | length > 0
           ' "$LOCK")
-          echo "start_services=$SVC" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "matrix=$MATRIX"
+            echo "start_services=$SVC"
+          } >> "$GITHUB_OUTPUT"
 
           # Check for demo
           DEMO_DIR="$ENV-demo"
           if [ -d "$DEMO_DIR" ] \
               && [ -f "$DEMO_DIR/.flox/env/manifest.lock" ]; then
-            echo "has_demo=true" >> "$GITHUB_OUTPUT"
-
             DEMO_LOCK="$DEMO_DIR/.flox/env/manifest.lock"
 
             DEMO_SYSTEMS=$(jq -r '
@@ -110,16 +111,22 @@ jobs:
                 else . end
             ' "$DEMO_LOCK")
             DEMO_MATRIX=$(echo "$DEMO_SYSTEMS" | jq -c '{system: .}')
-            echo "demo_matrix=$DEMO_MATRIX" >> "$GITHUB_OUTPUT"
 
             DEMO_SVC=$(jq -r '
               .manifest.services // {} | length > 0
             ' "$DEMO_LOCK")
-            echo "demo_start_services=$DEMO_SVC" >> "$GITHUB_OUTPUT"
+
+            {
+              echo "has_demo=true"
+              echo "demo_matrix=$DEMO_MATRIX"
+              echo "demo_start_services=$DEMO_SVC"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "has_demo=false" >> "$GITHUB_OUTPUT"
-            echo "demo_matrix={\"system\":[]}" >> "$GITHUB_OUTPUT"
-            echo "demo_start_services=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "has_demo=false"
+              echo "demo_matrix={\"system\":[]}"
+              echo "demo_start_services=false"
+            } >> "$GITHUB_OUTPUT"
           fi
 
   test:
@@ -155,16 +162,20 @@ jobs:
         run: |
           set -eo pipefail
           echo "${{ vars.MANAGED_REMOTE_BUILDERS }}" > machines
-          export REMOTE_SERVER_ENTRY=$(cat machines | shuf | grep ${{ matrix.system }} | head -1 ; )
-          export REMOTE_SERVER_ADDRESS=$(echo "$REMOTE_SERVER_ENTRY" | cut -f1 -d' ' | cut -f3 -d'/' | sed 's/nixbld@//' ; )
-          export REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$(mktemp)
-          export REMOTE_SERVER_PUBLIC_HOST_KEY=$(echo "$REMOTE_SERVER_ENTRY" | tr -s ' ' | cut -f8 -d' ' | base64 -d ; )
+          REMOTE_SERVER_ENTRY="$(shuf machines | grep "${{ matrix.system }}" | head -1)"
+          REMOTE_SERVER_ADDRESS="$(echo "$REMOTE_SERVER_ENTRY" | cut -f1 -d' ' | cut -f3 -d'/' | sed 's/nixbld@//')"
+          REMOTE_SERVER_USER_KNOWN_HOSTS_FILE="$(mktemp)"
+          REMOTE_SERVER_PUBLIC_HOST_KEY="$(echo "$REMOTE_SERVER_ENTRY" | tr -s ' ' | cut -f8 -d' ' | base64 -d)"
+          export REMOTE_SERVER_ENTRY REMOTE_SERVER_ADDRESS
+          export REMOTE_SERVER_USER_KNOWN_HOSTS_FILE REMOTE_SERVER_PUBLIC_HOST_KEY
           printf "%s %s\n" "$REMOTE_SERVER_ADDRESS" "$REMOTE_SERVER_PUBLIC_HOST_KEY" > "$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
           echo "REMOTE_SERVER_ADDRESS: $REMOTE_SERVER_ADDRESS"
           echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE: $REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
-          cat $REMOTE_SERVER_USER_KNOWN_HOSTS_FILE
-          echo "REMOTE_SERVER_ADDRESS=$REMOTE_SERVER_ADDRESS" >> $GITHUB_ENV
-          echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE" >> $GITHUB_ENV
+          cat "$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
+          {
+            echo "REMOTE_SERVER_ADDRESS=$REMOTE_SERVER_ADDRESS"
+            echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
+          } >> "$GITHUB_ENV"
           if [ -n "$REMOTE_SERVER_ADDRESS" ]; then
             tailscale ping "$REMOTE_SERVER_ADDRESS"
           fi
@@ -222,16 +233,20 @@ jobs:
         run: |
           set -eo pipefail
           echo "${{ vars.MANAGED_REMOTE_BUILDERS }}" > machines
-          export REMOTE_SERVER_ENTRY=$(cat machines | shuf | grep ${{ matrix.system }} | head -1 ; )
-          export REMOTE_SERVER_ADDRESS=$(echo "$REMOTE_SERVER_ENTRY" | cut -f1 -d' ' | cut -f3 -d'/' | sed 's/nixbld@//' ; )
-          export REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$(mktemp)
-          export REMOTE_SERVER_PUBLIC_HOST_KEY=$(echo "$REMOTE_SERVER_ENTRY" | tr -s ' ' | cut -f8 -d' ' | base64 -d ; )
+          REMOTE_SERVER_ENTRY="$(shuf machines | grep "${{ matrix.system }}" | head -1)"
+          REMOTE_SERVER_ADDRESS="$(echo "$REMOTE_SERVER_ENTRY" | cut -f1 -d' ' | cut -f3 -d'/' | sed 's/nixbld@//')"
+          REMOTE_SERVER_USER_KNOWN_HOSTS_FILE="$(mktemp)"
+          REMOTE_SERVER_PUBLIC_HOST_KEY="$(echo "$REMOTE_SERVER_ENTRY" | tr -s ' ' | cut -f8 -d' ' | base64 -d)"
+          export REMOTE_SERVER_ENTRY REMOTE_SERVER_ADDRESS
+          export REMOTE_SERVER_USER_KNOWN_HOSTS_FILE REMOTE_SERVER_PUBLIC_HOST_KEY
           printf "%s %s\n" "$REMOTE_SERVER_ADDRESS" "$REMOTE_SERVER_PUBLIC_HOST_KEY" > "$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
           echo "REMOTE_SERVER_ADDRESS: $REMOTE_SERVER_ADDRESS"
           echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE: $REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
-          cat $REMOTE_SERVER_USER_KNOWN_HOSTS_FILE
-          echo "REMOTE_SERVER_ADDRESS=$REMOTE_SERVER_ADDRESS" >> $GITHUB_ENV
-          echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE" >> $GITHUB_ENV
+          cat "$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
+          {
+            echo "REMOTE_SERVER_ADDRESS=$REMOTE_SERVER_ADDRESS"
+            echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
+          } >> "$GITHUB_ENV"
           if [ -n "$REMOTE_SERVER_ADDRESS" ]; then
             tailscale ping "$REMOTE_SERVER_ADDRESS"
           fi
@@ -276,7 +291,7 @@ jobs:
 
       - name: "Get FloxHub token"
         run: |
-          echo "FLOX_FLOXHUB_TOKEN=${{ secrets.FLOX_FLOXHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "FLOX_FLOXHUB_TOKEN=${{ secrets.FLOX_FLOXHUB_TOKEN }}" >> "$GITHUB_ENV"
 
       - name: "Determine target org"
         id: "org"
@@ -348,7 +363,7 @@ jobs:
 
       - name: "Get FloxHub token"
         run: |
-          echo "FLOX_FLOXHUB_TOKEN=${{ secrets.FLOX_FLOXHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "FLOX_FLOXHUB_TOKEN=${{ secrets.FLOX_FLOXHUB_TOKEN }}" >> "$GITHUB_ENV"
 
       - name: "Determine target org"
         id: "org"

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,11 @@
+---
+extends: default
+
+rules:
+  document-start: disable
+  truthy:
+    check-keys: false
+  line-length:
+    max: 130
+  comments:
+    min-spaces-from-content: 1


### PR DESCRIPTION
## Summary

Make `pre-commit run --all-files` pass for yamllint and actionlint. No workflow behavior changes.

Discovered while preparing #1770 — pre-commit was blocking every commit touching `environment.yml` with pre-existing yamllint and shellcheck findings.

## Changes

### 1. New `.yamllint.yaml` (GitHub Actions friendly)

```yaml
extends: default
rules:
  document-start: disable
  truthy:
    check-keys: false
  line-length:
    max: 130
  comments:
    min-spaces-from-content: 1
```

yamllint's defaults don't match GitHub Actions reality:

- workflows don't start with `---`
- `on:` is a valid GHA key but yamllint flags it as truthy
- pinned action SHAs make 80-char lines impossible (`uses: foo/bar@<40-char-sha> # vN`)
- the `# vN` pin comments use a single space

This config adopts the conventions used by virtually every well-maintained Actions repo.

### 2. Shellcheck fixes in `environment.yml`

- **SC2129** in the `discover` step: group consecutive `>> $GITHUB_OUTPUT` redirects into `{ ...; } >> "$GITHUB_OUTPUT"` blocks.
- **SC2086** in the `test` / `test-demo` "Find remote server" steps and both "Get FloxHub token" steps: quote `$GITHUB_ENV` and `$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE`.
- **SC2155** in the `test` / `test-demo` "Find remote server" steps: split `export VAR=$(cmd)` into separate assignment and `export` so a failure in `$(cmd)` isn't masked by `export`'s exit code.

Also swept out the useless `cat machines | shuf` → `shuf machines` while I was in the area (functionally identical, removes one process).

### 3. yamllint indentation fixes

- **`.github/workflows/auto-label.yml`**: indent the `steps:` sequence by 2 more to align under the surrounding mapping; remove the spurious blank line between `uses:` and `with:`; trim trailing blank lines.
- **`.github/dependabot.yml`**: indent the `updates:` sequence items by 2; correct the over-indented `commit-message:` children.

## Out of scope

- `ci.yml` and `ci_pkgs.yml` have leftover shellcheck findings (SC2001 style hint, SC2086 unquoted `$GITHUB_ENV`). Not blocking my work — happy to do a follow-up if wanted.

## Test plan

- [x] `pre-commit run yamllint --all-files` passes (whole repo clean).
- [x] `pre-commit run --files .github/workflows/environment.yml .github/workflows/auto-label.yml .github/dependabot.yml .yamllint.yaml` passes (actionlint + yamllint + convco-check).
- [ ] Workflow_dispatch any env on this branch and confirm the workflow still runs end-to-end (no behavioral change expected).