### PR TITLE
feat(remotion): add remotion plugin + envs

### DIFF
--- a/.flox/pkgs/claude-code-plugin-remotion/default.nix
+++ b/.flox/pkgs/claude-code-plugin-remotion/default.nix
@@ -1,0 +1,85 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version commit srcHash;
+in
+stdenv.mkDerivation {
+  pname = "claude-code-plugin-remotion";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "remotion-dev";
+    repo = "skills";
+    rev = commit;
+    hash = srcHash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    PLUGIN_DIR="$out/share/claude-code/plugins/remotion"
+    mkdir -p "$PLUGIN_DIR/skills"
+
+    # Upstream layout is `skills/remotion/` with SKILL.md + rules/
+    # and a handful of .tsx asset examples. Copy the whole skill
+    # tree verbatim — Claude Code reads SKILL.md frontmatter
+    # to advertise it as `remotion-best-practices`.
+    cp -r "$src/skills/remotion" "$PLUGIN_DIR/skills/remotion"
+    chmod -R u+w "$PLUGIN_DIR"
+
+    # Upstream ships no .claude-plugin/plugin.json — the canonical
+    # consumer is `npx remotion skills add`, which drops skill folders
+    # straight into the user's project at `.claude/skills/`. We're
+    # shipping the same content as a Claude Code plugin, so synthesize
+    # the manifest Claude Code expects. Fields mirror upstream's Codex
+    # plugin manifest (packages/codex-plugin/.codex-plugin/plugin.json)
+    # in the remotion-dev/remotion monorepo.
+    mkdir -p "$PLUGIN_DIR/.claude-plugin"
+    cat > "$PLUGIN_DIR/.claude-plugin/plugin.json" <<JSON
+    {
+      "name": "remotion",
+      "version": "${version}",
+      "description": "Remotion video creation skills — best practices, animations, audio, captions, 3D, and more for building programmatic videos with React.",
+      "homepage": "https://remotion.dev",
+      "repository": "https://github.com/remotion-dev/skills",
+      "license": "MIT",
+      "keywords": [
+        "remotion",
+        "video",
+        "react",
+        "animation",
+        "composition",
+        "rendering",
+        "ffmpeg",
+        "captions",
+        "audio"
+      ]
+    }
+    JSON
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Remotion best-practices plugin for Claude Code — 1 skill, "
+      + "30+ topic rules covering animations, audio, captions, 3D, "
+      + "transitions, and more for programmatic video creation in React.";
+    homepage = "https://github.com/remotion-dev/skills";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/claude-code-plugin-remotion/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-remotion/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "2026.05.07",
+  "commit": "277510e78245ac0fa275d7cb6520d52e0ac2e212",
+  "srcHash": "sha256-XklSJY8xZMExl+BFtbYo+nQ8qLnmwWipkSZh9ykwt1s="
+}

