### PR TITLE
feat(ollama-cuda): add ollama with NVIDIA CUDA acceleration

### DIFF
--- a/.flox/pkgs/ollama-cuda/default.nix
+++ b/.flox/pkgs/ollama-cuda/default.nix
@@ -1,0 +1,109 @@
+{
+  lib,
+  callPackage,
+  buildEnv,
+  cudaPackages,
+  addDriverRunpath,
+  autoAddDriverRunpath,
+  makeBinaryWrapper,
+}:
+
+# ollama-cuda: the local ollama package with NVIDIA CUDA
+# acceleration enabled. Version, source, and vendorHash are
+# inherited from ../ollama via callPackage so the two stay in
+# lockstep — bumping ollama bumps ollama-cuda automatically.
+
+let
+  ollama = callPackage ../ollama { };
+
+  # Default CUDA target architectures. Covers from Maxwell
+  # (GTX 9xx) through Hopper (H100). Add newer arches here
+  # when cudaPackages in nixpkgs starts supporting them.
+  cudaArches = [
+    "50" # Maxwell  - GTX 9xx
+    "60" # Pascal   - P100
+    "61" # Pascal   - GTX 10xx, P40
+    "70" # Volta    - V100
+    "75" # Turing   - RTX 20xx, T4
+    "80" # Ampere   - A100
+    "86" # Ampere   - RTX 30xx
+    "89" # Ada      - RTX 40xx
+    "90" # Hopper   - H100
+  ];
+  cudaArchitectures = lib.concatStringsSep ";" cudaArches;
+
+  cudaLibs = [
+    cudaPackages.cuda_cudart
+    cudaPackages.libcublas
+    cudaPackages.cuda_cccl
+  ];
+
+  # ollama's CMakePresets.json hardcodes the CUDA major
+  # version in its preset names, so we expose a merged
+  # toolkit at $CUDA_PATH that contains nvcc plus the
+  # libraries cmake needs to find.
+  cudaMajorVersion =
+    lib.versions.major cudaPackages.cuda_cudart.version;
+
+  cudaToolkit = buildEnv {
+    name = "cuda-merged-${cudaMajorVersion}";
+    paths =
+      map lib.getLib cudaLibs
+      ++ [
+        (lib.getOutput "static" cudaPackages.cuda_cudart)
+        (lib.getBin (
+          cudaPackages.cuda_nvcc.__spliced.buildHost
+            or cudaPackages.cuda_nvcc
+        ))
+      ];
+    ignoreCollisions = true;
+  };
+
+  cudaPath =
+    lib.removeSuffix "-${cudaMajorVersion}" cudaToolkit;
+
+  # ollama embeds llama.cpp binaries that run the actual
+  # inference; their DT_RUNPATH is not patched, so we
+  # leak the GPU runtime in via LD_LIBRARY_PATH at the
+  # wrapper level. Same approach as nixpkgs upstream.
+  wrapperArgs = builtins.concatStringsSep " " [
+    "--suffix LD_LIBRARY_PATH : '${addDriverRunpath.driverLink}/lib'"
+    "--suffix LD_LIBRARY_PATH : '${lib.makeLibraryPath (map lib.getLib cudaLibs)}'"
+  ];
+in
+ollama.overrideAttrs (prevAttrs: {
+  pname = "ollama-cuda";
+
+  env = (prevAttrs.env or { }) // {
+    CUDA_PATH = cudaPath;
+  };
+
+  nativeBuildInputs =
+    (prevAttrs.nativeBuildInputs or [ ])
+    ++ [
+      cudaPackages.cuda_nvcc
+      makeBinaryWrapper
+      autoAddDriverRunpath
+    ];
+
+  buildInputs = (prevAttrs.buildInputs or [ ]) ++ cudaLibs;
+
+  preBuild = ''
+    cmake -B build \
+      -DCMAKE_SKIP_BUILD_RPATH=ON \
+      -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+      -DCMAKE_CUDA_ARCHITECTURES='${cudaArchitectures}'
+    cmake --build build -j $NIX_BUILD_CORES
+  '';
+
+  postFixup = ''
+    wrapProgram "$out/bin/ollama" ${wrapperArgs}
+  '';
+
+  meta = prevAttrs.meta // {
+    description =
+      prevAttrs.meta.description
+      + ", using CUDA for NVIDIA GPU acceleration";
+    platforms = [ "x86_64-linux" ];
+  };
+})

--- a/.flox/pkgs/ollama-cuda/publish.json
+++ b/.flox/pkgs/ollama-cuda/publish.json
@@ -1,0 +1,6 @@
+{
+  "org": "flox",
+  "systems": [
+    "x86_64-linux"
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `.flox/pkgs/ollama-cuda/` — a thin override of the local `ollama` package that enables NVIDIA CUDA acceleration.
- Version, source, and `vendorHash` are inherited from `../ollama` via `callPackage`, so `ollama-cuda` stays locked to whatever `ollama/hashes.json` says (currently `0.23.4`). Bumping `ollama` bumps `ollama-cuda` automatically — no separate `hashes.json`/`upgrade.sh` needed.
- The override layers in CUDA: `cuda_nvcc` + `autoAddDriverRunpath` + `makeBinaryWrapper` as native build inputs; `cuda_cudart` + `libcublas` + `cuda_cccl` as build inputs; `CUDA_PATH` env; `-DCMAKE_CUDA_ARCHITECTURES='50;60;61;70;75;80;86;89;90'` covering Maxwell → Hopper; and a `wrapProgram` postFixup that suffixes `LD_LIBRARY_PATH` with the driver link and CUDA library paths. Same approach as upstream `nixpkgs.ollama-cuda`.
- `meta.platforms` and `publish.json.systems` locked to `x86_64-linux`. `ci_pkgs.yml` auto-discovers the new package and routes to the linux builder only.

## Verified

- `flox build ollama-cuda --system x86_64-linux` succeeds on the remote builder.
- Output `/nix/store/.../ollama-cuda-0.23.4/`:
  - `bin/ollama` wrapper sets `LD_LIBRARY_PATH` to include `/run/opengl-driver/lib` (via `addDriverRunpath`) and the cudart/cublas/cccl store paths.
  - `lib/ollama/libggml-cuda.so` built for all 9 target GPU architectures.
  - `versionCheckHook` confirms `ollama --version` reports `0.23.4`, identical to the base `ollama` package.
- `autoAddDriverRunpath` handles `addDriverRunpath` + `removeStubsFromRunpath` on every ELF automatically — no manual RPATH patching needed.

## Test plan

- [ ] CI: `ci_pkgs.yml` builds `ollama-cuda` on `x86_64-linux`.
- [ ] On a host with an NVIDIA GPU + driver: `flox install flox/ollama-cuda` and verify `ollama run <model>` uses the GPU (`nvidia-smi` shows ollama processes).