### PR TITLE
feat(herdr): package herdr

### DIFF
--- a/.flox/pkgs/herdr/default.nix
+++ b/.flox/pkgs/herdr/default.nix
@@ -1,0 +1,106 @@
+{
+  lib,
+  stdenv,
+  stdenvNoCC,
+  fetchurl,
+  makeWrapper,
+  autoPatchelfHook,
+  darwin,
+  versionCheckHook,
+}:
+
+let
+  versionData =
+    builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    x86_64-linux = "linux-x86_64";
+    aarch64-linux = "linux-aarch64";
+    x86_64-darwin = "macos-x86_64";
+    aarch64-darwin = "macos-aarch64";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  platformSuffix = platformMap.${platform}
+    or (throw "Unsupported system: ${platform}");
+
+  src = fetchurl {
+    url = "https://github.com/ogulcancelik/herdr/releases/download/v${version}/herdr-${platformSuffix}";
+    hash = hashes.${platform};
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "herdr";
+  inherit version src;
+
+  dontUnpack = true;
+  dontBuild = true;
+  dontConfigure = true;
+  dontStrip = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    darwin.autoSignDarwinBinariesHook
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/bin/herdr
+
+    # Disable the upstream background update check by
+    # redirecting its manifest URL to 127.0.0.1, where
+    # the TCP connect is refused instantly. Replacement
+    # is exactly 29 bytes (same as the original), so
+    # all string-slice offsets and code refs stay
+    # intact — only the bytes at the URL site change.
+    # Idempotent: if upstream changes the URL, sed
+    # matches nothing and the badge returns instead of
+    # breaking the build.
+    #
+    # Tracked upstream: PR proposing an
+    # HERDR_DISABLE_UPDATE_CHECK env-var gate. Once
+    # merged, drop this patch and just set the env var
+    # in the env manifest — the binary is then
+    # untouched and this whole step disappears.
+    sed -i \
+      's|https://herdr.dev/latest.json|https://127.0.0.1/latest.json|g' \
+      $out/bin/herdr
+
+    # Patching invalidates the upstream adhoc signature;
+    # macOS refuses to load Mach-O binaries with a stale
+    # signature (SIGKILL at exec time). The
+    # `autoSignDarwinBinariesHook` in nativeBuildInputs
+    # re-signs adhoc during fixupPhase so the codesign
+    # hash matches the patched bytes.
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+  ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "Agent multiplexer that lives in your terminal";
+    homepage = "https://github.com/ogulcancelik/herdr";
+    changelog = "https://github.com/ogulcancelik/herdr/releases/tag/v${version}";
+    license = lib.licenses.agpl3Only;
+    sourceProvenance = with lib.sourceTypes; [ binaryNativeCode ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    mainProgram = "herdr";
+  };
+}

--- a/.flox/pkgs/herdr/hashes.json
+++ b/.flox/pkgs/herdr/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.5.10",
+  "hashes": {
+    "aarch64-darwin": "sha256-hKp/OMg1tOtao4wpZggTAjzyMXjkZUHEucJgcS/lLVE=",
+    "aarch64-linux": "sha256-ly1ips1U0BYtLegNuY2uQVt3L1WCL09fb4wy0BZLKbk=",
+    "x86_64-darwin": "sha256-5yMqu9BWiHuv4Pa4Hlj1njPK/XrGCeO8w1S44A77Bjc=",
+    "x86_64-linux": "sha256-9FwU+UnYW0dOcpd6AJ2B2lL7pORuKgJEjb+lk3Bl/Uw="
+  }
+}

--- a/.flox/pkgs/herdr/publish.json
+++ b/.flox/pkgs/herdr/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/herdr/upgrade.sh
+++ b/.flox/pkgs/herdr/upgrade.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+
+latest_version=$(
+  curl -sfL \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/ogulcancelik/herdr/releases/latest" \
+  | jq -r '.tag_name' \
+  | sed 's/^v//'
+)
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating herdr from $current_version to $latest_version"
+
+declare -A PLATFORMS=(
+  ["aarch64-darwin"]="macos-aarch64"
+  ["x86_64-darwin"]="macos-x86_64"
+  ["aarch64-linux"]="linux-aarch64"
+  ["x86_64-linux"]="linux-x86_64"
+)
+
+base_url="https://github.com/ogulcancelik/herdr/releases/download/v${latest_version}"
+
+hashes_json="{}"
+for system in "${!PLATFORMS[@]}"; do
+  suffix="${PLATFORMS[$system]}"
+  url="${base_url}/herdr-${suffix}"
+  raw=$(nix-prefetch-url "$url" 2>/dev/null)
+  sri=$(nix --extra-experimental-features nix-command \
+    hash convert --hash-algo sha256 --to sri "$raw")
+  echo "  $system: $sri"
+  hashes_json=$(echo "$hashes_json" \
+    | jq --arg p "$system" --arg h "$sri" '.[$p] = $h')
+done
+
+jq -n \
+  --arg v "$latest_version" \
+  --argjson h "$hashes_json" \
+  '{version: $v, hashes: ($h | to_entries | sort_by(.key) | from_entries)}' \
+  > "$HASHES_FILE"
+
+echo "Updated to $latest_version"


### PR DESCRIPTION
## Summary

Packages [herdr](https://github.com/ogulcancelik/herdr) — agent multiplexer that lives in your terminal (workspaces, tabs, panes, mouse-native, detach/reattach with agents still running). AGPL-3.0.

Fetches platform-specific prebuilt binaries from GitHub releases (linux-x86_64, linux-aarch64, macos-x86_64, macos-aarch64). Pinned at v0.5.10.

## Update-check suppression

The packaged binary is patched at install time to redirect the background update-check manifest URL (`https://herdr.dev/latest.json`) to `https://127.0.0.1/latest.json` — same byte length (29), no offset shifts. `autoSignDarwinBinariesHook` re-signs adhoc on macOS so the patched Mach-O loads.

A patch proposing an `HERDR_DISABLE_UPDATE_CHECK` env-var gate has been prepared to send upstream. Once merged, the binary patch can be dropped and the env (in the follow-up PR) sets the env var directly.

## Follow-up PR

`herdr/`, `herdr-demo/`, the per-env CI workflow, and the README table entry are intentionally **not** in this PR — they reference `flox/herdr` which doesn't exist in the FloxHub catalog yet. Once this PR merges and `ci_pkgs` publishes the package, a follow-up PR will add the envs with proper lockfiles.

## Test plan

- [x] `flox build herdr` succeeds locally on aarch64-darwin
- [x] `result/bin/herdr --version` returns `herdr 0.5.10`
- [x] Patched binary has 0 occurrences of `https://herdr.dev/latest.json`, 2 of `https://127.0.0.1/latest.json`
- [x] `codesign -dv` confirms valid adhoc signature on patched Mach-O
- [x] CI: `Build 'herdr'` passes for all 4 platforms
- [ ] After merge: `ci_pkgs` publishes `flox/herdr` to FloxHub
- [ ] Follow-up PR adds envs + locks to published v0.5.10