### PR TITLE
feat(claude-code-plugin-ui-ux-pro-max): package nextlevelbuilder/ui-ux-pro-max-skill

### DIFF
--- a/.flox/pkgs/claude-code-plugin-ui-ux-pro-max/default.nix
+++ b/.flox/pkgs/claude-code-plugin-ui-ux-pro-max/default.nix
@@ -1,0 +1,142 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  python3,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash commitSha;
+
+  # Escape so the indented-string interpolation below produces the
+  # literal token `${CLAUDE_PLUGIN_ROOT}` in the resulting bash, with
+  # no further Nix or bash expansion.
+  pluginRootRef = "\${CLAUDE_PLUGIN_ROOT}";
+in
+stdenv.mkDerivation {
+  pname = "claude-code-plugin-ui-ux-pro-max";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "nextlevelbuilder";
+    repo = "ui-ux-pro-max-skill";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  # makeBinaryWrapper produces a compiled C wrapper for python3 so it
+  # is exec'd directly by the kernel via shebang on Darwin, where
+  # shebang chains through a shell-script wrapper are unreliable
+  # under stripped environments.
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    PLUGIN_DIR="$out/share/claude-code/plugins/ui-ux-pro-max"
+    mkdir -p "$PLUGIN_DIR"
+
+    # `cp -a` preserves the two symlinks
+    # `.claude/skills/ui-ux-pro-max/{data,scripts}` →
+    # `../../../src/ui-ux-pro-max/{data,scripts}` that wire the active
+    # skill to its CSV data and BM25 search scripts.
+    cp -a "$src"/. "$PLUGIN_DIR/"
+    chmod -R u+w "$PLUGIN_DIR"
+
+    # Drop dirs that aren't part of the runtime plugin: GitHub config,
+    # the standalone npm install CLI for non-Claude editors, docs site,
+    # marketing previews/screenshots, and the demo `cat-feeding-app`
+    # HTML page upstream ships as a sample artifact.
+    rm -rf "$PLUGIN_DIR/.github" \
+           "$PLUGIN_DIR/.gitignore" \
+           "$PLUGIN_DIR/cat-feeding-app" \
+           "$PLUGIN_DIR/cli" \
+           "$PLUGIN_DIR/docs" \
+           "$PLUGIN_DIR/preview" \
+           "$PLUGIN_DIR/screenshots"
+
+    # Wrap python3 so the BM25 search scripts always find a working
+    # interpreter even when the consumer's flox env doesn't ship one.
+    # The active skill imports only stdlib (csv/json/re/argparse/...),
+    # so no extra packages needed.
+    mkdir -p "$PLUGIN_DIR/bin"
+    makeBinaryWrapper "${python3}/bin/python3" "$PLUGIN_DIR/bin/python3"
+
+    # Normalize CRLF → LF on `.py` files first. Upstream ships
+    # `src/ui-ux-pro-max/scripts/search.py` with Windows line endings,
+    # which leaves a `\r` at the end of the shebang line and makes the
+    # kernel try to exec `<wrapped-python>\r` (ENOENT). Other CSV/MD
+    # files we leave alone — the `\r` only matters where it ends up on
+    # the shebang line, and Python's `csv` module handles both.
+    find "$PLUGIN_DIR" -type f -name '*.py' \
+      -exec sed -i 's/\r$//' {} +
+
+    # Repoint every `#!/usr/bin/env python3` shebang at the wrapped
+    # python so Claude Code can invoke scripts via their path without
+    # depending on the caller's PATH. Marks them executable so the
+    # kernel honors the shebang.
+    while IFS= read -r f; do
+      head -1 "$f" | grep -q '/usr/bin/env python3' || continue
+      substituteInPlace "$f" --replace-fail \
+        '#!/usr/bin/env python3' "#!$PLUGIN_DIR/bin/python3"
+      chmod +x "$f"
+    done < <(find "$PLUGIN_DIR" -type f -name '*.py')
+
+    # Rewrite the SKILL.md's `python3 skills/ui-ux-pro-max/scripts/<X>`
+    # invocations to absolute references that work under a plugin
+    # install. Upstream's markdown embeds the user-install layout (where
+    # `skills/` is the install dir), which doesn't resolve from a plugin
+    # whose root is wherever Claude Code unpacks it. Also routes them
+    # through our bundled python so the consumer's env doesn't have to
+    # ship one.
+    rewritten=0
+    while IFS= read -r f; do
+      grep -q 'python3 skills/ui-ux-pro-max/scripts/' "$f" || continue
+      substituteInPlace "$f" --replace-quiet \
+        'python3 skills/ui-ux-pro-max/scripts/' \
+        '${pluginRootRef}/bin/python3 ${pluginRootRef}/.claude/skills/ui-ux-pro-max/scripts/'
+      rewritten=$((rewritten + 1))
+    done < <(find "$PLUGIN_DIR" -type f -name '*.md')
+    echo "rewrote python invocations in $rewritten markdown file(s)"
+
+    # Drop an installed_plugins.json next to the plugin so claude-managed
+    # registers it in $CLAUDE_CONFIG_DIR/plugins/installed_plugins.json
+    # — without that file Claude Code lists the plugin but won't trust it.
+    # Schema follows the v2 (`plugins` wrapper) format claude-managed uses;
+    # installPath is patched to the real symlink target by `plugins add`.
+    cat > "$PLUGIN_DIR/installed_plugins.json" <<JSON
+    {
+      "plugins": {
+        "ui-ux-pro-max@flox": [
+          {
+            "installPath": "",
+            "scope": "project",
+            "version": "${version}",
+            "gitCommitSha": "${commitSha}"
+          }
+        ]
+      },
+      "version": 2
+    }
+    JSON
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "UI/UX Pro Max design intelligence plugin for Claude Code "
+      + "— styles, palettes, typography, charts, and UX guidance "
+      + "across 15+ stacks (Python search engine bundled).";
+    homepage = "https://github.com/nextlevelbuilder/ui-ux-pro-max-skill";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/claude-code-plugin-ui-ux-pro-max/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-ui-ux-pro-max/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "2.5.0",
+  "srcHash": "sha256-zrWVV48rhz+4Hm4Ho1371yymkwbbtSveXLUvq55EGB4=",
+  "commitSha": "07f4ef3ac2568c25a3b0c8ef5165a86abc3e56e4"
+}

