### PR TITLE
fix(ci): make sed in push-demo portable across GNU and BSD sed

### DIFF
--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -406,7 +406,11 @@ jobs:
         run: |
           ENV="${{ inputs.environment }}"
           DEMO_DIR="$ENV-demo"
-          sed -i "s|{ dir = \"../$ENV\" }|{ remote = \"$FLOX_REMOTE_OWNER/$ENV\" }|g" "$DEMO_DIR/.flox/env/manifest.toml"
+          # sed -i is non-portable between GNU (Linux) and BSD (macOS) sed;
+          # write through a temp file so the same step works on both runners.
+          MANIFEST="$DEMO_DIR/.flox/env/manifest.toml"
+          sed "s|{ dir = \"../$ENV\" }|{ remote = \"$FLOX_REMOTE_OWNER/$ENV\" }|g" "$MANIFEST" > "$MANIFEST.new"
+          mv "$MANIFEST.new" "$MANIFEST"
           cat "$DEMO_DIR/.flox/env/manifest.toml"
 
       - name: "Upgrade includes"


### PR DESCRIPTION
## Summary

Fix the `omlx-demo` push failure on `main`: [run 25766539873](https://github.com/flox/floxenvs/actions/runs/25766539873/job/75680750626).

## What broke

After #1770, darwin-only envs like `omlx` run their push and push-demo jobs on `macos-latest`. The push-demo "Rewrite include to use remote environment" step ran:

```bash
sed -i "s|...|...|g" "$DEMO_DIR/.flox/env/manifest.toml"
```

That form works on **GNU sed** (Linux) where `-i` takes an optional argument, but **BSD sed** (macOS) requires `-i` to be followed by a backup extension. BSD sed parses the `s|...|g` expression as the extension, then tries to interpret the file path as a command, producing:

```
sed: 1: "omlx-demo/.flox/env/man ...": invalid command code o
```

## Fix

Rewrite via a temp file + `mv`. Same semantics on every runner, no `-i` quirk, no leftover `.bak` files:

```bash
MANIFEST="$DEMO_DIR/.flox/env/manifest.toml"
sed "s|...|...|g" "$MANIFEST" > "$MANIFEST.new"
mv "$MANIFEST.new" "$MANIFEST"
```

## Test plan

- [ ] Workflow_dispatch the `omlx` env on this branch and confirm `Push 'omlx-demo' to FloxHub` succeeds end-to-end on `macos-latest`.
- [ ] Workflow_dispatch a multi-system env with a demo (e.g. `python-uv-demo`) on this branch and confirm push-demo still succeeds on `ubuntu-latest`.