### PR TITLE
feat: add caveman plugin and envs (JuliusBrussee/caveman v1.8.2)

### DIFF
--- a/.flox/pkgs/claude-code-plugin-caveman/default.nix
+++ b/.flox/pkgs/claude-code-plugin-caveman/default.nix
@@ -1,0 +1,162 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  nodejs,
+  python3,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash;
+
+  # Escape so the indented-string interpolation below produces the
+  # literal token `${CLAUDE_PLUGIN_ROOT}` in the resulting bash, with
+  # no further Nix or bash expansion.
+  pluginRootRef = "\${CLAUDE_PLUGIN_ROOT}";
+in
+stdenv.mkDerivation {
+  pname = "claude-code-plugin-caveman";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "JuliusBrussee";
+    repo = "caveman";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    PLUGIN_DIR="$out/share/claude-code/plugins/caveman"
+    mkdir -p "$PLUGIN_DIR"
+
+    # Upstream ships the Claude Code plugin source at the repo root —
+    # `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
+    # both reference `./` as the plugin source. Copy the whole tree, then
+    # strip per-harness mirrors, dev-only metadata, and the installer
+    # entry points so Claude Code doesn't try to load or surface them
+    # as plugin content.
+    cp -r "$src"/. "$PLUGIN_DIR/"
+    chmod -R u+w "$PLUGIN_DIR"
+
+    rm -rf "$PLUGIN_DIR/.codex" \
+           "$PLUGIN_DIR/.junie" \
+           "$PLUGIN_DIR/.kiro" \
+           "$PLUGIN_DIR/.roo" \
+           "$PLUGIN_DIR/.agents" \
+           "$PLUGIN_DIR/.github" \
+           "$PLUGIN_DIR/.gitignore" \
+           "$PLUGIN_DIR/.gitattributes" \
+           "$PLUGIN_DIR/AGENTS.md" \
+           "$PLUGIN_DIR/GEMINI.md" \
+           "$PLUGIN_DIR/CLAUDE.md" \
+           "$PLUGIN_DIR/CONTRIBUTING.md" \
+           "$PLUGIN_DIR/INSTALL.md" \
+           "$PLUGIN_DIR/gemini-extension.json" \
+           "$PLUGIN_DIR/install.sh" \
+           "$PLUGIN_DIR/install.ps1" \
+           "$PLUGIN_DIR/package.json" \
+           "$PLUGIN_DIR/skills-lock.json" \
+           "$PLUGIN_DIR/bin" \
+           "$PLUGIN_DIR/dist" \
+           "$PLUGIN_DIR/docs" \
+           "$PLUGIN_DIR/evals" \
+           "$PLUGIN_DIR/benchmarks" \
+           "$PLUGIN_DIR/tests" \
+           "$PLUGIN_DIR/plugins" \
+           "$PLUGIN_DIR/src/plugins" \
+           "$PLUGIN_DIR/src/rules" \
+           "$PLUGIN_DIR/src/tools"
+
+    # The commands/ directory ships *only* Codex-flavored `.toml` files
+    # at the upstream root. Claude Code's plugin loader picks up `.md`
+    # files from `commands/` and would otherwise warn on the `.toml`s.
+    # Drop them — Claude Code users drive caveman through the
+    # UserPromptSubmit hook (which matches `/caveman …` in raw input),
+    # so removing the TOMLs doesn't lose functionality on this harness.
+    rm -rf "$PLUGIN_DIR/commands"
+
+    # Bundle node + python so the runtime dependencies of the hooks
+    # (Node) and the caveman-compress skill scripts (Python) resolve
+    # without requiring the consumer's flox env to install either one.
+    # Plain symlinks — no makeBinaryWrapper, no PATH prefix — because
+    # caveman's Node hooks use only stdlib (fs, path, os, child_process
+    # calling itself via process.execPath), and the Python scripts use
+    # only stdlib (subprocess + the `claude` CLI which the consumer env
+    # is expected to provide via flox/claude-code).
+    mkdir -p "$PLUGIN_DIR/bin"
+    ln -s "${nodejs}/bin/node" "$PLUGIN_DIR/bin/node"
+    ln -s "${python3}/bin/python3" "$PLUGIN_DIR/bin/python3"
+
+    # Repoint every #!/usr/bin/env node shebang at the bundled node.
+    # Marks files executable so the kernel honors the shebang when
+    # Claude Code (or the SessionStart / UserPromptSubmit hook command)
+    # invokes them.
+    while IFS= read -r f; do
+      head -1 "$f" | grep -q '/usr/bin/env node' || continue
+      substituteInPlace "$f" --replace-fail \
+        '#!/usr/bin/env node' "#!$PLUGIN_DIR/bin/node"
+      chmod +x "$f"
+    done < <(find "$PLUGIN_DIR" -type f \
+              \( -name '*.js' -o -name '*.mjs' -o -name '*.cjs' \))
+
+    # Repoint every #!/usr/bin/env python3 shebang at the bundled
+    # python3 for the same reason. caveman-compress invokes scripts as
+    # a module (`python3 -m scripts …`), but the individual files also
+    # carry shebangs and may be invoked directly during development.
+    while IFS= read -r f; do
+      head -1 "$f" | grep -q '/usr/bin/env python3' || continue
+      substituteInPlace "$f" --replace-fail \
+        '#!/usr/bin/env python3' "#!$PLUGIN_DIR/bin/python3"
+      chmod +x "$f"
+    done < <(find "$PLUGIN_DIR" -type f -name '*.py')
+
+    # Rewrite the bare `node "${pluginRootRef}/..."` invocations in
+    # plugin.json (SessionStart + UserPromptSubmit hooks) to use the
+    # bundled node by absolute path. Upstream assumes `node` is on the
+    # caller's PATH, which it isn't under flox unless the consumer env
+    # also installs nodejs — and we don't want to force that, since the
+    # whole point of bundling node here is to avoid it. The file ships
+    # the path as a JSON string with escaped quotes, so the literal
+    # bytes to match are `node \"${pluginRootRef}/`.
+    substituteInPlace "$PLUGIN_DIR/.claude-plugin/plugin.json" \
+      --replace-fail \
+      'node \"${pluginRootRef}/' \
+      '\"${pluginRootRef}/bin/node\" \"${pluginRootRef}/'
+
+    # Rewrite the caveman-compress invocation in SKILL.md so it uses
+    # the bundled python3 rather than the consumer's PATH. Upstream
+    # tells Claude to "cd to the SKILL.md directory, then run
+    # `python3 -m scripts <filepath>`" — that fails on consumer envs
+    # that don't ship python3. The bundled `bin/python3` is at the
+    # plugin root, two levels up from `skills/caveman-compress/`.
+    compress_skill="$PLUGIN_DIR/skills/caveman-compress/SKILL.md"
+    if [ -f "$compress_skill" ]; then
+      substituteInPlace "$compress_skill" --replace-fail \
+        'python3 -m scripts' \
+        '${pluginRootRef}/bin/python3 -m scripts'
+    fi
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Caveman plugin for Claude Code — ultra-compressed communication "
+      + "mode (7 skills + SessionStart/UserPromptSubmit hooks) with "
+      + "Node.js and Python bundled for the hooks and compress scripts.";
+    homepage = "https://github.com/JuliusBrussee/caveman";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/claude-code-plugin-caveman/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-caveman/hashes.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.8.2",
+  "srcHash": "sha256-Jlfas2MPoQx3pOw+yKCta8kYlOEY27SP5NXJtSL+GGI="
+}