--- a/.flox/pkgs/claude-code-plugin-remotion/publish.json
+++ b/.flox/pkgs/claude-code-plugin-remotion/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/claude-code-plugin-remotion/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-remotion/upgrade.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="remotion-dev"
+REPO="skills"
+
+current_commit=$(jq -r '.commit' "$HASHES_FILE")
+
+# remotion-dev/skills publishes no tags — the canonical
+# "latest" is the HEAD of `main`, which the upstream `npx
+# remotion skills add` command also tracks. Pin to the
+# committer date so the floxhub version field stays
+# monotonic across upgrades.
+latest_commit=$(curl -sf \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/main" \
+  | jq -r '.sha')
+latest_date=$(curl -sf \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/$latest_commit" \
+  | jq -r '.commit.committer.date')
+latest_version=$(echo "$latest_date" | cut -dT -f1 | tr - .)
+
+echo "Current commit: $current_commit"
+echo "Latest commit:  $latest_commit ($latest_version)"
+
+if [ "$current_commit" = "$latest_commit" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating claude-code-plugin-remotion to $latest_version ($latest_commit)"
+
+src_url="https://github.com/$OWNER/$REPO/archive/${latest_commit}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg c "$latest_commit" \
+  --arg s "$src_sri" \
+  '{version: $v, commit: $c, srcHash: $s}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.github/workflows/ci_remotion.yml
+++ b/.github/workflows/ci_remotion.yml
@@ -1,0 +1,36 @@
+name: "CI: remotion"
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "remotion/**"
+      - "remotion-demo/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "scripts/**"
+      - ".github/workflows/environment.yml"
+      - ".github/workflows/ci_remotion.yml"
+  pull_request:
+    paths:
+      - "remotion/**"
+      - "remotion-demo/**"
+      - "flake.nix"
+      - "flake.lock"
+      - "scripts/**"
+      - ".github/workflows/environment.yml"
+      - ".github/workflows/ci_remotion.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: "read"
+  packages: "write"
+  attestations: "write"
+  id-token: "write"
+
+jobs:
+  run:
+    uses: "./.github/workflows/environment.yml"
+    with:
+      environment: "remotion"
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Most environments follow a dual-layer pattern:
 | _└ huggingface-demo_ | | [floxhub](https://hub.flox.dev/flox/huggingface-demo) · [docs](huggingface-demo/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/huggingface-demo-latest) |
 | graphify | Knowledge-graph skill for Claude Code | [floxhub](https://hub.flox.dev/flox/graphify) · [docs](graphify/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/graphify-latest) |
 | _└ graphify-demo_ | | [floxhub](https://hub.flox.dev/flox/graphify-demo) · [docs](graphify-demo/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/graphify-demo-latest) |
+| remotion | Remotion video skill for Claude Code | [floxhub](https://hub.flox.dev/flox/remotion) · [docs](remotion/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/remotion-latest) |
+| _└ remotion-demo_ | | [floxhub](https://hub.flox.dev/flox/remotion-demo) · [docs](remotion-demo/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/remotion-demo-latest) |
 | langchain | LangChain + Ollama | [floxhub](https://hub.flox.dev/flox/langchain) · [docs](langchain/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/langchain-latest) |
 | _└ langchain-demo_ | | [floxhub](https://hub.flox.dev/flox/langchain-demo) · [docs](langchain-demo/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/langchain-demo-latest) |
 | verba | Verba RAG app | [floxhub](https://hub.flox.dev/flox/verba) · [docs](verba/README.md) · [docker](https://github.com/flox/floxenvs/pkgs/container/floxenvs/verba-latest) |

--- a/remotion-demo/.flox/env.json
+++ b/remotion-demo/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "remotion-demo",
+  "version": 1
+}

--- a/remotion-demo/.flox/env/manifest.lock
+++ b/remotion-demo/.flox/env/manifest.lock
@@ -1,0 +1,683 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "schema-version": "1.10.0",
+    "install": {
+      "claude-code": {
+        "pkg-path": "flox/claude-code",
+        "pkg-group": "claude-code"
+      },
+      "claude-code-plugin-remotion": {
+        "pkg-path": "flox/claude-code-plugin-remotion",
+        "pkg-group": "claude-code-plugin-remotion"
+      },
+      "claude-managed": {
+        "pkg-path": "flox/claude-managed",
+        "pkg-group": "claude-managed",
+        "version": "^0.4.1"
+      },
+      "gum": {
+        "pkg-path": "gum",
+        "pkg-group": "demo-tools"
+      },
+      "nodejs": {
+        "pkg-path": "nodejs_22",
+        "pkg-group": "remotion"
+      }
+    },
+    "hook": {
+      "on-activate": "eval \"$(claude-managed setup-hook)\"\n\nif [[ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]]; then\n  gum style --border double --margin '1 2' \\\n    --padding '1 4' \\\n    'Remotion + Claude Code' '' \\\n    'Scaffold a new video project:' \\\n    '  npx create-video@latest --yes --blank --no-tailwind my-video' '' \\\n    'Inside a Remotion project:' \\\n    '  npx remotion studio       Open the visual editor' \\\n    '  npx remotion render       Render to MP4' \\\n    '  npx remotion ffmpeg ...   Bundled ffmpeg' '' \\\n    'Ask Claude (skill auto-loads on Remotion code):' \\\n    '  claude' '' \\\n    \"Node: $(node --version)\"\nfi\n"
+    },
+    "profile": {
+      "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
+      "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
+      "fish": "claude-managed setup-profile-fish | source\n"
+    },
+    "options": {}
+  },
+  "packages": [
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/8l2hay17dh0f2cnqdiww3h716nl078n9-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:55:37.290894Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gckpbs4vk8wyfgarr8w6wz53ykhxzbw1-claude-code-2.1.141"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/lg349nwky5rgl7gnmqyxzwagcwdp9x5h-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:55:37.290895Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gdzh2ynafj30iz3gvmplcrch92sgarm0-claude-code-2.1.141"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/ngx8rhlnfnxlfdjqwhawi5pri4ykd83f-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:55:37.290896Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ijkl9clcsgp9fvzg4qjb5xnv0v8gmkny-claude-code-2.1.141"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/f5p3akgnffldplwk394l5b27r499syxb-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:55:37.290896Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/n69zkbh80r7d9c7lw5wny45qg8yj78v5-claude-code-2.1.141"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-remotion",
+      "broken": false,
+      "derivation": "/nix/store/di7jhmv88qpv5fryfdm0dfcjc3ci7an1-claude-code-plugin-remotion-2026.05.07.drv",
+      "description": "Remotion best-practices plugin for Claude Code — 1 skill, 30+ topic rules covering animations, audio, captions, 3D, transitions, and more for programmatic video creation in React.",
+      "install_id": "claude-code-plugin-remotion",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "name": "claude-code-plugin-remotion-2026.05.07",
+      "pname": "claude-code-plugin-remotion",
+      "rev": "821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:19:21Z",
+      "scrape_date": "2026-05-18T22:55:37.290916Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2026.05.07",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/lcqvq7k9cp3x4sjrqrbqlycq2kv3y91m-claude-code-plugin-remotion-2026.05.07"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-code-plugin-remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-remotion",
+      "broken": false,
+      "derivation": "/nix/store/4z4r5drgag85nqkfhipbyxig1srlq9dh-claude-code-plugin-remotion-2026.05.07.drv",
+      "description": "Remotion best-practices plugin for Claude Code — 1 skill, 30+ topic rules covering animations, audio, captions, 3D, transitions, and more for programmatic video creation in React.",
+      "install_id": "claude-code-plugin-remotion",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "name": "claude-code-plugin-remotion-2026.05.07",
+      "pname": "claude-code-plugin-remotion",
+      "rev": "821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:19:21Z",
+      "scrape_date": "2026-05-18T22:55:37.290918Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2026.05.07",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/xllanv8m4h21fw248wg4ibs02ld1736z-claude-code-plugin-remotion-2026.05.07"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-code-plugin-remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-remotion",
+      "broken": false,
+      "derivation": "/nix/store/kdyjlpv5mkwp9z11c86g5c54dmc8ldfi-claude-code-plugin-remotion-2026.05.07.drv",
+      "description": "Remotion best-practices plugin for Claude Code — 1 skill, 30+ topic rules covering animations, audio, captions, 3D, transitions, and more for programmatic video creation in React.",
+      "install_id": "claude-code-plugin-remotion",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "name": "claude-code-plugin-remotion-2026.05.07",
+      "pname": "claude-code-plugin-remotion",
+      "rev": "821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:19:21Z",
+      "scrape_date": "2026-05-18T22:55:37.290918Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2026.05.07",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/baj2q5adfinxlrzl4nyr4a3ml6a1l2x8-claude-code-plugin-remotion-2026.05.07"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-code-plugin-remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-remotion",
+      "broken": false,
+      "derivation": "/nix/store/144vzwh69dx936ii8sm37327phmblzr6-claude-code-plugin-remotion-2026.05.07.drv",
+      "description": "Remotion best-practices plugin for Claude Code — 1 skill, 30+ topic rules covering animations, audio, captions, 3D, transitions, and more for programmatic video creation in React.",
+      "install_id": "claude-code-plugin-remotion",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "name": "claude-code-plugin-remotion-2026.05.07",
+      "pname": "claude-code-plugin-remotion",
+      "rev": "821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:19:21Z",
+      "scrape_date": "2026-05-18T22:55:37.290919Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2026.05.07",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/1jzkj730qrwl9vf72zla10659653w60l-claude-code-plugin-remotion-2026.05.07"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-code-plugin-remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/w1klmic8k8a5iwgijlx0cm9yj48p8gih-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:55:37.290923Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ai6ahqbl18ai53h6qxs3jyfzx25xvlv2-claude-managed-0.4.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/hiz3gjm8xnaadxn8fcnn3cqv00ak7jmx-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:55:37.290926Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/kxhnszh6kirs6a024s0bnjyx04dy0rkx-claude-managed-0.4.1"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/7cbjxv67m749n5mw2pb0lkh2i82s292k-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:55:37.290926Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/5amvlx9kqjc19v0r9s0pianxpj60qz4l-claude-managed-0.4.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/snshhqypg93w1yr27gxz9c239z3i9nax-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:55:37.290926Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/nr2v9wsw4c1zry0hzkg9psfs7kksvh4l-claude-managed-0.4.1"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/3if65h5mjjgjwgvd18srmm35cn3w6xs8-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T07:05:52.142375Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ba53aq5kpjm2qb817qgxswy2hvnkxnyj-gum-0.17.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/ka558hvp8n0vhw8lzwsw66zw3g3lavzd-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T07:33:31.643735Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/3hlyv3x7jjn5364f08jw0bic3zddqhxc-gum-0.17.0"
+      },
+      "system": "aarch64-linux",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/z2rm91h36jx1ym7gpl3avxqqxc407pn2-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T08:01:18.656478Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/qkwxvmldb9a8nmqq6aqqd47gj3pxwx42-gum-0.17.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/835d9xq5q9w2hv6dzlsc3yjbh44kmpjn-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T08:32:12.167065Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/c149nbx8xh8knvply95623gnwqds19xr-gum-0.17.0"
+      },
+      "system": "x86_64-linux",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "nodejs_22",
+      "broken": false,
+      "derivation": "/nix/store/9vin8a8v16ncwc09r49fzf5bfd1vxyjs-nodejs-22.22.3.drv",
+      "description": "Event-driven I/O framework for the V8 JavaScript engine",
+      "install_id": "nodejs",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "nodejs-22.22.3",
+      "pname": "nodejs_22",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T07:06:15.337998Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "22.22.3",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/4gl9pclv6ygwmgpg1gijza978bqbmpga-nodejs-22.22.3"
+      },
+      "system": "aarch64-darwin",
+      "group": "remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "nodejs_22",
+      "broken": false,
+      "derivation": "/nix/store/qdslyqw513xx2a1w48wzhhh4iwqsn280-nodejs-22.22.3.drv",
+      "description": "Event-driven I/O framework for the V8 JavaScript engine",
+      "install_id": "nodejs",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "nodejs-22.22.3",
+      "pname": "nodejs_22",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T07:34:06.225108Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "22.22.3",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/xa7qmarsab5ch5g7ra9ssq2x5ggdv62b-nodejs-22.22.3"
+      },
+      "system": "aarch64-linux",
+      "group": "remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "nodejs_22",
+      "broken": false,
+      "derivation": "/nix/store/1jfrkyd73z2q4dy9xkp3ln8k7wpxh41d-nodejs-22.22.3.drv",
+      "description": "Event-driven I/O framework for the V8 JavaScript engine",
+      "install_id": "nodejs",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "nodejs-22.22.3",
+      "pname": "nodejs_22",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T08:01:42.784503Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "22.22.3",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/6db8w02ymrx1pf37fvpfzv6py0c7q0y6-nodejs-22.22.3"
+      },
+      "system": "x86_64-darwin",
+      "group": "remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "nodejs_22",
+      "broken": false,
+      "derivation": "/nix/store/7bazayk4ff1i55wmllmm8b8sjxx1rl1h-nodejs-22.22.3.drv",
+      "description": "Event-driven I/O framework for the V8 JavaScript engine",
+      "install_id": "nodejs",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "nodejs-22.22.3",
+      "pname": "nodejs_22",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T08:32:50.643579Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "22.22.3",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/qyvq4avj27g75z29c88m7pvrlkjihvj4-nodejs-22.22.3"
+      },
+      "system": "x86_64-linux",
+      "group": "remotion",
+      "priority": 5
+    }
+  ],
+  "compose": {
+    "composer": {
+      "schema-version": "1.10.0",
+      "install": {
+        "gum": {
+          "pkg-path": "gum",
+          "pkg-group": "demo-tools"
+        }
+      },
+      "hook": {
+        "on-activate": "if [[ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]]; then\n  gum style --border double --margin '1 2' \\\n    --padding '1 4' \\\n    'Remotion + Claude Code' '' \\\n    'Scaffold a new video project:' \\\n    '  npx create-video@latest --yes --blank --no-tailwind my-video' '' \\\n    'Inside a Remotion project:' \\\n    '  npx remotion studio       Open the visual editor' \\\n    '  npx remotion render       Render to MP4' \\\n    '  npx remotion ffmpeg ...   Bundled ffmpeg' '' \\\n    'Ask Claude (skill auto-loads on Remotion code):' \\\n    '  claude' '' \\\n    \"Node: $(node --version)\"\nfi\n"
+      },
+      "options": {},
+      "include": {
+        "environments": [
+          {
+            "dir": "../remotion"
+          }
+        ]
+      }
+    },
+    "include": [
+      {
+        "manifest": {
+          "schema-version": "1.10.0",
+          "install": {
+            "claude-code": {
+              "pkg-path": "flox/claude-code",
+              "pkg-group": "claude-code"
+            },
+            "claude-code-plugin-remotion": {
+              "pkg-path": "flox/claude-code-plugin-remotion",
+              "pkg-group": "claude-code-plugin-remotion"
+            },
+            "claude-managed": {
+              "pkg-path": "flox/claude-managed",
+              "pkg-group": "claude-managed",
+              "version": "^0.4.1"
+            },
+            "nodejs": {
+              "pkg-path": "nodejs_22",
+              "pkg-group": "remotion"
+            }
+          },
+          "hook": {
+            "on-activate": "eval \"$(claude-managed setup-hook)\"\n"
+          },
+          "profile": {
+            "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
+            "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
+            "fish": "claude-managed setup-profile-fish | source\n"
+          },
+          "options": {}
+        },
+        "name": "remotion",
+        "descriptor": {
+          "dir": "../remotion"
+        }
+      }
+    ],
+    "warnings": []
+  }
+}

--- a/remotion-demo/.flox/env/manifest.toml
+++ b/remotion-demo/.flox/env/manifest.toml
@@ -1,0 +1,30 @@
+schema-version = "1.10.0"
+
+[include]
+environments = [
+  { dir = "../remotion" }
+]
+
+# gum is a demo-only tool for styled terminal output.
+
+[install]
+gum.pkg-path = "gum"
+gum.pkg-group = "demo-tools"
+
+[hook]
+on-activate = '''
+if [[ "${FLOX_ENVS_TESTING:-}" != "1" ]]; then
+  gum style --border double --margin '1 2' \
+    --padding '1 4' \
+    'Remotion + Claude Code' '' \
+    'Scaffold a new video project:' \
+    '  npx create-video@latest --yes --blank --no-tailwind my-video' '' \
+    'Inside a Remotion project:' \
+    '  npx remotion studio       Open the visual editor' \
+    '  npx remotion render       Render to MP4' \
+    '  npx remotion ffmpeg ...   Bundled ffmpeg' '' \
+    'Ask Claude (skill auto-loads on Remotion code):' \
+    '  claude' '' \
+    "Node: $(node --version)"
+fi
+'''

--- a/remotion-demo/README.md
+++ b/remotion-demo/README.md
@@ -1,0 +1,47 @@
+# remotion-demo
+
+Demo variant of [remotion](../remotion) — adds `gum` for a
+styled welcome banner with quick-start commands.
+
+## Quick start
+
+```bash
+flox activate -r flox/remotion-demo
+```
+
+The banner prints the canonical bootstrap commands for a new
+Remotion project. From here:
+
+```bash
+# Scaffold a fresh blank project (npm)
+npx create-video@latest --yes --blank --no-tailwind my-video
+cd my-video
+
+# Open the visual editor
+npx remotion studio
+
+# Render to MP4
+npx remotion render
+
+# Open Claude Code — the remotion-best-practices skill is
+# already registered. Whenever you ask Claude to touch
+# Remotion code, the skill auto-loads with the topic rules
+# (animations, audio, captions, 3D, transitions, etc.).
+claude
+```
+
+## What's added on top of `flox/remotion`
+
+- `gum` — styled banner during `on-activate`
+
+Everything else (Node.js 22, ffmpeg, Claude Code, and the
+`claude-code-plugin-remotion` plugin) comes from the
+included [remotion](../remotion) environment.
+
+## See also
+
+- [remotion](../remotion) — minimal env meant for
+  `[include]` in your own projects
+- Upstream skill source:
+  <https://github.com/remotion-dev/skills>
+- Remotion docs: <https://remotion.dev>

--- a/remotion-demo/test.sh
+++ b/remotion-demo/test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+command_exists() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Error: '$1' command not found."
+    return 1
+  fi
+  echo ">>> '$1' command exists"
+}
+
+# ── Required commands (inherited from ../remotion) ─────
+command_exists node
+command_exists npx
+command_exists claude
+command_exists claude-managed
+
+# ── Demo-only ──────────────────────────────────────────
+command_exists gum
+
+echo ">>> node version:    $(node --version)"
+echo ">>> npm version:     $(npm --version)"
+echo ">>> claude version:  $(claude --version 2>&1 | head -1)"
+echo ">>> gum version:     $(gum --version)"
+
+# ── Plugin tree present ────────────────────────────────
+plugin_dir="$FLOX_ENV/share/claude-code/plugins/remotion"
+if [ ! -f "$plugin_dir/.claude-plugin/plugin.json" ]; then
+  echo "Error: plugin.json missing at $plugin_dir"
+  exit 1
+fi
+if [ ! -f "$plugin_dir/skills/remotion/SKILL.md" ]; then
+  echo "Error: SKILL.md missing at $plugin_dir"
+  exit 1
+fi
+echo ">>> remotion plugin tree present"
+
+# ── claude-managed registered the plugin ───────────────
+if ! claude-managed plugins list 2>&1 | grep -q remotion; then
+  echo "Error: claude-managed did not register the remotion plugin"
+  claude-managed doctor || true
+  exit 1
+fi
+echo ">>> claude-managed registered the remotion plugin"
+
+echo ">>> remotion-demo environment is working"

--- a/remotion/.flox/env.json
+++ b/remotion/.flox/env.json
@@ -1,0 +1,4 @@
+{
+  "name": "remotion",
+  "version": 1
+}

--- a/remotion/.flox/env/manifest.lock
+++ b/remotion/.flox/env/manifest.lock
@@ -1,0 +1,500 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "schema-version": "1.10.0",
+    "install": {
+      "claude-code": {
+        "pkg-path": "flox/claude-code",
+        "pkg-group": "claude-code"
+      },
+      "claude-code-plugin-remotion": {
+        "pkg-path": "flox/claude-code-plugin-remotion",
+        "pkg-group": "claude-code-plugin-remotion"
+      },
+      "claude-managed": {
+        "pkg-path": "flox/claude-managed",
+        "pkg-group": "claude-managed",
+        "version": "^0.4.1"
+      },
+      "nodejs": {
+        "pkg-path": "nodejs_22",
+        "pkg-group": "remotion"
+      }
+    },
+    "hook": {
+      "on-activate": "eval \"$(claude-managed setup-hook)\"\n"
+    },
+    "profile": {
+      "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
+      "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
+      "fish": "claude-managed setup-profile-fish | source\n"
+    },
+    "options": {}
+  },
+  "packages": [
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/8l2hay17dh0f2cnqdiww3h716nl078n9-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:55:03.994633Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gckpbs4vk8wyfgarr8w6wz53ykhxzbw1-claude-code-2.1.141"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/lg349nwky5rgl7gnmqyxzwagcwdp9x5h-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:55:03.994634Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/gdzh2ynafj30iz3gvmplcrch92sgarm0-claude-code-2.1.141"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/ngx8rhlnfnxlfdjqwhawi5pri4ykd83f-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:55:03.994635Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ijkl9clcsgp9fvzg4qjb5xnv0v8gmkny-claude-code-2.1.141"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code",
+      "broken": false,
+      "derivation": "/nix/store/f5p3akgnffldplwk394l5b27r499syxb-claude-code-2.1.141.drv",
+      "description": "Agentic coding tool from Anthropic",
+      "install_id": "claude-code",
+      "license": "Unfree",
+      "locked_url": "https://github.com/flox/floxenvs?rev=bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "name": "claude-code-2.1.141",
+      "pname": "claude-code",
+      "rev": "bd93f614381fd4ea0eaf18f5c95b4efd626427a3",
+      "rev_count": 3327,
+      "rev_date": "2026-05-14T10:08:55Z",
+      "scrape_date": "2026-05-18T22:55:03.994635Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": true,
+      "version": "2.1.141",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/n69zkbh80r7d9c7lw5wny45qg8yj78v5-claude-code-2.1.141"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-code",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-remotion",
+      "broken": false,
+      "derivation": "/nix/store/di7jhmv88qpv5fryfdm0dfcjc3ci7an1-claude-code-plugin-remotion-2026.05.07.drv",
+      "description": "Remotion best-practices plugin for Claude Code — 1 skill, 30+ topic rules covering animations, audio, captions, 3D, transitions, and more for programmatic video creation in React.",
+      "install_id": "claude-code-plugin-remotion",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "name": "claude-code-plugin-remotion-2026.05.07",
+      "pname": "claude-code-plugin-remotion",
+      "rev": "821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:19:21Z",
+      "scrape_date": "2026-05-18T22:55:03.994639Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2026.05.07",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/lcqvq7k9cp3x4sjrqrbqlycq2kv3y91m-claude-code-plugin-remotion-2026.05.07"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-code-plugin-remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-remotion",
+      "broken": false,
+      "derivation": "/nix/store/4z4r5drgag85nqkfhipbyxig1srlq9dh-claude-code-plugin-remotion-2026.05.07.drv",
+      "description": "Remotion best-practices plugin for Claude Code — 1 skill, 30+ topic rules covering animations, audio, captions, 3D, transitions, and more for programmatic video creation in React.",
+      "install_id": "claude-code-plugin-remotion",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "name": "claude-code-plugin-remotion-2026.05.07",
+      "pname": "claude-code-plugin-remotion",
+      "rev": "821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:19:21Z",
+      "scrape_date": "2026-05-18T22:55:03.994640Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2026.05.07",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/xllanv8m4h21fw248wg4ibs02ld1736z-claude-code-plugin-remotion-2026.05.07"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-code-plugin-remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-remotion",
+      "broken": false,
+      "derivation": "/nix/store/kdyjlpv5mkwp9z11c86g5c54dmc8ldfi-claude-code-plugin-remotion-2026.05.07.drv",
+      "description": "Remotion best-practices plugin for Claude Code — 1 skill, 30+ topic rules covering animations, audio, captions, 3D, transitions, and more for programmatic video creation in React.",
+      "install_id": "claude-code-plugin-remotion",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "name": "claude-code-plugin-remotion-2026.05.07",
+      "pname": "claude-code-plugin-remotion",
+      "rev": "821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:19:21Z",
+      "scrape_date": "2026-05-18T22:55:03.994640Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2026.05.07",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/baj2q5adfinxlrzl4nyr4a3ml6a1l2x8-claude-code-plugin-remotion-2026.05.07"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-code-plugin-remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-code-plugin-remotion",
+      "broken": false,
+      "derivation": "/nix/store/144vzwh69dx936ii8sm37327phmblzr6-claude-code-plugin-remotion-2026.05.07.drv",
+      "description": "Remotion best-practices plugin for Claude Code — 1 skill, 30+ topic rules covering animations, audio, captions, 3D, transitions, and more for programmatic video creation in React.",
+      "install_id": "claude-code-plugin-remotion",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs.git?rev=821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "name": "claude-code-plugin-remotion-2026.05.07",
+      "pname": "claude-code-plugin-remotion",
+      "rev": "821b04c10ae5bcb0e5d5cabdcedfccade16e1dd9",
+      "rev_count": 3404,
+      "rev_date": "2026-05-18T22:19:21Z",
+      "scrape_date": "2026-05-18T22:55:03.994641Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2026.05.07",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/1jzkj730qrwl9vf72zla10659653w60l-claude-code-plugin-remotion-2026.05.07"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-code-plugin-remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/w1klmic8k8a5iwgijlx0cm9yj48p8gih-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:55:03.994648Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ai6ahqbl18ai53h6qxs3jyfzx25xvlv2-claude-managed-0.4.1"
+      },
+      "system": "aarch64-darwin",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/hiz3gjm8xnaadxn8fcnn3cqv00ak7jmx-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:55:03.994666Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/kxhnszh6kirs6a024s0bnjyx04dy0rkx-claude-managed-0.4.1"
+      },
+      "system": "aarch64-linux",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/7cbjxv67m749n5mw2pb0lkh2i82s292k-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:55:03.994667Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/5amvlx9kqjc19v0r9s0pianxpj60qz4l-claude-managed-0.4.1"
+      },
+      "system": "x86_64-darwin",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "claude-managed",
+      "broken": false,
+      "derivation": "/nix/store/snshhqypg93w1yr27gxz9c239z3i9nax-claude-managed-0.4.1.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "claude-managed",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "name": "claude-managed-0.4.1",
+      "pname": "claude-managed",
+      "rev": "4df4a706b3ef96b35bb2d2f6efacc42d11f271b2",
+      "rev_count": 3243,
+      "rev_date": "2026-05-12T18:55:19Z",
+      "scrape_date": "2026-05-18T22:55:03.994668Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.4.1",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/nr2v9wsw4c1zry0hzkg9psfs7kksvh4l-claude-managed-0.4.1"
+      },
+      "system": "x86_64-linux",
+      "group": "claude-managed",
+      "priority": 5
+    },
+    {
+      "attr_path": "nodejs_22",
+      "broken": false,
+      "derivation": "/nix/store/9vin8a8v16ncwc09r49fzf5bfd1vxyjs-nodejs-22.22.3.drv",
+      "description": "Event-driven I/O framework for the V8 JavaScript engine",
+      "install_id": "nodejs",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "nodejs-22.22.3",
+      "pname": "nodejs_22",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T07:06:15.337998Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "22.22.3",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/4gl9pclv6ygwmgpg1gijza978bqbmpga-nodejs-22.22.3"
+      },
+      "system": "aarch64-darwin",
+      "group": "remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "nodejs_22",
+      "broken": false,
+      "derivation": "/nix/store/qdslyqw513xx2a1w48wzhhh4iwqsn280-nodejs-22.22.3.drv",
+      "description": "Event-driven I/O framework for the V8 JavaScript engine",
+      "install_id": "nodejs",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "nodejs-22.22.3",
+      "pname": "nodejs_22",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T07:34:06.225108Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "22.22.3",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/xa7qmarsab5ch5g7ra9ssq2x5ggdv62b-nodejs-22.22.3"
+      },
+      "system": "aarch64-linux",
+      "group": "remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "nodejs_22",
+      "broken": false,
+      "derivation": "/nix/store/1jfrkyd73z2q4dy9xkp3ln8k7wpxh41d-nodejs-22.22.3.drv",
+      "description": "Event-driven I/O framework for the V8 JavaScript engine",
+      "install_id": "nodejs",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "nodejs-22.22.3",
+      "pname": "nodejs_22",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T08:01:42.784503Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "22.22.3",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/6db8w02ymrx1pf37fvpfzv6py0c7q0y6-nodejs-22.22.3"
+      },
+      "system": "x86_64-darwin",
+      "group": "remotion",
+      "priority": 5
+    },
+    {
+      "attr_path": "nodejs_22",
+      "broken": false,
+      "derivation": "/nix/store/7bazayk4ff1i55wmllmm8b8sjxx1rl1h-nodejs-22.22.3.drv",
+      "description": "Event-driven I/O framework for the V8 JavaScript engine",
+      "install_id": "nodejs",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "nodejs-22.22.3",
+      "pname": "nodejs_22",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T08:32:50.643579Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "22.22.3",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/qyvq4avj27g75z29c88m7pvrlkjihvj4-nodejs-22.22.3"
+      },
+      "system": "x86_64-linux",
+      "group": "remotion",
+      "priority": 5
+    }
+  ]
+}

--- a/remotion/.flox/env/manifest.toml
+++ b/remotion/.flox/env/manifest.toml
@@ -1,0 +1,44 @@
+schema-version = "1.10.0"
+
+# Minimal Remotion environment for use with [include].
+#
+# Include it in your own manifest:
+#
+#   [include]
+#   environments = ["flox/remotion"]
+#
+# Ships Claude Code with the Remotion best-practices skill
+# pre-registered as a plugin, plus Node.js so
+# `npx create-video@latest`, `npx remotion studio`, and
+# `npx remotion render` work out of the box. ffmpeg/ffprobe
+# are intentionally not installed — Remotion bundles its own
+# via `npx remotion ffmpeg` (per skills/remotion/rules/ffmpeg.md),
+# and nixpkgs' Darwin ffmpeg build trips macOS' invalid-signature
+# check (SIGKILL on launch).
+
+[install]
+claude-code.pkg-path = "flox/claude-code"
+claude-code.pkg-group = "claude-code"
+claude-managed.pkg-path = "flox/claude-managed"
+claude-managed.pkg-group = "claude-managed"
+claude-managed.version = "^0.4.1"
+claude-code-plugin-remotion.pkg-path = "flox/claude-code-plugin-remotion"
+claude-code-plugin-remotion.pkg-group = "claude-code-plugin-remotion"
+nodejs.pkg-path = "nodejs_22"
+nodejs.pkg-group = "remotion"
+
+[hook]
+on-activate = '''
+eval "$(claude-managed setup-hook)"
+'''
+
+[profile]
+bash = '''
+eval "$(claude-managed setup-profile-bash)"
+'''
+zsh = '''
+eval "$(claude-managed setup-profile-zsh)"
+'''
+fish = '''
+claude-managed setup-profile-fish | source
+'''

--- a/remotion/README.md
+++ b/remotion/README.md
@@ -1,0 +1,79 @@
+# remotion
+
+Minimal [Remotion](https://remotion.dev) environment. Include
+it in your own manifest to get Claude Code with the Remotion
+best-practices skill pre-registered as a plugin, plus Node.js
+22 so `npx create-video`, `npx remotion studio`, and
+`npx remotion render` work out of the box.
+
+`ffmpeg`/`ffprobe` are intentionally not installed — Remotion
+ships its own via `npx remotion ffmpeg`, which is what the
+skill tells Claude to use.
+
+Remotion lets you build videos programmatically with React —
+animations, audio, captions, 3D, transitions, charts, and
+more.
+
+## Quick start
+
+Activate directly:
+
+```bash
+flox activate -r flox/remotion
+```
+
+Scaffold a new project and open the studio:
+
+```bash
+npx create-video@latest --yes --blank --no-tailwind my-video
+cd my-video
+npx remotion studio
+```
+
+Open Claude Code in the project and the `remotion-best-practices`
+skill is already registered — Claude will automatically load
+it whenever you work with Remotion code.
+
+## Include in your project
+
+Add to your `manifest.toml`:
+
+```toml
+[include]
+environments = ["flox/remotion"]
+```
+
+## What is included
+
+- `claude-code` — the Claude Code CLI
+- `claude-managed` — auto-registers the bundled plugin
+- `claude-code-plugin-remotion` — Remotion best-practices
+  skill (1 SKILL.md + 36 topic rules) installed under
+  `share/claude-code/plugins/remotion/`
+- `nodejs_22` — for `npx remotion …` and
+  `npx create-video@latest`
+
+## What the skill covers
+
+| Topic | Rule file |
+| ----- | --------- |
+| Animations & timing | `timing.md`, `text-animations.md`, `transitions.md` |
+| Audio & captions | `audio.md`, `voiceover.md`, `display-captions.md`, `subtitles.md`, `import-srt-captions.md`, `transcribe-captions.md`, `silence-detection.md` |
+| Video sources | `videos.md`, `gifs.md`, `transparent-videos.md`, `trimming.md` |
+| Images & fonts | `images.md`, `google-fonts.md`, `local-fonts.md` |
+| 3D & effects | `3d.md`, `lottie.md`, `light-leaks.md`, `html-in-canvas.md` |
+| Maps & charts | `maplibre.md`, `audio-visualization.md` |
+| Composition API | `compositions.md`, `sequencing.md`, `parameters.md`, `calculate-metadata.md` |
+| ffmpeg & measurement | `ffmpeg.md`, `measuring-dom-nodes.md`, `measuring-text.md`, `get-audio-duration.md`, `get-video-duration.md`, `get-video-dimensions.md` |
+| Styling | `tailwind.md` |
+| Misc | `sfx.md` |
+
+## See also
+
+For a styled demo with a sample blank project, see
+[remotion-demo](../remotion-demo/).
+
+Upstream skill source:
+<https://github.com/remotion-dev/skills>
+
+Remotion docs: <https://remotion.dev>

--- a/remotion/test.sh
+++ b/remotion/test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "Error: 'node' command not found."
+  exit 1
+fi
+if ! command -v claude >/dev/null 2>&1; then
+  echo "Error: 'claude' command not found."
+  exit 1
+fi
+if ! command -v claude-managed >/dev/null 2>&1; then
+  echo "Error: 'claude-managed' command not found."
+  exit 1
+fi
+
+echo ">>> node version: $(node --version)"
+echo ">>> claude version: $(claude --version 2>&1 | head -1)"
+
+# The plugin ships its skill tree under
+# $FLOX_ENV/share/claude-code/plugins/remotion/. Verify the
+# files claude-managed will discover are actually present —
+# without them the on-activate hook would silently register
+# an empty plugin.
+plugin_dir="$FLOX_ENV/share/claude-code/plugins/remotion"
+if [ ! -f "$plugin_dir/.claude-plugin/plugin.json" ]; then
+  echo "Error: plugin.json missing at $plugin_dir"
+  exit 1
+fi
+if [ ! -f "$plugin_dir/skills/remotion/SKILL.md" ]; then
+  echo "Error: SKILL.md missing at $plugin_dir"
+  exit 1
+fi
+echo ">>> remotion plugin tree present"
+
+# claude-managed setup-hook ran in on-activate and should
+# have symlinked the plugin under .claude-managed/. Without
+# this Claude Code lists the plugin but won't load it.
+if ! claude-managed plugins list 2>&1 | grep -q remotion; then
+  echo "Error: claude-managed did not register the remotion plugin"
+  claude-managed doctor || true
+  exit 1
+fi
+echo ">>> claude-managed registered the remotion plugin"
+
+echo ">>> remotion environment is working"


### PR DESCRIPTION
## Summary

Packages the Remotion Claude Code skill from<br>[remotion-dev/skills](<https://github.com/remotion-dev/skills>)<br>(the upstream consumed by `npx remotion skills add`) and<br>wires up minimal + demo flox envs around it.

* `claude-code-plugin-remotion` — nix package that<br>installs `skills/remotion/` (SKILL.md + 36 topic rules
  * 3 .tsx asset templates) under<br>`share/claude-code/plugins/remotion/`, with a<br>synthesized `.claude-plugin/plugin.json` (upstream<br>ships none — its canonical consumer drops skills<br>straight into `.claude/skills/`). Already published<br>for all 4 systems on FloxHub.
* `remotion/` — minimal env. Claude Code +<br>`claude-managed` + the plugin + `nodejs_22`. The<br>on-activate hook auto-registers the plugin, so `claude`<br>loads the skill immediately and `npx create-video`,<br>`npx remotion studio`, `npx remotion render` work out<br>of the box.
* `remotion-demo/` — adds `gum` for a styled welcome<br>banner with quick-start commands. No sample project —<br>Remotion's canonical scaffold is `npx create-video`,<br>so the demo points users at it instead of carrying a<br>stale snapshot.

ffmpeg/ffprobe intentionally omitted: nixpkgs' Darwin<br>ffmpeg trips the macOS invalid-signature check (SIGKILL<br>on launch), and the skill itself routes everything<br>through Remotion's bundled `npx remotion ffmpeg`.

## Test plan

- [X] `flox build claude-code-plugin-remotion` produces a<br>tree with `.claude-plugin/plugin.json` + 1 SKILL.md +<br>36 rules + 3 .tsx assets
- [X] `flox publish` succeeded for aarch64-darwin,<br>aarch64-linux, x86_64-darwin, x86_64-linux
- [X] `remotion/test.sh` passes inside `flox activate`<br>(node, claude, claude-managed present; plugin tree<br>present; plugin registered)
- [X] `remotion-demo/test.sh` passes (adds gum check)
- [X] `upgrade.sh` reports up-to-date against<br>remotion-dev/skills `main` HEAD
- [X] CI green