### PR TITLE
fix(agent-deck): upgrade to 1.9.3 and skip flaky Linux tests

### DIFF
--- a/.flox/pkgs/agent-deck/default.nix
+++ b/.flox/pkgs/agent-deck/default.nix
@@ -30,7 +30,19 @@ buildGoModule (finalAttrs: {
   # in a subprocess and waits for it to write debug.log. The TUI bails
   # in the sandbox (no tmux/terminal), so debug.log never appears. The
   # test guards the subprocess arm with testing.Short(), so honour that.
-  checkFlags = [ "-short" ];
+  #
+  # TestValidatePluginFlags_* relies on a process-wide config cache keyed
+  # on file mtime. On fast Linux filesystems (tmpfs in the Nix sandbox)
+  # mtimes collide between tests, so the catalog from an earlier test
+  # leaks into a later one and the assertion flips. Upstream's
+  # clearSessionUserConfigCache is a no-op (see plugin_cli_test.go:35).
+  # Darwin's coarser mtime resolution hides this. Skip the group until
+  # upstream wires real cache invalidation.
+  checkFlags = [
+    "-short"
+    "-skip"
+    "^TestValidatePluginFlags_"
+  ];
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/.flox/pkgs/agent-deck/hashes.json
+++ b/.flox/pkgs/agent-deck/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.9.1",
-  "srcHash": "sha256-QSrM9zTT1xgx55KduOLo66UmuR1fbLnJqmQHW15eOdA=",
-  "vendorHash": "sha256-aH32Up3redCpeyjZkjcjiVN0tfYpF+GFB2WVAGm3J2I="
+  "version": "1.9.3",
+  "srcHash": "sha256-zUQ927SCU1CIR9KdBPTfxcOyNXy46c3ezqpjqBIY4bg=",
+  "vendorHash": "sha256-/7hzCID4Vu9z6VHN7NiAjyoZPEBPHet4fJdh/VSZaGQ="
 }


### PR DESCRIPTION
## Summary

Supersedes #1781, which failed Linux builds.

- Upgrades agent-deck 1.9.1 → 1.9.3 (same as #1781).
- Skips upstream's flaky `TestValidatePluginFlags_*` group on the
  Nix sandbox so the build stops being held hostage by a race in
  upstream tests.

## Why #1781 failed

Upstream's plugin catalog cache is keyed on `config.toml` mtime. On
fast Linux filesystems (Nix sandbox tmpfs) consecutive sub-tests
collide on the same nanosecond, so the catalog written by an earlier
test leaks into a later one and one of the `TestValidatePluginFlags_*`
assertions flips. Which one flips is timing-dependent — `x86_64-linux`
hit `TestValidatePluginFlags_TelegramForkAccepted`, `aarch64-linux`
hit `TestValidatePluginFlags_EmptyCatalogActionableError`.

Upstream's `clearSessionUserConfigCache` is an empty function
(`plugin_cli_test.go:35`) even though its comment promises real
invalidation. Darwin's coarser mtime resolution hides the race, which
is why the 1.9.1 → 1.9.3 bump only failed on Linux.

## Test plan

- [x] `flox build agent-deck` (aarch64-darwin) — passes
- [x] `flox build agent-deck --system aarch64-linux` — passes via
      remote builder
- [x] `flox build agent-deck --system x86_64-linux` — passes via
      remote builder
- [x] versionCheckHook reports `Agent Deck v1.9.3`