--- a/.flox/pkgs/claude-code-plugin-caveman/publish.json
+++ b/.flox/pkgs/claude-code-plugin-caveman/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/claude-code-plugin-caveman/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-caveman/upgrade.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+
+# Upstream tags releases as `vX.Y.Z`. Pull the latest such tag.
+latest_tag=$(curl -sf \
+  https://api.github.com/repos/JuliusBrussee/caveman/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating claude-code-plugin-caveman from $current_version to $latest_version"
+
+src_url="https://github.com/JuliusBrussee/caveman/archive/refs/tags/v${latest_version}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  '{version: $v, srcHash: $s}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/caveman-demo/.flox/env.json
+++ b/caveman-demo/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "caveman-demo",
+  "version": 1
+}

--- a/caveman-demo/.flox/env/manifest.lock
+++ b/caveman-demo/.flox/env/manifest.lock
@@ -1,0 +1,559 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "schema-version": "1.11.0",
+    "install": {
+      "claude-code": {
+        "pkg-path": "flox/claude-code",
+        "pkg-group": "claude-code"
+      },
+      "claude-code-plugin-caveman": {
+        "pkg-path": "flox/claude-code-plugin-caveman",
+        "pkg-group": "claude-code-plugin-caveman"
+      },
+      "claude-managed": {
+        "pkg-path": "flox/claude-managed",
+        "pkg-group": "claude-managed",
+        "version": "^0.4.1"
+      },
+      "gum": {
+        "pkg-path": "gum",
+        "pkg-group": "demo-tools"
+      }
+    },
+    "hook": {
+      "on-activate": "eval \"$(claude-managed setup-hook)\"\n\nif [ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]; then\n  gum style \\\n    --foreground 212 --border-foreground 212 \\\n    --border double --align center \\\n    --width 50 --margin \"1 2\" --padding \"1 2\" \\\n    \"Caveman Mode\" \"Talk like caveman. Save ~75% tokens.\"\n  echo \"\"\n  echo \"  claude           — start Claude Code\"\n  echo \"  /caveman         — toggle caveman mode (default: full)\"\n  echo \"  /caveman lite    — drop filler only, keep grammar\"\n  echo \"  /caveman ultra   — extreme abbreviation\"\n  echo \"  /caveman wenyan-full — classical-Chinese style\"\n  echo \"  /caveman-help    — full reference card\"\n  echo \"  /caveman-stats   — show real session token usage\"\n  echo \"\"\nfi\n"
+    },
+    "profile": {
+      "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
+      "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
+      "fish": "claude-managed setup-profile-fish | source\n"
+    },
+    "options": {}
+  },
+  "packages": [
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/8l2hay17dh0f2cnqdiww3h716nl078n9-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:56:28.627365Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gckpbs4vk8wyfgarr8w6wz53ykhxzbw1-claude-code-2.1.141"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/lg349nwky5rgl7gnmqyxzwagcwdp9x5h-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:56:28.627367Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gdzh2ynafj30iz3gvmplcrch92sgarm0-claude-code-2.1.141"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/ngx8rhlnfnxlfdjqwhawi5pri4ykd83f-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:56:28.627367Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ijkl9clcsgp9fvzg4qjb5xnv0v8gmkny-claude-code-2.1.141"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/f5p3akgnffldplwk394l5b27r499syxb-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:56:28.627368Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/n69zkbh80r7d9c7lw5wny45qg8yj78v5-claude-code-2.1.141"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-caveman",
+      "broken": false,
+      "derivation": "/nix/store/scxp2q8mc2zvai34835qfbc3mig5kvp0-claude-code-plugin-caveman-1.8.2.drv",
+      "description": "Caveman plugin for Claude Code — ultra-compressed communication mode (7 skills + SessionStart/UserPromptSubmit hooks) with Node.js and Python bundled for the hooks and compress scripts.",
+      "install_id": "claude-code-plugin-caveman",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "name": "claude-code-plugin-caveman-1.8.2",
+      "pname": "claude-code-plugin-caveman",
+      "rev": "b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:48:55Z",
+      "scrape_date": "2026-05-18T22:56:28.627371Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.8.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/8fack9l3dmgcpy06lg81kii4h3ffb5g7-claude-code-plugin-caveman-1.8.2"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-code-plugin-caveman",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-caveman",
+      "broken": false,
+      "derivation": "/nix/store/5cp8ilg11drb4z7shsmpb959m8837vsi-claude-code-plugin-caveman-1.8.2.drv",
+      "description": "Caveman plugin for Claude Code — ultra-compressed communication mode (7 skills + SessionStart/UserPromptSubmit hooks) with Node.js and Python bundled for the hooks and compress scripts.",
+      "install_id": "claude-code-plugin-caveman",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "name": "claude-code-plugin-caveman-1.8.2",
+      "pname": "claude-code-plugin-caveman",
+      "rev": "b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:48:55Z",
+      "scrape_date": "2026-05-18T22:56:28.627372Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.8.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/5dfq5l3qfph7vzy2aypz469h50fvm0f4-claude-code-plugin-caveman-1.8.2"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-code-plugin-caveman",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-caveman",
+      "broken": false,
+      "derivation": "/nix/store/9kjpr6ckgz4nkzf78z9c1n7s71aqxj65-claude-code-plugin-caveman-1.8.2.drv",
+      "description": "Caveman plugin for Claude Code — ultra-compressed communication mode (7 skills + SessionStart/UserPromptSubmit hooks) with Node.js and Python bundled for the hooks and compress scripts.",
+      "install_id": "claude-code-plugin-caveman",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "name": "claude-code-plugin-caveman-1.8.2",
+      "pname": "claude-code-plugin-caveman",
+      "rev": "b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:48:55Z",
+      "scrape_date": "2026-05-18T22:56:28.627373Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.8.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/agssd364yc59fc2g8xqv2wb4s0vh3msw-claude-code-plugin-caveman-1.8.2"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-code-plugin-caveman",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-caveman",
+      "broken": false,
+      "derivation": "/nix/store/pzddqkgwr94z467gslcvhz1llra6ajji-claude-code-plugin-caveman-1.8.2.drv",
+      "description": "Caveman plugin for Claude Code — ultra-compressed communication mode (7 skills + SessionStart/UserPromptSubmit hooks) with Node.js and Python bundled for the hooks and compress scripts.",
+      "install_id": "claude-code-plugin-caveman",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "name": "claude-code-plugin-caveman-1.8.2",
+      "pname": "claude-code-plugin-caveman",
+      "rev": "b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:48:55Z",
+      "scrape_date": "2026-05-18T22:56:28.627373Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.8.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/4mm584rv9vm8ia8hwv0igkqx8wppkfsb-claude-code-plugin-caveman-1.8.2"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-code-plugin-caveman",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/w1klmic8k8a5iwgijlx0cm9yj48p8gih-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:56:28.627378Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ai6ahqbl18ai53h6qxs3jyfzx25xvlv2-claude-managed-0.4.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/hiz3gjm8xnaadxn8fcnn3cqv00ak7jmx-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:56:28.627383Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/kxhnszh6kirs6a024s0bnjyx04dy0rkx-claude-managed-0.4.1"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/7cbjxv67m749n5mw2pb0lkh2i82s292k-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:56:28.627384Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/5amvlx9kqjc19v0r9s0pianxpj60qz4l-claude-managed-0.4.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/snshhqypg93w1yr27gxz9c239z3i9nax-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:56:28.627384Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/nr2v9wsw4c1zry0hzkg9psfs7kksvh4l-claude-managed-0.4.1"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/3if65h5mjjgjwgvd18srmm35cn3w6xs8-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T07:05:52.142375Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ba53aq5kpjm2qb817qgxswy2hvnkxnyj-gum-0.17.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/ka558hvp8n0vhw8lzwsw66zw3g3lavzd-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T07:33:31.643735Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/3hlyv3x7jjn5364f08jw0bic3zddqhxc-gum-0.17.0"
+      },
+      "system": "aarch64-linux",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/z2rm91h36jx1ym7gpl3avxqqxc407pn2-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T08:01:18.656478Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/qkwxvmldb9a8nmqq6aqqd47gj3pxwx42-gum-0.17.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/835d9xq5q9w2hv6dzlsc3yjbh44kmpjn-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T08:32:12.167065Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/c149nbx8xh8knvply95623gnwqds19xr-gum-0.17.0"
+      },
+      "system": "x86_64-linux",
+      "group": "demo-tools",
+      "priority": 5
+    }
+  ],
+  "compose": {
+    "composer": {
+      "schema-version": "1.11.0",
+      "install": {
+        "gum": {
+          "pkg-path": "gum",
+          "pkg-group": "demo-tools"
+        }
+      },
+      "hook": {
+        "on-activate": "if [ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]; then\n  gum style \\\n    --foreground 212 --border-foreground 212 \\\n    --border double --align center \\\n    --width 50 --margin \"1 2\" --padding \"1 2\" \\\n    \"Caveman Mode\" \"Talk like caveman. Save ~75% tokens.\"\n  echo \"\"\n  echo \"  claude           — start Claude Code\"\n  echo \"  /caveman         — toggle caveman mode (default: full)\"\n  echo \"  /caveman lite    — drop filler only, keep grammar\"\n  echo \"  /caveman ultra   — extreme abbreviation\"\n  echo \"  /caveman wenyan-full — classical-Chinese style\"\n  echo \"  /caveman-help    — full reference card\"\n  echo \"  /caveman-stats   — show real session token usage\"\n  echo \"\"\nfi\n"
+      },
+      "options": {},
+      "include": {
+        "environments": [
+          {
+            "dir": "../caveman"
+          }
+        ]
+      }
+    },
+    "include": [
+      {
+        "manifest": {
+          "schema-version": "1.10.0",
+          "install": {
+            "claude-code": {
+              "pkg-path": "flox/claude-code",
+              "pkg-group": "claude-code"
+            },
+            "claude-code-plugin-caveman": {
+              "pkg-path": "flox/claude-code-plugin-caveman",
+              "pkg-group": "claude-code-plugin-caveman"
+            },
+            "claude-managed": {
+              "pkg-path": "flox/claude-managed",
+              "pkg-group": "claude-managed",
+              "version": "^0.4.1"
+            }
+          },
+          "hook": {
+            "on-activate": "eval \"$(claude-managed setup-hook)\"\n"
+          },
+          "profile": {
+            "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
+            "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
+            "fish": "claude-managed setup-profile-fish | source\n"
+          },
+          "options": {}
+        },
+        "name": "caveman",
+        "descriptor": {
+          "dir": "../caveman"
+        }
+      }
+    ],
+    "warnings": []
+  }
+}