--- a/.flox/pkgs/claude-code-plugin-ui-ux-pro-max/publish.json
+++ b/.flox/pkgs/claude-code-plugin-ui-ux-pro-max/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/claude-code-plugin-ui-ux-pro-max/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-ui-ux-pro-max/upgrade.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="nextlevelbuilder"
+REPO="ui-ux-pro-max-skill"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+
+# Upstream tags releases as `vX.Y.Z`. Pull the latest such tag.
+latest_tag=$(curl -sf \
+  "https://api.github.com/repos/$OWNER/$REPO/releases/latest" \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating claude-code-plugin-ui-ux-pro-max from $current_version to $latest_version"
+
+src_url="https://github.com/$OWNER/$REPO/archive/refs/tags/v${latest_version}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+# Resolve the tag to its commit SHA — Claude Code's installed_plugins.json
+# records gitCommitSha per entry, and shipping the real SHA lets users
+# reproduce or audit exactly which upstream commit they have.
+commit_sha=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/tags/v${latest_version}" | awk '{print $1}')
+if [ -z "$commit_sha" ]; then
+  echo "ERROR: could not resolve v${latest_version} to a commit SHA"
+  exit 1
+fi
+echo "  commitSha: $commit_sha"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg c "$commit_sha" \
+  '{version: $v, srcHash: $s, commitSha: $c}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,17 @@
 version: 2
 updates:
 
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-  labels:
-    - "team-developer-support"
-  open-pull-requests-limit: 1
-  commit-message:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+      - "team-developer-support"
+    open-pull-requests-limit: 1
+    commit-message:
       prefix: "chore"
       include: "scope"
-  groups:
-    all:
-      patterns:
-        - "*"
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -13,11 +13,8 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-    - name: Add team  label automatically to new issues and PRs
-      uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
-
-      with:
-        github_token: "${{ secrets.GITHUB_TOKEN }}"
-        labels: "team-content"
-
-
+      - name: Add team  label automatically to new issues and PRs
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
+        with:
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          labels: "team-content"

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -86,20 +86,21 @@ jobs:
               else . end
           ' "$LOCK")
           MATRIX=$(echo "$SYSTEMS" | jq -c '{system: .}')
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
           # Detect services
           SVC=$(jq -r '
             .manifest.services // {} | length > 0
           ' "$LOCK")
-          echo "start_services=$SVC" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "matrix=$MATRIX"
+            echo "start_services=$SVC"
+          } >> "$GITHUB_OUTPUT"
 
           # Check for demo
           DEMO_DIR="$ENV-demo"
           if [ -d "$DEMO_DIR" ] \
               && [ -f "$DEMO_DIR/.flox/env/manifest.lock" ]; then
-            echo "has_demo=true" >> "$GITHUB_OUTPUT"
-
             DEMO_LOCK="$DEMO_DIR/.flox/env/manifest.lock"
 
             DEMO_SYSTEMS=$(jq -r '
@@ -110,16 +111,22 @@ jobs:
                 else . end
             ' "$DEMO_LOCK")
             DEMO_MATRIX=$(echo "$DEMO_SYSTEMS" | jq -c '{system: .}')
-            echo "demo_matrix=$DEMO_MATRIX" >> "$GITHUB_OUTPUT"
 
             DEMO_SVC=$(jq -r '
               .manifest.services // {} | length > 0
             ' "$DEMO_LOCK")
-            echo "demo_start_services=$DEMO_SVC" >> "$GITHUB_OUTPUT"
+
+            {
+              echo "has_demo=true"
+              echo "demo_matrix=$DEMO_MATRIX"
+              echo "demo_start_services=$DEMO_SVC"
+            } >> "$GITHUB_OUTPUT"
           else
-            echo "has_demo=false" >> "$GITHUB_OUTPUT"
-            echo "demo_matrix={\"system\":[]}" >> "$GITHUB_OUTPUT"
-            echo "demo_start_services=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "has_demo=false"
+              echo "demo_matrix={\"system\":[]}"
+              echo "demo_start_services=false"
+            } >> "$GITHUB_OUTPUT"
           fi
 
   test:
@@ -155,16 +162,20 @@ jobs:
         run: |
           set -eo pipefail
           echo "${{ vars.MANAGED_REMOTE_BUILDERS }}" > machines
-          export REMOTE_SERVER_ENTRY=$(cat machines | shuf | grep ${{ matrix.system }} | head -1 ; )
-          export REMOTE_SERVER_ADDRESS=$(echo "$REMOTE_SERVER_ENTRY" | cut -f1 -d' ' | cut -f3 -d'/' | sed 's/nixbld@//' ; )
-          export REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$(mktemp)
-          export REMOTE_SERVER_PUBLIC_HOST_KEY=$(echo "$REMOTE_SERVER_ENTRY" | tr -s ' ' | cut -f8 -d' ' | base64 -d ; )
+          REMOTE_SERVER_ENTRY="$(shuf machines | grep "${{ matrix.system }}" | head -1)"
+          REMOTE_SERVER_ADDRESS="$(echo "$REMOTE_SERVER_ENTRY" | cut -f1 -d' ' | cut -f3 -d'/' | sed 's/nixbld@//')"
+          REMOTE_SERVER_USER_KNOWN_HOSTS_FILE="$(mktemp)"
+          REMOTE_SERVER_PUBLIC_HOST_KEY="$(echo "$REMOTE_SERVER_ENTRY" | tr -s ' ' | cut -f8 -d' ' | base64 -d)"
+          export REMOTE_SERVER_ENTRY REMOTE_SERVER_ADDRESS
+          export REMOTE_SERVER_USER_KNOWN_HOSTS_FILE REMOTE_SERVER_PUBLIC_HOST_KEY
           printf "%s %s\n" "$REMOTE_SERVER_ADDRESS" "$REMOTE_SERVER_PUBLIC_HOST_KEY" > "$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
           echo "REMOTE_SERVER_ADDRESS: $REMOTE_SERVER_ADDRESS"
           echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE: $REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
-          cat $REMOTE_SERVER_USER_KNOWN_HOSTS_FILE
-          echo "REMOTE_SERVER_ADDRESS=$REMOTE_SERVER_ADDRESS" >> $GITHUB_ENV
-          echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE" >> $GITHUB_ENV
+          cat "$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
+          {
+            echo "REMOTE_SERVER_ADDRESS=$REMOTE_SERVER_ADDRESS"
+            echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
+          } >> "$GITHUB_ENV"
           if [ -n "$REMOTE_SERVER_ADDRESS" ]; then
             tailscale ping "$REMOTE_SERVER_ADDRESS"
           fi
@@ -222,16 +233,20 @@ jobs:
         run: |
           set -eo pipefail
           echo "${{ vars.MANAGED_REMOTE_BUILDERS }}" > machines
-          export REMOTE_SERVER_ENTRY=$(cat machines | shuf | grep ${{ matrix.system }} | head -1 ; )
-          export REMOTE_SERVER_ADDRESS=$(echo "$REMOTE_SERVER_ENTRY" | cut -f1 -d' ' | cut -f3 -d'/' | sed 's/nixbld@//' ; )
-          export REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$(mktemp)
-          export REMOTE_SERVER_PUBLIC_HOST_KEY=$(echo "$REMOTE_SERVER_ENTRY" | tr -s ' ' | cut -f8 -d' ' | base64 -d ; )
+          REMOTE_SERVER_ENTRY="$(shuf machines | grep "${{ matrix.system }}" | head -1)"
+          REMOTE_SERVER_ADDRESS="$(echo "$REMOTE_SERVER_ENTRY" | cut -f1 -d' ' | cut -f3 -d'/' | sed 's/nixbld@//')"
+          REMOTE_SERVER_USER_KNOWN_HOSTS_FILE="$(mktemp)"
+          REMOTE_SERVER_PUBLIC_HOST_KEY="$(echo "$REMOTE_SERVER_ENTRY" | tr -s ' ' | cut -f8 -d' ' | base64 -d)"
+          export REMOTE_SERVER_ENTRY REMOTE_SERVER_ADDRESS
+          export REMOTE_SERVER_USER_KNOWN_HOSTS_FILE REMOTE_SERVER_PUBLIC_HOST_KEY
           printf "%s %s\n" "$REMOTE_SERVER_ADDRESS" "$REMOTE_SERVER_PUBLIC_HOST_KEY" > "$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
           echo "REMOTE_SERVER_ADDRESS: $REMOTE_SERVER_ADDRESS"
           echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE: $REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
-          cat $REMOTE_SERVER_USER_KNOWN_HOSTS_FILE
-          echo "REMOTE_SERVER_ADDRESS=$REMOTE_SERVER_ADDRESS" >> $GITHUB_ENV
-          echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE" >> $GITHUB_ENV
+          cat "$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
+          {
+            echo "REMOTE_SERVER_ADDRESS=$REMOTE_SERVER_ADDRESS"
+            echo "REMOTE_SERVER_USER_KNOWN_HOSTS_FILE=$REMOTE_SERVER_USER_KNOWN_HOSTS_FILE"
+          } >> "$GITHUB_ENV"
           if [ -n "$REMOTE_SERVER_ADDRESS" ]; then
             tailscale ping "$REMOTE_SERVER_ADDRESS"
           fi
@@ -276,7 +291,7 @@ jobs:
 
       - name: "Get FloxHub token"
         run: |
-          echo "FLOX_FLOXHUB_TOKEN=${{ secrets.FLOX_FLOXHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "FLOX_FLOXHUB_TOKEN=${{ secrets.FLOX_FLOXHUB_TOKEN }}" >> "$GITHUB_ENV"
 
       - name: "Determine target org"
         id: "org"
@@ -348,7 +363,7 @@ jobs:
 
       - name: "Get FloxHub token"
         run: |
-          echo "FLOX_FLOXHUB_TOKEN=${{ secrets.FLOX_FLOXHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "FLOX_FLOXHUB_TOKEN=${{ secrets.FLOX_FLOXHUB_TOKEN }}" >> "$GITHUB_ENV"
 
       - name: "Determine target org"
         id: "org"

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,11 @@
+---
+extends: default
+
+rules:
+  document-start: disable
+  truthy:
+    check-keys: false
+  line-length:
+    max: 130
+  comments:
+    min-spaces-from-content: 1


### PR DESCRIPTION
## Summary

- Adds `.flox/pkgs/claude-code-plugin-ui-ux-pro-max/` — a custom nix
  package mirroring the `claude-code-plugin-impeccable` layout
- Installs the upstream Claude Code plugin
  ([nextlevelbuilder/ui-ux-pro-max-skill](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill))
  at `share/claude-code/plugins/ui-ux-pro-max`, preserving the two
  symlinks (`.claude/skills/ui-ux-pro-max/{data,scripts}` →
  `../../../src/ui-ux-pro-max/{data,scripts}`) that wire the active
  skill to its CSV data and BM25 Python search scripts
- Drops non-runtime dirs (`.github`, `cli`, `docs`, `preview`,
  `screenshots`, the demo `cat-feeding-app`)
- Bundles a `makeBinaryWrapper`-wrapped `python3` — the active scripts
  only import stdlib, so no PyPI deps needed
- Normalizes CRLF → LF on `.py` files (upstream ships `search.py` with
  Windows line endings, which corrupts the shebang)
- Rewrites the SKILL.md's
  `python3 skills/ui-ux-pro-max/scripts/<X>` invocations to absolute
  `${CLAUDE_PLUGIN_ROOT}`-based paths so they resolve under a plugin
  install
- Drops a v2-schema `installed_plugins.json` so `claude-managed`
  trusts the plugin
- Pinned to upstream tag `v2.5.0` (commit `07f4ef3a`, 2026-03-10);
  `upgrade.sh` follows the latest GitHub release

## Test plan

- [x] `nix-build -E '(import <nixpkgs> {}).callPackage ./.flox/pkgs/claude-code-plugin-ui-ux-pro-max/default.nix {}'`
      builds locally on aarch64-darwin
- [x] Verified install layout — `.claude-plugin/plugin.json`,
      `.claude/skills/ui-ux-pro-max/SKILL.md`, preserved
      `data`/`scripts` symlinks, bundled `bin/python3`, and
      `installed_plugins.json` all present
- [x] End-to-end: ran `bin/python3 .claude/skills/ui-ux-pro-max/scripts/search.py "dashboard saas" --domain product`
      from the store path and got BM25 results
- [x] Smoke-tested `upgrade.sh` — correctly detects we're already at
      the latest release
- [ ] `ci_pkgs.yml` builds on all 4 systems
- [ ] Manual `flox publish -o flox claude-code-plugin-ui-ux-pro-max --system <system>`
      after merge