### PR TITLE
feat(gstack): add minimal + demo environments for Garry Tan's Claude Code stack

### DIFF
--- a/.flox/pkgs/claude-code-plugin-gstack/default.nix
+++ b/.flox/pkgs/claude-code-plugin-gstack/default.nix
@@ -1,0 +1,199 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  bun,
+  nodejs,
+  git,
+  jq,
+  curl,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version rev srcHash;
+
+  # Escape so the indented-string interpolation below produces the
+  # literal token `${CLAUDE_PLUGIN_ROOT}` in the resulting bash, with
+  # no further Nix or bash expansion.
+  pluginRootRef = "\${CLAUDE_PLUGIN_ROOT}";
+
+  # Synthesized plugin manifest. gstack upstream targets the legacy
+  # ~/.claude/skills/gstack/ install path and ships no
+  # .claude-plugin/plugin.json of its own.
+  pluginManifest = builtins.toJSON {
+    name = "gstack";
+    inherit version;
+    description =
+      "Garry Tan's Claude Code stack — 45 skills for planning, "
+      + "design, QA, code review, security, and shipping. "
+      + "Originally designed for the legacy ~/.claude/skills/gstack/ "
+      + "install path; this is the Claude Code plugin port.";
+    homepage = "https://github.com/garrytan/gstack";
+    repository = "https://github.com/garrytan/gstack";
+    license = "MIT";
+  };
+in
+stdenv.mkDerivation {
+  pname = "claude-code-plugin-gstack";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "garrytan";
+    repo = "gstack";
+    inherit rev;
+    hash = srcHash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  # ─── Substitution tokens ──────────────────────────────────────────
+  # Available as @TOKEN@ in installPhase via stdenv's substitute helpers,
+  # but we use plain bash variables here for clarity.
+
+  installPhase = ''
+    runHook preInstall
+
+    PLUGIN_DIR="$out/share/claude-code/plugins/gstack"
+    mkdir -p "$PLUGIN_DIR"
+
+    cp -r "$src"/. "$PLUGIN_DIR/"
+    chmod -R u+w "$PLUGIN_DIR"
+
+    # ─── Strip repo-only metadata + tests ─────────────────────────
+    # These directories add ~megabytes and never run from the
+    # installed plugin tree. Leave the top-level *.md (CHANGELOG,
+    # README, CONTRIBUTING, etc.) in place — they help users orient.
+    rm -rf "$PLUGIN_DIR/.github" \
+           "$PLUGIN_DIR/.gitignore" \
+           "$PLUGIN_DIR/.gitattributes" \
+           "$PLUGIN_DIR/.gitlab-ci.yml" \
+           "$PLUGIN_DIR/.env.example" \
+           "$PLUGIN_DIR/test" \
+           "$PLUGIN_DIR/conductor.json" \
+           "$PLUGIN_DIR/slop-scan.config.json"
+
+    # Remove the dangling symlink (points at gstack/open-gstack-browser
+    # which lives elsewhere in the upstream tree). Claude Code's plugin
+    # loader walks the tree and chokes on broken symlinks.
+    rm -f "$PLUGIN_DIR/connect-chrome"
+
+    # ─── Expose skill dirs under skills/ for the plugin loader ────
+    # Upstream keeps each skill at the top level of the gstack tree
+    # (legacy ~/.claude/skills/gstack/<name>/SKILL.md layout). Skills
+    # cross-reference each other (and back at bin/, lib/, design/)
+    # using top-level paths — moving them under skills/ breaks every
+    # such reference inside the skill prose. Claude Code's plugin
+    # loader scans $PLUGIN_ROOT/skills/<name>/SKILL.md, so expose the
+    # dirs there via symlinks instead.
+    mkdir -p "$PLUGIN_DIR/skills"
+    while IFS= read -r skill_md; do
+      dir="$(dirname "$skill_md")"
+      base="$(basename "$dir")"
+      # Skip the plugin root itself (its SKILL.md is the unused
+      # root-skill template, removed below).
+      [ "$dir" = "$PLUGIN_DIR" ] && continue
+      # Skip anything already under skills/ (defensive — upstream
+      # currently has nothing nested, but a future rename shouldn't
+      # break the build).
+      case "$dir" in *"/skills/"*) continue;; esac
+      ln -s "../$base" "$PLUGIN_DIR/skills/$base"
+    done < <(find "$PLUGIN_DIR" -maxdepth 2 -name 'SKILL.md' -type f)
+
+    # Remove the root SKILL.md / SKILL.md.tmpl — they describe the
+    # standalone "/gstack" command that gstack's setup script
+    # generates on direct install. The plugin loader doesn't use it,
+    # and leaving SKILL.md at the plugin root would register a bare
+    # `/gstack` command that collides with the package name.
+    rm -f "$PLUGIN_DIR/SKILL.md" "$PLUGIN_DIR/SKILL.md.tmpl"
+
+    # ─── Bundle runtime tools ─────────────────────────────────────
+    # gstack bin scripts shell out to bun, node, git, jq, curl. Bundle
+    # symlinks inside the plugin so they resolve without depending on
+    # the consumer's flox env having every one installed.
+    mkdir -p "$PLUGIN_DIR/tools/bin"
+    ln -s ${bun}/bin/bun        "$PLUGIN_DIR/tools/bin/bun"
+    ln -s ${nodejs}/bin/node    "$PLUGIN_DIR/tools/bin/node"
+    ln -s ${nodejs}/bin/npm     "$PLUGIN_DIR/tools/bin/npm"
+    ln -s ${nodejs}/bin/npx     "$PLUGIN_DIR/tools/bin/npx"
+    ln -s ${git}/bin/git        "$PLUGIN_DIR/tools/bin/git"
+    ln -s ${jq}/bin/jq          "$PLUGIN_DIR/tools/bin/jq"
+    ln -s ${curl}/bin/curl      "$PLUGIN_DIR/tools/bin/curl"
+
+    # ─── Synthesize plugin.json ───────────────────────────────────
+    mkdir -p "$PLUGIN_DIR/.claude-plugin"
+    cat > "$PLUGIN_DIR/.claude-plugin/plugin.json" <<'PLUGIN_JSON_EOF'
+    ${pluginManifest}
+    PLUGIN_JSON_EOF
+
+    # ─── Rewrite hardcoded skill-root paths ───────────────────────
+    # Upstream SKILL.md preambles hardcode
+    #   ~/.claude/skills/gstack/bin/...
+    #   .claude/skills/gstack/bin/...
+    # which only resolve under a standalone gstack install. In plugin
+    # mode, Claude Code exports CLAUDE_PLUGIN_ROOT for every Bash tool
+    # invocation — substitute that token so the preambles resolve to
+    # the bundled bin/, browse/, design/, make-pdf/ trees.
+    #
+    # The grep guards keep substituteInPlace from failing the build on
+    # files that don't contain the source token (--replace-fail
+    # semantics in nixpkgs).
+    rewritten=0
+    while IFS= read -r f; do
+      changed=0
+      if grep -q '~/\.claude/skills/gstack/' "$f"; then
+        substituteInPlace "$f" --replace-quiet \
+          '~/.claude/skills/gstack/' \
+          '${pluginRootRef}/'
+        changed=1
+      fi
+      if grep -q '"\$HOME"/\.claude/skills/gstack/' "$f"; then
+        substituteInPlace "$f" --replace-quiet \
+          '"$HOME"/.claude/skills/gstack/' \
+          '${pluginRootRef}/'
+        changed=1
+      fi
+      if grep -q '\$HOME/\.claude/skills/gstack/' "$f"; then
+        substituteInPlace "$f" --replace-quiet \
+          '$HOME/.claude/skills/gstack/' \
+          '${pluginRootRef}/'
+        changed=1
+      fi
+      if grep -q '\.claude/skills/gstack/' "$f"; then
+        substituteInPlace "$f" --replace-quiet \
+          '.claude/skills/gstack/' \
+          '${pluginRootRef}/'
+        changed=1
+      fi
+      [ $changed -eq 1 ] && rewritten=$((rewritten + 1))
+    done < <(find "$PLUGIN_DIR" -type f -name '*.md')
+    echo "rewrote skill-root path refs in $rewritten markdown file(s)"
+
+    # ─── Executable bits ──────────────────────────────────────────
+    # nix-store copies preserve mode for files originating as +x, but
+    # the gstack bin/ scripts ship without committed +x in some forks
+    # (Windows checkouts). Force +x on every bin entry.
+    find "$PLUGIN_DIR/bin" -type f -exec chmod +x {} +
+    # gstack's own setup script (not used in plugin mode, but harmless
+    # to keep executable for users inspecting the tree).
+    [ -f "$PLUGIN_DIR/setup" ] && chmod +x "$PLUGIN_DIR/setup" || true
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Garry Tan's Claude Code stack (gstack) — 45 skills covering "
+      + "planning, design, QA, review, security, and release "
+      + "management. Packaged as a Claude Code plugin.";
+    homepage = "https://github.com/garrytan/gstack";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/claude-code-plugin-gstack/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-gstack/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.40.0.0-026751e",
+  "rev": "026751ea2012ec7cbedc149ba615929a20026501",
+  "srcHash": "sha256-WSEtNduE8EDgXZ7Cv5HdvcK9nL38Bkz7cLaB78Bl6tw="
+}