--- a/caveman-demo/.flox/env/manifest.toml
+++ b/caveman-demo/.flox/env/manifest.toml
@@ -1,0 +1,30 @@
+schema-version = "1.11.0"
+
+[include]
+environments = [
+  { dir = "../caveman" }
+]
+
+[install]
+gum.pkg-path = "gum"
+gum.pkg-group = "demo-tools"
+
+[hook]
+on-activate = '''
+if [ "${FLOX_ENVS_TESTING:-}" != "1" ]; then
+  gum style \
+    --foreground 212 --border-foreground 212 \
+    --border double --align center \
+    --width 50 --margin "1 2" --padding "1 2" \
+    "Caveman Mode" "Talk like caveman. Save ~75% tokens."
+  echo ""
+  echo "  claude           — start Claude Code"
+  echo "  /caveman         — toggle caveman mode (default: full)"
+  echo "  /caveman lite    — drop filler only, keep grammar"
+  echo "  /caveman ultra   — extreme abbreviation"
+  echo "  /caveman wenyan-full — classical-Chinese style"
+  echo "  /caveman-help    — full reference card"
+  echo "  /caveman-stats   — show real session token usage"
+  echo ""
+fi
+'''

--- a/caveman-demo/README.md
+++ b/caveman-demo/README.md
@@ -1,0 +1,27 @@
+# Caveman Demo
+
+Interactive demo of the
+[caveman](https://github.com/JuliusBrussee/caveman)
+plugin for Claude Code -- ultra-compressed
+communication mode with a styled welcome banner.
+
+## Quick start
+
+```bash
+flox activate -r flox/caveman-demo
+```
+
+## What it provides
+
+Everything from [caveman](../caveman/) plus:
+
+- `gum` -- styled terminal UI
+- Welcome banner on activate with a cheat sheet of
+  the `/caveman` slash commands and intensity levels
+
+## See also
+
+- [caveman](../caveman/) -- minimal environment for
+  `[include]`
+- [claude](../claude/) -- the base Claude Code
+  environment caveman builds on

--- a/caveman-demo/test.sh
+++ b/caveman-demo/test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+command_exists() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' command not found."
+    return 1
+  fi
+  echo ">>> '$1' command exists"
+}
+
+# ── Required commands ─────────────────────────────────
+command_exists claude
+command_exists claude-managed
+command_exists gum
+
+echo ">>> claude version: $(claude --version)"
+echo ">>> claude-managed version: $(claude-managed version)"
+echo ">>> gum version: $(gum --version)"
+
+# ── Managed mode ──────────────────────────────────────
+if [ "${CLAUDE_MANAGED:-}" != "1" ]; then
+  echo "Error: CLAUDE_MANAGED not set."
+  exit 1
+fi
+echo ">>> CLAUDE_MANAGED=1"
+
+if [ -z "${CLAUDE_CONFIG_DIR:-}" ]; then
+  echo "Error: CLAUDE_CONFIG_DIR not set."
+  exit 1
+fi
+echo ">>> CLAUDE_CONFIG_DIR=$CLAUDE_CONFIG_DIR"
+
+if [ "${CLAUDE_CODE_DISABLE_AUTO_MEMORY:-}" != "1" ]; then
+  echo "Error: CLAUDE_CODE_DISABLE_AUTO_MEMORY not set."
+  exit 1
+fi
+echo ">>> CLAUDE_CODE_DISABLE_AUTO_MEMORY=1"
+
+# ── Config dir exists ─────────────────────────────────
+if [ ! -d "$CLAUDE_CONFIG_DIR" ]; then
+  echo "Error: CLAUDE_CONFIG_DIR does not exist: $CLAUDE_CONFIG_DIR"
+  exit 1
+fi
+echo ">>> config dir exists"
+
+# ── Caveman plugin discoverable ──────────────────────
+plugin_dir="$FLOX_ENV/share/claude-code/plugins/caveman"
+if [ ! -d "$plugin_dir" ]; then
+  echo "Error: caveman plugin dir missing: $plugin_dir"
+  exit 1
+fi
+echo ">>> caveman plugin dir exists"
+
+# ── Doctor check ──────────────────────────────────────
+echo ">>> claude-managed doctor"
+claude-managed doctor
+
+echo ">>> caveman-demo environment is working"