--- a/.flox/pkgs/claude-code-plugin-gstack/publish.json
+++ b/.flox/pkgs/claude-code-plugin-gstack/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/claude-code-plugin-gstack/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-gstack/upgrade.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="garrytan"
+REPO="gstack"
+BRANCH="main"
+
+current_version=$(jq -r '.version // ""' "$HASHES_FILE")
+current_rev=$(jq -r '.rev // ""' "$HASHES_FILE")
+
+# Resolve current HEAD on main to a full SHA.
+rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/heads/$BRANCH" | awk '{print $1}')
+
+if [ -z "$rev" ]; then
+  echo "Failed to resolve $BRANCH on $OWNER/$REPO" >&2
+  exit 1
+fi
+
+# Read upstream VERSION file at this commit. gstack publishes
+# 4-segment versions (e.g. 1.40.0.0) in `VERSION` rather than
+# git tags or GitHub releases.
+upstream_version=$(curl -sfL \
+  "https://raw.githubusercontent.com/$OWNER/$REPO/$rev/VERSION" \
+  | tr -d '[:space:]')
+
+if [ -z "$upstream_version" ]; then
+  echo "Failed to read VERSION from $OWNER/$REPO@$rev" >&2
+  exit 1
+fi
+
+short_sha="${rev:0:7}"
+new_version="${upstream_version}-${short_sha}"
+
+echo "Current: $current_version (rev: ${current_rev:0:7})"
+echo "Latest:  $new_version (rev: $short_sha)"
+
+if [ "$current_rev" = "$rev" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating claude-code-plugin-gstack to $new_version"
+
+# Prefetch the source tarball and compute SRI hash.
+sha256_base32=$(nix-prefetch-url --unpack \
+  "https://github.com/$OWNER/$REPO/archive/$rev.tar.gz")
+sri_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$sha256_base32")
+
+jq -n \
+  --arg v "$new_version" \
+  --arg r "$rev" \
+  --arg h "$sri_hash" \
+  '{version: $v, rev: $r, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Wrote $HASHES_FILE:"
+cat "$HASHES_FILE"

--- a/.github/workflows/ci_gstack.yml
+++ b/.github/workflows/ci_gstack.yml
@@ -1,0 +1,36 @@
+name: "CI: gstack"
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "gstack/**"
+      - "gstack-demo/**"
+      - ".flox/pkgs/claude-code-plugin-gstack/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "scripts/**"
+      - ".github/workflows/environment.yml"
+  pull_request:
+    paths:
+      - "gstack/**"
+      - "gstack-demo/**"
+      - ".flox/pkgs/claude-code-plugin-gstack/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "scripts/**"
+      - ".github/workflows/environment.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: "read"
+  packages: "write"
+  attestations: "write"
+  id-token: "write"
+
+jobs:
+  run:
+    uses: "./.github/workflows/environment.yml"
+    with:
+      environment: "gstack"
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Most environments follow a dual-layer pattern:
 | _└ huggingface-demo_ | | [floxhub](https://hub.flox.dev/flox/huggingface-demo) · [docs](huggingface-demo/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/huggingface-demo-latest) |
 | graphify | Knowledge-graph skill for Claude Code | [floxhub](https://hub.flox.dev/flox/graphify) · [docs](graphify/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/graphify-latest) |
 | _└ graphify-demo_ | | [floxhub](https://hub.flox.dev/flox/graphify-demo) · [docs](graphify-demo/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/graphify-demo-latest) |
+| gstack | Garry Tan's Claude Code stack | [floxhub](https://hub.flox.dev/flox/gstack) · [docs](gstack/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/gstack-latest) |
+| _└ gstack-demo_ | | [floxhub](https://hub.flox.dev/flox/gstack-demo) · [docs](gstack-demo/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/gstack-demo-latest) |
 | langchain | LangChain + Ollama | [floxhub](https://hub.flox.dev/flox/langchain) · [docs](langchain/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/langchain-latest) |
 | _└ langchain-demo_ | | [floxhub](https://hub.flox.dev/flox/langchain-demo) · [docs](langchain-demo/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/langchain-demo-latest) |
 | verba | Verba RAG app | [floxhub](https://hub.flox.dev/flox/verba) · [docs](verba/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/verba-latest) |

--- a/gstack-demo/.flox/.gitignore
+++ b/gstack-demo/.flox/.gitignore
@@ -1,0 +1,4 @@
+run/
+cache/
+lib/
+log/

--- a/gstack-demo/.flox/env.json
+++ b/gstack-demo/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "gstack-demo",
+  "version": 1
+}

--- a/gstack-demo/.flox/env/manifest.lock
+++ b/gstack-demo/.flox/env/manifest.lock
@@ -1,0 +1,559 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "schema-version": "1.10.0",
+    "install": {
+      "claude-code": {
+        "pkg-path": "flox/claude-code",
+        "pkg-group": "claude-code"
+      },
+      "claude-code-plugin-gstack": {
+        "pkg-path": "flox/claude-code-plugin-gstack",
+        "pkg-group": "claude-code-plugin-gstack"
+      },
+      "claude-managed": {
+        "pkg-path": "flox/claude-managed",
+        "pkg-group": "claude-managed",
+        "version": "^0.4.1"
+      },
+      "gum": {
+        "pkg-path": "gum",
+        "pkg-group": "demo-tools"
+      }
+    },
+    "hook": {
+      "on-activate": "eval \"$(claude-managed setup-hook)\"\n\nif [ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]; then\n  gum style \\\n    --foreground 212 --border-foreground 212 \\\n    --border double --align center \\\n    --width 60 --margin \"1 2\" --padding \"1 2\" \\\n    \"gstack\" \"Garry Tan's Claude Code stack\"\n  echo \"\"\n  echo \"  claude                 — start Claude Code\"\n  echo \"  claude-managed doctor  — show config and validate\"\n  echo \"\"\n  echo \"  Try one of:\"\n  echo \"    /office-hours    Pitch an idea, get a CEO grill\"\n  echo \"    /plan-ceo-review Strategic challenge of a plan\"\n  echo \"    /review          Pre-landing review of a branch\"\n  echo \"    /qa              Browser-driven QA on a URL\"\n  echo \"    /ship            Open a PR with the gstack flow\"\n  echo \"\"\nfi\n"
+    },
+    "profile": {
+      "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
+      "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
+      "fish": "claude-managed setup-profile-fish | source\n"
+    },
+    "options": {}
+  },
+  "packages": [
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/8l2hay17dh0f2cnqdiww3h716nl078n9-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T23:07:12.035251Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gckpbs4vk8wyfgarr8w6wz53ykhxzbw1-claude-code-2.1.141"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/lg349nwky5rgl7gnmqyxzwagcwdp9x5h-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T23:07:12.035252Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gdzh2ynafj30iz3gvmplcrch92sgarm0-claude-code-2.1.141"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/ngx8rhlnfnxlfdjqwhawi5pri4ykd83f-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T23:07:12.035253Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ijkl9clcsgp9fvzg4qjb5xnv0v8gmkny-claude-code-2.1.141"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/f5p3akgnffldplwk394l5b27r499syxb-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T23:07:12.035253Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/n69zkbh80r7d9c7lw5wny45qg8yj78v5-claude-code-2.1.141"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-gstack",
+      "broken": false,
+      "derivation": "/nix/store/bah7ca14p9xgzv4vgy8kqd56kl7bx7wj-claude-code-plugin-gstack-1.40.0.0-026751e.drv",
+      "description": "Garry Tan's Claude Code stack (gstack) — 45 skills covering planning, design, QA, review, security, and release management. Packaged as a Claude Code plugin.",
+      "install_id": "claude-code-plugin-gstack",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "name": "claude-code-plugin-gstack-1.40.0.0-026751e",
+      "pname": "claude-code-plugin-gstack",
+      "rev": "d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "rev_count": 3405,
+      "rev_date": "2026-05-18T22:52:12Z",
+      "scrape_date": "2026-05-18T23:07:12.035256Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.40.0.0-026751e",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/73xrp28rgzdka2xmpjrasq7j43vhh0sg-claude-code-plugin-gstack-1.40.0.0-026751e"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-code-plugin-gstack",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-gstack",
+      "broken": false,
+      "derivation": "/nix/store/3645wyhis7bjnllf8i7a961asilrglv5-claude-code-plugin-gstack-1.40.0.0-026751e.drv",
+      "description": "Garry Tan's Claude Code stack (gstack) — 45 skills covering planning, design, QA, review, security, and release management. Packaged as a Claude Code plugin.",
+      "install_id": "claude-code-plugin-gstack",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "name": "claude-code-plugin-gstack-1.40.0.0-026751e",
+      "pname": "claude-code-plugin-gstack",
+      "rev": "d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "rev_count": 3405,
+      "rev_date": "2026-05-18T22:52:12Z",
+      "scrape_date": "2026-05-18T23:07:12.035257Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.40.0.0-026751e",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/654gdwsx8ms3jmm2hgmabsaxgvsqyizk-claude-code-plugin-gstack-1.40.0.0-026751e"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-code-plugin-gstack",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-gstack",
+      "broken": false,
+      "derivation": "/nix/store/5yvbbmclmc7l8gdzwhxy2c46nmv101sf-claude-code-plugin-gstack-1.40.0.0-026751e.drv",
+      "description": "Garry Tan's Claude Code stack (gstack) — 45 skills covering planning, design, QA, review, security, and release management. Packaged as a Claude Code plugin.",
+      "install_id": "claude-code-plugin-gstack",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "name": "claude-code-plugin-gstack-1.40.0.0-026751e",
+      "pname": "claude-code-plugin-gstack",
+      "rev": "d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "rev_count": 3405,
+      "rev_date": "2026-05-18T22:52:12Z",
+      "scrape_date": "2026-05-18T23:07:12.035257Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.40.0.0-026751e",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/3nr4l1x453f95gzv1fscg3939nrikgpi-claude-code-plugin-gstack-1.40.0.0-026751e"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-code-plugin-gstack",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-gstack",
+      "broken": false,
+      "derivation": "/nix/store/ygc36gvi3sj60qlif3czr3h0a2z2h1js-claude-code-plugin-gstack-1.40.0.0-026751e.drv",
+      "description": "Garry Tan's Claude Code stack (gstack) — 45 skills covering planning, design, QA, review, security, and release management. Packaged as a Claude Code plugin.",
+      "install_id": "claude-code-plugin-gstack",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "name": "claude-code-plugin-gstack-1.40.0.0-026751e",
+      "pname": "claude-code-plugin-gstack",
+      "rev": "d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "rev_count": 3405,
+      "rev_date": "2026-05-18T22:52:12Z",
+      "scrape_date": "2026-05-18T23:07:12.035258Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.40.0.0-026751e",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/z36kkp9s7fhhns4v69qvkxp7azbjjlj7-claude-code-plugin-gstack-1.40.0.0-026751e"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-code-plugin-gstack",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/w1klmic8k8a5iwgijlx0cm9yj48p8gih-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T23:07:12.035262Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ai6ahqbl18ai53h6qxs3jyfzx25xvlv2-claude-managed-0.4.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/hiz3gjm8xnaadxn8fcnn3cqv00ak7jmx-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T23:07:12.035267Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/kxhnszh6kirs6a024s0bnjyx04dy0rkx-claude-managed-0.4.1"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/7cbjxv67m749n5mw2pb0lkh2i82s292k-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T23:07:12.035268Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/5amvlx9kqjc19v0r9s0pianxpj60qz4l-claude-managed-0.4.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/snshhqypg93w1yr27gxz9c239z3i9nax-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T23:07:12.035268Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/nr2v9wsw4c1zry0hzkg9psfs7kksvh4l-claude-managed-0.4.1"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/3if65h5mjjgjwgvd18srmm35cn3w6xs8-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T07:05:52.142375Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ba53aq5kpjm2qb817qgxswy2hvnkxnyj-gum-0.17.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/ka558hvp8n0vhw8lzwsw66zw3g3lavzd-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T07:33:31.643735Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/3hlyv3x7jjn5364f08jw0bic3zddqhxc-gum-0.17.0"
+      },
+      "system": "aarch64-linux",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/z2rm91h36jx1ym7gpl3avxqqxc407pn2-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T08:01:18.656478Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/qkwxvmldb9a8nmqq6aqqd47gj3pxwx42-gum-0.17.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/835d9xq5q9w2hv6dzlsc3yjbh44kmpjn-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T08:32:12.167065Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/c149nbx8xh8knvply95623gnwqds19xr-gum-0.17.0"
+      },
+      "system": "x86_64-linux",
+      "group": "demo-tools",
+      "priority": 5
+    }
+  ],
+  "compose": {
+    "composer": {
+      "schema-version": "1.10.0",
+      "install": {
+        "gum": {
+          "pkg-path": "gum",
+          "pkg-group": "demo-tools"
+        }
+      },
+      "hook": {
+        "on-activate": "if [ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]; then\n  gum style \\\n    --foreground 212 --border-foreground 212 \\\n    --border double --align center \\\n    --width 60 --margin \"1 2\" --padding \"1 2\" \\\n    \"gstack\" \"Garry Tan's Claude Code stack\"\n  echo \"\"\n  echo \"  claude                 — start Claude Code\"\n  echo \"  claude-managed doctor  — show config and validate\"\n  echo \"\"\n  echo \"  Try one of:\"\n  echo \"    /office-hours    Pitch an idea, get a CEO grill\"\n  echo \"    /plan-ceo-review Strategic challenge of a plan\"\n  echo \"    /review          Pre-landing review of a branch\"\n  echo \"    /qa              Browser-driven QA on a URL\"\n  echo \"    /ship            Open a PR with the gstack flow\"\n  echo \"\"\nfi\n"
+      },
+      "options": {},
+      "include": {
+        "environments": [
+          {
+            "dir": "../gstack"
+          }
+        ]
+      }
+    },
+    "include": [
+      {
+        "manifest": {
+          "schema-version": "1.10.0",
+          "install": {
+            "claude-code": {
+              "pkg-path": "flox/claude-code",
+              "pkg-group": "claude-code"
+            },
+            "claude-code-plugin-gstack": {
+              "pkg-path": "flox/claude-code-plugin-gstack",
+              "pkg-group": "claude-code-plugin-gstack"
+            },
+            "claude-managed": {
+              "pkg-path": "flox/claude-managed",
+              "pkg-group": "claude-managed",
+              "version": "^0.4.1"
+            }
+          },
+          "hook": {
+            "on-activate": "eval \"$(claude-managed setup-hook)\"\n"
+          },
+          "profile": {
+            "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
+            "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
+            "fish": "claude-managed setup-profile-fish | source\n"
+          },
+          "options": {}
+        },
+        "name": "gstack",
+        "descriptor": {
+          "dir": "../gstack"
+        }
+      }
+    ],
+    "warnings": []
+  }
+}

--- a/gstack-demo/.flox/env/manifest.toml
+++ b/gstack-demo/.flox/env/manifest.toml
@@ -1,0 +1,32 @@
+schema-version = "1.10.0"
+
+[include]
+environments = [
+  { dir = "../gstack" }
+]
+
+[install]
+gum.pkg-path = "gum"
+gum.pkg-group = "demo-tools"
+
+[hook]
+on-activate = '''
+if [ "${FLOX_ENVS_TESTING:-}" != "1" ]; then
+  gum style \
+    --foreground 212 --border-foreground 212 \
+    --border double --align center \
+    --width 60 --margin "1 2" --padding "1 2" \
+    "gstack" "Garry Tan's Claude Code stack"
+  echo ""
+  echo "  claude                 — start Claude Code"
+  echo "  claude-managed doctor  — show config and validate"
+  echo ""
+  echo "  Try one of:"
+  echo "    /office-hours    Pitch an idea, get a CEO grill"
+  echo "    /plan-ceo-review Strategic challenge of a plan"
+  echo "    /review          Pre-landing review of a branch"
+  echo "    /qa              Browser-driven QA on a URL"
+  echo "    /ship            Open a PR with the gstack flow"
+  echo ""
+fi
+'''

--- a/gstack-demo/README.md
+++ b/gstack-demo/README.md
@@ -1,0 +1,26 @@
+# gstack Demo
+
+Interactive demo of the gstack environment with a
+styled welcome banner.
+
+## Quick start
+
+```bash
+flox activate -r flox/gstack-demo
+```
+
+Then start Claude Code (`claude`) and try one of the
+gstack skills printed on activation — `/office-hours`,
+`/plan-ceo-review`, `/review`, `/qa`, `/ship`.
+
+## What it provides
+
+Everything from [gstack](../gstack/) plus:
+
+- `gum` — styled terminal UI for the welcome banner
+
+## See also
+
+- [gstack](../gstack/) — minimal environment for
+  `[include]` composition
+- Upstream gstack: <https://github.com/garrytan/gstack>

--- a/gstack-demo/test.sh
+++ b/gstack-demo/test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+command_exists() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' command not found."
+    return 1
+  fi
+  echo ">>> '$1' command exists"
+}
+
+# ── Required commands (inherited from flox/claude + demo) ─
+command_exists claude
+command_exists claude-managed
+command_exists gum
+
+echo ">>> claude version: $(claude --version)"
+echo ">>> claude-managed version: $(claude-managed version)"
+echo ">>> gum version: $(gum --version)"
+
+# ── Managed mode ──────────────────────────────────────
+if [ "${CLAUDE_MANAGED:-}" != "1" ]; then
+  echo "Error: CLAUDE_MANAGED not set."
+  exit 1
+fi
+echo ">>> CLAUDE_MANAGED=1"
+
+# ── gstack plugin is installed ────────────────────────
+GSTACK_ROOT="$FLOX_ENV/share/claude-code/plugins/gstack"
+if [ ! -d "$GSTACK_ROOT" ]; then
+  echo "Error: gstack plugin dir missing: $GSTACK_ROOT"
+  exit 1
+fi
+echo ">>> gstack plugin root: $GSTACK_ROOT"
+
+if [ ! -f "$GSTACK_ROOT/.claude-plugin/plugin.json" ]; then
+  echo "Error: plugin.json missing"
+  exit 1
+fi
+echo ">>> plugin.json present"
+
+# ── Doctor check ──────────────────────────────────────
+echo ">>> claude-managed doctor"
+claude-managed doctor
+
+echo ">>> gstack-demo environment is working"

--- a/gstack/.flox/env.json
+++ b/gstack/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "gstack",
+  "version": 1
+}

--- a/gstack/.flox/env/manifest.lock
+++ b/gstack/.flox/env/manifest.lock
@@ -1,0 +1,431 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "schema-version": "1.10.0",
+    "install": {
+      "claude-code": {
+        "pkg-path": "flox/claude-code",
+        "pkg-group": "claude-code"
+      },
+      "claude-code-plugin-gstack": {
+        "pkg-path": "flox/claude-code-plugin-gstack",
+        "pkg-group": "claude-code-plugin-gstack"
+      },
+      "claude-managed": {
+        "pkg-path": "flox/claude-managed",
+        "pkg-group": "claude-managed",
+        "version": "^0.4.1"
+      }
+    },
+    "hook": {
+      "on-activate": "eval \"$(claude-managed setup-hook)\"\n"
+    },
+    "profile": {
+      "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
+      "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
+      "fish": "claude-managed setup-profile-fish | source\n"
+    },
+    "options": {}
+  },
+  "packages": [
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/8l2hay17dh0f2cnqdiww3h716nl078n9-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T23:07:03.438864Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gckpbs4vk8wyfgarr8w6wz53ykhxzbw1-claude-code-2.1.141"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/lg349nwky5rgl7gnmqyxzwagcwdp9x5h-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T23:07:03.438866Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gdzh2ynafj30iz3gvmplcrch92sgarm0-claude-code-2.1.141"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/ngx8rhlnfnxlfdjqwhawi5pri4ykd83f-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T23:07:03.438867Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ijkl9clcsgp9fvzg4qjb5xnv0v8gmkny-claude-code-2.1.141"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/f5p3akgnffldplwk394l5b27r499syxb-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T23:07:03.438868Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/n69zkbh80r7d9c7lw5wny45qg8yj78v5-claude-code-2.1.141"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-gstack",
+      "broken": false,
+      "derivation": "/nix/store/bah7ca14p9xgzv4vgy8kqd56kl7bx7wj-claude-code-plugin-gstack-1.40.0.0-026751e.drv",
+      "description": "Garry Tan's Claude Code stack (gstack) — 45 skills covering planning, design, QA, review, security, and release management. Packaged as a Claude Code plugin.",
+      "install_id": "claude-code-plugin-gstack",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "name": "claude-code-plugin-gstack-1.40.0.0-026751e",
+      "pname": "claude-code-plugin-gstack",
+      "rev": "d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "rev_count": 3405,
+      "rev_date": "2026-05-18T22:52:12Z",
+      "scrape_date": "2026-05-18T23:07:03.438885Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.40.0.0-026751e",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/73xrp28rgzdka2xmpjrasq7j43vhh0sg-claude-code-plugin-gstack-1.40.0.0-026751e"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-code-plugin-gstack",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-gstack",
+      "broken": false,
+      "derivation": "/nix/store/3645wyhis7bjnllf8i7a961asilrglv5-claude-code-plugin-gstack-1.40.0.0-026751e.drv",
+      "description": "Garry Tan's Claude Code stack (gstack) — 45 skills covering planning, design, QA, review, security, and release management. Packaged as a Claude Code plugin.",
+      "install_id": "claude-code-plugin-gstack",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "name": "claude-code-plugin-gstack-1.40.0.0-026751e",
+      "pname": "claude-code-plugin-gstack",
+      "rev": "d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "rev_count": 3405,
+      "rev_date": "2026-05-18T22:52:12Z",
+      "scrape_date": "2026-05-18T23:07:03.438886Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.40.0.0-026751e",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/654gdwsx8ms3jmm2hgmabsaxgvsqyizk-claude-code-plugin-gstack-1.40.0.0-026751e"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-code-plugin-gstack",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-gstack",
+      "broken": false,
+      "derivation": "/nix/store/5yvbbmclmc7l8gdzwhxy2c46nmv101sf-claude-code-plugin-gstack-1.40.0.0-026751e.drv",
+      "description": "Garry Tan's Claude Code stack (gstack) — 45 skills covering planning, design, QA, review, security, and release management. Packaged as a Claude Code plugin.",
+      "install_id": "claude-code-plugin-gstack",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "name": "claude-code-plugin-gstack-1.40.0.0-026751e",
+      "pname": "claude-code-plugin-gstack",
+      "rev": "d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "rev_count": 3405,
+      "rev_date": "2026-05-18T22:52:12Z",
+      "scrape_date": "2026-05-18T23:07:03.438887Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.40.0.0-026751e",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/3nr4l1x453f95gzv1fscg3939nrikgpi-claude-code-plugin-gstack-1.40.0.0-026751e"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-code-plugin-gstack",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-gstack",
+      "broken": false,
+      "derivation": "/nix/store/ygc36gvi3sj60qlif3czr3h0a2z2h1js-claude-code-plugin-gstack-1.40.0.0-026751e.drv",
+      "description": "Garry Tan's Claude Code stack (gstack) — 45 skills covering planning, design, QA, review, security, and release management. Packaged as a Claude Code plugin.",
+      "install_id": "claude-code-plugin-gstack",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "name": "claude-code-plugin-gstack-1.40.0.0-026751e",
+      "pname": "claude-code-plugin-gstack",
+      "rev": "d6201f5ef3663614fd723049f3a285c60abd8b7a",
+      "rev_count": 3405,
+      "rev_date": "2026-05-18T22:52:12Z",
+      "scrape_date": "2026-05-18T23:07:03.438888Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.40.0.0-026751e",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/z36kkp9s7fhhns4v69qvkxp7azbjjlj7-claude-code-plugin-gstack-1.40.0.0-026751e"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-code-plugin-gstack",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/w1klmic8k8a5iwgijlx0cm9yj48p8gih-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T23:07:03.438901Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ai6ahqbl18ai53h6qxs3jyfzx25xvlv2-claude-managed-0.4.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/hiz3gjm8xnaadxn8fcnn3cqv00ak7jmx-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T23:07:03.438902Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/kxhnszh6kirs6a024s0bnjyx04dy0rkx-claude-managed-0.4.1"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/7cbjxv67m749n5mw2pb0lkh2i82s292k-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T23:07:03.438903Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/5amvlx9kqjc19v0r9s0pianxpj60qz4l-claude-managed-0.4.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/snshhqypg93w1yr27gxz9c239z3i9nax-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T23:07:03.438904Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/nr2v9wsw4c1zry0hzkg9psfs7kksvh4l-claude-managed-0.4.1"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-managed",
+      "priority": 5
+    }
+  ],
+  "compose": {
+    "composer": {
+      "schema-version": "1.10.0",
+      "install": {
+        "claude-code-plugin-gstack": {
+          "pkg-path": "flox/claude-code-plugin-gstack",
+          "pkg-group": "claude-code-plugin-gstack"
+        }
+      },
+      "options": {},
+      "include": {
+        "environments": [
+          {
+            "remote": "flox/claude"
+          }
+        ]
+      }
+    },
+    "include": [
+      {
+        "manifest": {
+          "schema-version": "1.10.0",
+          "install": {
+            "claude-code": {
+              "pkg-path": "flox/claude-code",
+              "pkg-group": "claude-code"
+            },
+            "claude-managed": {
+              "pkg-path": "flox/claude-managed",
+              "pkg-group": "claude-managed",
+              "version": "^0.4.1"
+            }
+          },
+          "hook": {
+            "on-activate": "eval \"$(claude-managed setup-hook)\"\n"
+          },
+          "profile": {
+            "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
+            "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
+            "fish": "claude-managed setup-profile-fish | source\n"
+          },
+          "options": {}
+        },
+        "name": "claude",
+        "descriptor": {
+          "remote": "flox/claude"
+        }
+      }
+    ],
+    "warnings": []
+  }
+}

--- a/gstack/.flox/env/manifest.toml
+++ b/gstack/.flox/env/manifest.toml
@@ -14,7 +14,9 @@ schema-version = "1.10.0"
 # Upstream gstack: https://github.com/garrytan/gstack
 
 [include]
-environments = ["flox/claude"]
+environments = [
+  { remote = "flox/claude" }
+]
 
 [install]
 claude-code-plugin-gstack.pkg-path = "flox/claude-code-plugin-gstack"

--- a/gstack/.flox/env/manifest.toml
+++ b/gstack/.flox/env/manifest.toml
@@ -1,0 +1,21 @@
+schema-version = "1.10.0"
+
+# Minimal gstack environment for use with [include].
+#
+# Layers Garry Tan's gstack (45 skills covering planning,
+# design, QA, code review, security, and shipping) onto
+# the flox/claude managed Claude Code config.
+#
+# Include it in your own manifest:
+#
+#   [include]
+#   environments = ["flox/gstack"]
+#
+# Upstream gstack: https://github.com/garrytan/gstack
+
+[include]
+environments = ["flox/claude"]
+
+[install]
+claude-code-plugin-gstack.pkg-path = "flox/claude-code-plugin-gstack"
+claude-code-plugin-gstack.pkg-group = "claude-code-plugin-gstack"

--- a/gstack/README.md
+++ b/gstack/README.md
@@ -1,0 +1,114 @@
+# gstack
+
+Ready-to-use environment for [gstack][upstream] —
+Garry Tan's Claude Code stack of 45 opinionated skills
+covering planning, design, QA, code review, security,
+and shipping. Layered on top of `flox/claude` so the
+skills get discovered through the managed config.
+
+[upstream]: https://github.com/garrytan/gstack
+
+## Quick start
+
+Include in your manifest:
+
+```toml
+[include]
+environments = ["flox/gstack"]
+```
+
+Then `flox activate` and start invoking gstack skills
+from Claude Code (`/qa`, `/review`, `/ship`,
+`/office-hours`, …).
+
+## What it provides
+
+Everything from [`claude`](../claude/) plus the
+`claude-code-plugin-gstack` package, which installs the
+gstack plugin tree at
+`$FLOX_ENV/share/claude-code/plugins/gstack/`.
+
+`claude-managed` discovers the plugin and symlinks it
+into the project-local `$CLAUDE_CONFIG_DIR/plugins/`,
+so all 45 skills become available without touching
+`~/.claude/`.
+
+### Bundled runtime tools
+
+Several gstack skills shell out to `bun`, `node`,
+`git`, `jq`, and `curl`. These are bundled inside the
+plugin tree at `plugins/gstack/tools/bin/` and resolved
+via `${CLAUDE_PLUGIN_ROOT}` — no need for the consumer
+flox env to install them separately for skills to run.
+
+### Skills
+
+- Planning: `/office-hours`, `/plan-ceo-review`,
+  `/plan-eng-review`, `/plan-design-review`,
+  `/plan-devex-review`, `/plan-tune`, `/autoplan`
+- Design: `/design-consultation`, `/design-html`,
+  `/design-shotgun`, `/design-review`
+- Review: `/review`, `/devex-review`, `/cso` (security)
+- QA: `/qa`, `/qa-only`, `/careful`, `/guard`,
+  `/freeze`, `/unfreeze`
+- Shipping: `/ship`, `/land-and-deploy`, `/canary`,
+  `/document-release`, `/document-generate`
+- Debugging & ops: `/investigate`, `/retro`,
+  `/health`, `/learn`, `/benchmark`,
+  `/benchmark-models`
+- Browser & docs: `/browse`, `/open-gstack-browser`,
+  `/setup-browser-cookies`, `/make-pdf`, `/scrape`
+- Context: `/context-save`, `/context-restore`,
+  `/pair-agent`, `/codex`, `/landing-report`
+- Maintenance: `/gstack-upgrade`, `/skillify`,
+  `/setup-deploy`, `/setup-gbrain`, `/sync-gbrain`
+
+Full list and per-skill docs live under
+`plugins/gstack/skills/<name>/SKILL.md`.
+
+## Caveats
+
+### Compiled CLIs (`browse`, `design`, `make-pdf`)
+
+gstack's `/browse`, `/design-*`, and `/make-pdf` skills
+shell out to bun-compiled binaries that upstream
+produces with `bun install && bun run build`. We don't
+run that at Nix build time (it pulls Playwright,
+Puppeteer, and other JS deps from the network into a
+read-only nix store path).
+
+If you want those skills to work, run inside an
+activated environment, once, in a writable copy:
+
+```bash
+cp -R "$FLOX_ENV/share/claude-code/plugins/gstack" /tmp/gstack-build
+cd /tmp/gstack-build
+"$FLOX_ENV/share/claude-code/plugins/gstack/tools/bin/bun" install
+"$FLOX_ENV/share/claude-code/plugins/gstack/tools/bin/bun" run build
+```
+
+…then point gstack at the build directory via
+`CLAUDE_PLUGIN_ROOT`. The text-only skills (everything
+else) work without the build step.
+
+### Telemetry, state, learnings
+
+gstack writes session/telemetry/learnings state under
+`$HOME/.gstack/` by default (or `$CLAUDE_PLUGIN_DATA`
+if Claude Code exports it). The plugin tree itself is
+read-only — `gstack-config` writes go to the state
+dir, not into the nix store.
+
+### Standalone gstack install
+
+If you already have gstack cloned at
+`~/.claude/skills/gstack/` (the upstream-recommended
+install), the plugin install is independent and
+non-conflicting — `claude-managed` only touches its
+own config dir. Both can coexist, though Claude Code
+may surface duplicate skill names.
+
+## See also
+
+- [gstack-demo](../gstack-demo/) — interactive demo
+- Upstream: <https://github.com/garrytan/gstack>

--- a/gstack/test.sh
+++ b/gstack/test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+command_exists() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' command not found."
+    return 1
+  fi
+  echo ">>> '$1' command exists"
+}
+
+# ── Required commands (inherited from flox/claude) ────
+command_exists claude
+command_exists claude-managed
+
+echo ">>> claude version: $(claude --version)"
+echo ">>> claude-managed version: $(claude-managed version)"
+
+# ── Managed mode ──────────────────────────────────────
+if [ "${CLAUDE_MANAGED:-}" != "1" ]; then
+  echo "Error: CLAUDE_MANAGED not set."
+  exit 1
+fi
+echo ">>> CLAUDE_MANAGED=1"
+
+if [ -z "${CLAUDE_CONFIG_DIR:-}" ]; then
+  echo "Error: CLAUDE_CONFIG_DIR not set."
+  exit 1
+fi
+echo ">>> CLAUDE_CONFIG_DIR=$CLAUDE_CONFIG_DIR"
+
+# ── gstack plugin is installed ────────────────────────
+GSTACK_ROOT="$FLOX_ENV/share/claude-code/plugins/gstack"
+if [ ! -d "$GSTACK_ROOT" ]; then
+  echo "Error: gstack plugin dir missing: $GSTACK_ROOT"
+  exit 1
+fi
+echo ">>> gstack plugin root: $GSTACK_ROOT"
+
+if [ ! -f "$GSTACK_ROOT/.claude-plugin/plugin.json" ]; then
+  echo "Error: plugin.json missing"
+  exit 1
+fi
+echo ">>> plugin.json present"
+
+skill_count=$(find "$GSTACK_ROOT/skills" -maxdepth 1 -mindepth 1 \
+  \( -type d -o -type l \) | wc -l | tr -d ' ')
+if [ "$skill_count" -lt 40 ]; then
+  echo "Error: expected at least 40 skills, found $skill_count"
+  exit 1
+fi
+echo ">>> skills/ has $skill_count entries"
+
+# ── Bundled runtime tools ─────────────────────────────
+for tool in bun node git jq curl; do
+  if [ ! -x "$GSTACK_ROOT/tools/bin/$tool" ]; then
+    echo "Error: bundled tool missing: $tool"
+    exit 1
+  fi
+done
+echo ">>> bundled tools present"
+
+# ── Plugin is discoverable through claude-managed ─────
+echo ">>> claude-managed doctor"
+claude-managed doctor
+
+echo ">>> gstack environment is working"


### PR DESCRIPTION
## Summary

- New custom package `flox/claude-code-plugin-gstack` packaging [garrytan/gstack](https://github.com/garrytan/gstack) v1.40.0.0 (pinned to commit `026751e`) as a Claude Code plugin
- New `gstack/` minimal env (`[include]`s `flox/claude` + installs the plugin) and `gstack-demo/` interactive env (adds `gum` welcome banner)
- All four target systems published to FloxHub; lockfiles generated

## What's interesting about this package

Upstream gstack is designed for the **legacy** `~/.claude/skills/gstack/` install path: each skill dir sits at the top level of the repo and references siblings via hardcoded paths. There is no `.claude-plugin/plugin.json`.

The derivation handles this by:

- **Synthesizing** a plugin manifest under `.claude-plugin/plugin.json`
- **Exposing** the 46 skill directories under `skills/<name>/` via symlinks — the plugin loader finds them while upstream cross-references at the root (`bin/`, `lib/`, `design/dist/`, etc.) keep resolving
- **Bundling** `bun`, `node`, `npm`, `npx`, `git`, `jq`, `curl` under `tools/bin/` so SKILL.md preambles that shell out resolve without depending on the consumer env having every tool
- **Rewriting** hardcoded `~/.claude/skills/gstack/<path>` references to `\${CLAUDE_PLUGIN_ROOT}/<path>` across SKILL.md files (Claude Code exports `CLAUDE_PLUGIN_ROOT` for every Bash tool invocation inside a plugin)

### What's not packaged

The bun-compiled CLIs (`browse/dist/browse`, `design/dist/design`, `make-pdf/dist/pdf`) are skipped — they need `bun install && bun run build` which pulls Playwright/Puppeteer into a read-only nix store path at build time. The 40 text-driven skills (`/office-hours`, `/plan-ceo-review`, `/review`, `/ship`, `/cso`, …) work without them. `gstack/README.md` documents a one-time writable-copy build for users who want the browser/PDF tooling.

## Test plan

- [x] `nix-build` produces a 39MB plugin tree at `$out/share/claude-code/plugins/gstack/`
- [x] `flox publish -o flox claude-code-plugin-gstack` succeeds for all four systems
- [x] `flox edit -f` generates lockfiles for both envs against the published package
- [x] `flox activate -c 'bash test.sh'` passes for `gstack/` and `gstack-demo/`
- [x] `claude-managed doctor` reports `✓ gstack` plugin
- [x] 46 skills discovered under `skills/`
- [x] Bundled `tools/bin/{bun,node,git,jq,curl}` present
- [ ] CI green