--- a/caveman/.flox/env.json
+++ b/caveman/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "caveman",
+  "version": 1
+}

--- a/caveman/.flox/env/manifest.lock
+++ b/caveman/.flox/env/manifest.lock
@@ -1,0 +1,431 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "schema-version": "1.10.0",
+    "install": {
+      "claude-code": {
+        "pkg-path": "flox/claude-code",
+        "pkg-group": "claude-code"
+      },
+      "claude-code-plugin-caveman": {
+        "pkg-path": "flox/claude-code-plugin-caveman",
+        "pkg-group": "claude-code-plugin-caveman"
+      },
+      "claude-managed": {
+        "pkg-path": "flox/claude-managed",
+        "pkg-group": "claude-managed",
+        "version": "^0.4.1"
+      }
+    },
+    "hook": {
+      "on-activate": "eval \"$(claude-managed setup-hook)\"\n"
+    },
+    "profile": {
+      "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
+      "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
+      "fish": "claude-managed setup-profile-fish | source\n"
+    },
+    "options": {}
+  },
+  "packages": [
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/8l2hay17dh0f2cnqdiww3h716nl078n9-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:56:04.774534Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gckpbs4vk8wyfgarr8w6wz53ykhxzbw1-claude-code-2.1.141"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/lg349nwky5rgl7gnmqyxzwagcwdp9x5h-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:56:04.774566Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gdzh2ynafj30iz3gvmplcrch92sgarm0-claude-code-2.1.141"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/ngx8rhlnfnxlfdjqwhawi5pri4ykd83f-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:56:04.774570Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ijkl9clcsgp9fvzg4qjb5xnv0v8gmkny-claude-code-2.1.141"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/f5p3akgnffldplwk394l5b27r499syxb-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:56:04.774571Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/n69zkbh80r7d9c7lw5wny45qg8yj78v5-claude-code-2.1.141"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-caveman",
+      "broken": false,
+      "derivation": "/nix/store/scxp2q8mc2zvai34835qfbc3mig5kvp0-claude-code-plugin-caveman-1.8.2.drv",
+      "description": "Caveman plugin for Claude Code — ultra-compressed communication mode (7 skills + SessionStart/UserPromptSubmit hooks) with Node.js and Python bundled for the hooks and compress scripts.",
+      "install_id": "claude-code-plugin-caveman",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "name": "claude-code-plugin-caveman-1.8.2",
+      "pname": "claude-code-plugin-caveman",
+      "rev": "b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:48:55Z",
+      "scrape_date": "2026-05-18T22:56:04.774579Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.8.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/8fack9l3dmgcpy06lg81kii4h3ffb5g7-claude-code-plugin-caveman-1.8.2"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-code-plugin-caveman",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-caveman",
+      "broken": false,
+      "derivation": "/nix/store/5cp8ilg11drb4z7shsmpb959m8837vsi-claude-code-plugin-caveman-1.8.2.drv",
+      "description": "Caveman plugin for Claude Code — ultra-compressed communication mode (7 skills + SessionStart/UserPromptSubmit hooks) with Node.js and Python bundled for the hooks and compress scripts.",
+      "install_id": "claude-code-plugin-caveman",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "name": "claude-code-plugin-caveman-1.8.2",
+      "pname": "claude-code-plugin-caveman",
+      "rev": "b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:48:55Z",
+      "scrape_date": "2026-05-18T22:56:04.774582Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.8.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/5dfq5l3qfph7vzy2aypz469h50fvm0f4-claude-code-plugin-caveman-1.8.2"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-code-plugin-caveman",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-caveman",
+      "broken": false,
+      "derivation": "/nix/store/9kjpr6ckgz4nkzf78z9c1n7s71aqxj65-claude-code-plugin-caveman-1.8.2.drv",
+      "description": "Caveman plugin for Claude Code — ultra-compressed communication mode (7 skills + SessionStart/UserPromptSubmit hooks) with Node.js and Python bundled for the hooks and compress scripts.",
+      "install_id": "claude-code-plugin-caveman",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "name": "claude-code-plugin-caveman-1.8.2",
+      "pname": "claude-code-plugin-caveman",
+      "rev": "b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:48:55Z",
+      "scrape_date": "2026-05-18T22:56:04.774582Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.8.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/agssd364yc59fc2g8xqv2wb4s0vh3msw-claude-code-plugin-caveman-1.8.2"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-code-plugin-caveman",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-caveman",
+      "broken": false,
+      "derivation": "/nix/store/pzddqkgwr94z467gslcvhz1llra6ajji-claude-code-plugin-caveman-1.8.2.drv",
+      "description": "Caveman plugin for Claude Code — ultra-compressed communication mode (7 skills + SessionStart/UserPromptSubmit hooks) with Node.js and Python bundled for the hooks and compress scripts.",
+      "install_id": "claude-code-plugin-caveman",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "name": "claude-code-plugin-caveman-1.8.2",
+      "pname": "claude-code-plugin-caveman",
+      "rev": "b8272bbbd50ab17275d35a3a97f2475149b96bb6",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:48:55Z",
+      "scrape_date": "2026-05-18T22:56:04.774582Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "1.8.2",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/4mm584rv9vm8ia8hwv0igkqx8wppkfsb-claude-code-plugin-caveman-1.8.2"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-code-plugin-caveman",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/w1klmic8k8a5iwgijlx0cm9yj48p8gih-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:56:04.774612Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ai6ahqbl18ai53h6qxs3jyfzx25xvlv2-claude-managed-0.4.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/hiz3gjm8xnaadxn8fcnn3cqv00ak7jmx-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:56:04.774613Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/kxhnszh6kirs6a024s0bnjyx04dy0rkx-claude-managed-0.4.1"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/7cbjxv67m749n5mw2pb0lkh2i82s292k-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:56:04.774614Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/5amvlx9kqjc19v0r9s0pianxpj60qz4l-claude-managed-0.4.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/snshhqypg93w1yr27gxz9c239z3i9nax-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:56:04.774614Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/nr2v9wsw4c1zry0hzkg9psfs7kksvh4l-claude-managed-0.4.1"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-managed",
+      "priority": 5
+    }
+  ],
+  "compose": {
+    "composer": {
+      "schema-version": "1.10.0",
+      "install": {
+        "claude-code-plugin-caveman": {
+          "pkg-path": "flox/claude-code-plugin-caveman",
+          "pkg-group": "claude-code-plugin-caveman"
+        }
+      },
+      "options": {},
+      "include": {
+        "environments": [
+          {
+            "dir": "../claude"
+          }
+        ]
+      }
+    },
+    "include": [
+      {
+        "manifest": {
+          "schema-version": "1.10.0",
+          "install": {
+            "claude-code": {
+              "pkg-path": "flox/claude-code",
+              "pkg-group": "claude-code"
+            },
+            "claude-managed": {
+              "pkg-path": "flox/claude-managed",
+              "pkg-group": "claude-managed",
+              "version": "^0.4.1"
+            }
+          },
+          "hook": {
+            "on-activate": "eval \"$(claude-managed setup-hook)\"\n"
+          },
+          "profile": {
+            "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
+            "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
+            "fish": "claude-managed setup-profile-fish | source\n"
+          },
+          "options": {}
+        },
+        "name": "claude",
+        "descriptor": {
+          "dir": "../claude"
+        }
+      }
+    ],
+    "warnings": []
+  }
+}

--- a/caveman/.flox/env/manifest.toml
+++ b/caveman/.flox/env/manifest.toml
@@ -1,0 +1,23 @@
+schema-version = "1.10.0"
+
+# Claude Code environment with the caveman plugin
+# pre-installed. Ultra-compressed communication
+# mode that cuts ~75% of tokens while keeping full
+# technical accuracy.
+#
+# Include it in your own manifest:
+#
+#   [include]
+#   environments = ["flox/caveman"]
+#
+# Then activate the mode by typing /caveman in
+# Claude Code, or saying "talk like caveman".
+
+[include]
+environments = [
+  { dir = "../claude" }
+]
+
+[install]
+claude-code-plugin-caveman.pkg-path = "flox/claude-code-plugin-caveman"
+claude-code-plugin-caveman.pkg-group = "claude-code-plugin-caveman"

--- a/caveman/README.md
+++ b/caveman/README.md
@@ -1,0 +1,58 @@
+# Caveman
+
+Claude Code environment with the
+[caveman](https://github.com/JuliusBrussee/caveman)
+plugin pre-installed.
+
+Ultra-compressed communication mode that cuts ~75%
+of tokens while keeping full technical accuracy.
+
+## Quick start
+
+Include in your manifest:
+
+```toml
+[include]
+environments = ["flox/caveman"]
+```
+
+## What it provides
+
+Everything from [claude](../claude/) plus:
+
+- `claude-code-plugin-caveman` -- the caveman plugin
+  with 7 skills:
+  - `caveman` -- the headline compression mode
+  - `caveman-commit` -- terse commit messages
+  - `caveman-review` -- terse PR review comments
+  - `caveman-compress` -- compress markdown memory
+    files (e.g. `CLAUDE.md`, todo lists)
+  - `caveman-stats` -- show real token usage and
+    estimated savings for the active session
+  - `caveman-help` -- quick-reference card
+  - `cavecrew` -- decision guide for delegating
+    to caveman-style subagents
+
+A SessionStart hook activates caveman mode on every
+session, and a UserPromptSubmit hook recognizes
+`/caveman lite|full|ultra|wenyan-lite|wenyan-full|wenyan-ultra`
+to switch intensity.
+
+Node.js and Python are bundled inside the plugin,
+so the hooks and the `caveman-compress` scripts run
+without requiring the consumer env to install
+either runtime.
+
+## Usage
+
+After `flox activate`, start Claude Code and type
+`/caveman` (or just say "talk like caveman"). Switch
+intensity with `/caveman ultra`. Deactivate with
+"stop caveman" or "normal mode".
+
+## See also
+
+- [caveman-demo](../caveman-demo/) -- interactive
+  demo with welcome banner
+- [claude](../claude/) -- the base Claude Code
+  environment this builds on

--- a/caveman/test.sh
+++ b/caveman/test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+command_exists() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' command not found."
+    return 1
+  fi
+  echo ">>> '$1' command exists"
+}
+
+# ── Required commands (inherited from flox/claude) ────
+command_exists claude
+command_exists claude-managed
+
+echo ">>> claude version: $(claude --version)"
+echo ">>> claude-managed version: $(claude-managed version)"
+
+# ── Managed mode ──────────────────────────────────────
+if [ "${CLAUDE_MANAGED:-}" != "1" ]; then
+  echo "Error: CLAUDE_MANAGED not set."
+  exit 1
+fi
+echo ">>> CLAUDE_MANAGED=1"
+
+if [ -z "${CLAUDE_CONFIG_DIR:-}" ]; then
+  echo "Error: CLAUDE_CONFIG_DIR not set."
+  exit 1
+fi
+echo ">>> CLAUDE_CONFIG_DIR=$CLAUDE_CONFIG_DIR"
+
+if [ "${CLAUDE_CODE_DISABLE_AUTO_MEMORY:-}" != "1" ]; then
+  echo "Error: CLAUDE_CODE_DISABLE_AUTO_MEMORY not set."
+  exit 1
+fi
+echo ">>> CLAUDE_CODE_DISABLE_AUTO_MEMORY=1"
+
+# ── Config dir exists ─────────────────────────────────
+if [ ! -d "$CLAUDE_CONFIG_DIR" ]; then
+  echo "Error: CLAUDE_CONFIG_DIR does not exist: $CLAUDE_CONFIG_DIR"
+  exit 1
+fi
+echo ">>> config dir exists"
+
+# ── Caveman plugin discoverable ──────────────────────
+plugin_dir="$FLOX_ENV/share/claude-code/plugins/caveman"
+if [ ! -d "$plugin_dir" ]; then
+  echo "Error: caveman plugin dir missing: $plugin_dir"
+  exit 1
+fi
+echo ">>> caveman plugin dir exists"
+
+# Plugin manifest is what Claude Code reads on discovery.
+plugin_json="$plugin_dir/.claude-plugin/plugin.json"
+if [ ! -f "$plugin_json" ]; then
+  echo "Error: caveman plugin.json missing: $plugin_json"
+  exit 1
+fi
+echo ">>> caveman plugin.json present"
+
+# Bundled runtimes must resolve — both are referenced
+# from the rewritten plugin.json (node) and SKILL.md
+# (python3) by absolute ${CLAUDE_PLUGIN_ROOT}/bin/...
+if [ ! -x "$plugin_dir/bin/node" ]; then
+  echo "Error: bundled node missing: $plugin_dir/bin/node"
+  exit 1
+fi
+echo ">>> bundled node: $("$plugin_dir/bin/node" --version)"
+
+if [ ! -x "$plugin_dir/bin/python3" ]; then
+  echo "Error: bundled python3 missing: $plugin_dir/bin/python3"
+  exit 1
+fi
+echo ">>> bundled python3: $("$plugin_dir/bin/python3" --version)"
+
+# ── Doctor check ──────────────────────────────────────
+echo ">>> claude-managed doctor"
+claude-managed doctor
+
+echo ">>> caveman environment is working"


### PR DESCRIPTION
## Summary

- Package [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman) — Claude Code plugin for ultra-compressed communication mode that cuts ~75% of tokens while keeping technical accuracy (7 skills + `SessionStart` and `UserPromptSubmit` hooks).
- `.flox/pkgs/claude-code-plugin-caveman/{default.nix,hashes.json,publish.json,upgrade.sh}` follows the existing `claude-code-plugin-superpowers` layout: copies the upstream repo root (`marketplace.json` declares `source = "./"`) into `share/claude-code/plugins/caveman/`, drops per-harness mirrors (`.codex/.junie/.kiro/.roo/.agents`), dev docs, the npx installer, and the Codex-only `commands/*.toml`.
- Bundles `nodejs` + `python3` as symlinks under `bin/` (both runtimes are stdlib-only). Rewrites `#!/usr/bin/env node|python3` shebangs, the two `node \"${CLAUDE_PLUGIN_ROOT}/…\"` commands in `plugin.json`, and `python3 -m scripts` in `caveman-compress/SKILL.md` so the hooks and compress scripts run without `node`/`python3` on the consumer's PATH.
- Adds `caveman/` (minimal, `[include]`-friendly — composes `../claude` plus the plugin) and `caveman-demo/` (adds `gum` + welcome banner with a `/caveman` cheat sheet; pinned to schema-version `1.11.0` to match flox 1.11's compose auto-bump).
- Pinned to `v1.8.2`. Auto-upgrades via `upgrade_pkgs.yml` (GitHub releases API → re-prefetch source for the latest `vX.Y.Z` tag). Publishes to the `flox` org for all four systems.

## Test plan

- [x] `flox build claude-code-plugin-caveman --system aarch64-darwin` succeeds locally
- [x] `flox build claude-code-plugin-caveman --system aarch64-linux` succeeds via remote builder
- [x] `flox publish` succeeded for all 4 systems → `flox/claude-code-plugin-caveman@1.8.2` is live in the catalog
- [x] `caveman/.flox/env/manifest.lock` and `caveman-demo/.flox/env/manifest.lock` resolve cleanly against the published package
- [x] `caveman/test.sh` passes under `flox activate` — bundled `bin/node` (`v24.14.1`) and `bin/python3` (`Python 3.13.12`) execute, `claude-managed doctor` reports `✓ caveman` under Plugins
- [x] `caveman-demo/test.sh` passes — `claude-managed doctor` reports `✓ caveman` under Plugins
- [x] `SessionStart` hook (`caveman-activate.js`) emits the caveman ruleset on activation
- [x] `UserPromptSubmit` hook (`caveman-mode-tracker.js`) recognizes `/caveman lite` and emits the JSON `additionalContext` payload
- [x] `bash .flox/pkgs/claude-code-plugin-caveman/upgrade.sh` correctly reports "Already up to date"
- [ ] CI `Build 'claude-code-plugin-caveman' (<system>)` passes for all four systems