### PR TITLE
feat(skills-shipshit): package github.com/shipshitdev/skills

### DIFF
--- a/.flox/pkgs/skills-shipshit/default.nix
+++ b/.flox/pkgs/skills-shipshit/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+let
+  data = builtins.fromJSON (builtins.readFile ./hashes.json);
+
+  src = fetchFromGitHub {
+    owner = "shipshitdev";
+    repo = "skills";
+    rev = data.rev;
+    hash = data.srcHash;
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "skills-shipshit";
+  version = data.version;
+  inherit src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # The upstream repo bundles a collection of skills under
+    # `skills/<name>/SKILL.md`. Install each one as its own
+    # discoverable skill for both Claude Code and OpenCode.
+    for base in \
+      "$out/share/claude-code/skills" \
+      "$out/share/opencode/skills"; do
+      mkdir -p "$base"
+      for sub in "$src"/skills/*/; do
+        name="$(basename "$sub")"
+        if [ -f "$sub/SKILL.md" ]; then
+          mkdir -p "$base/$name"
+          cp -r "$sub"/. "$base/$name/"
+        fi
+      done
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Ship Shit Dev skills bundle for Claude Code and OpenCode "
+      + "— 150+ specialized agent skills for indie developers.";
+    homepage = "https://github.com/shipshitdev/skills";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/skills-shipshit/hashes.json
+++ b/.flox/pkgs/skills-shipshit/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "0+unstable-2026-04-21.f02a275",
+  "rev": "f02a2752896e7be1631fc252063561c2cff8123f",
+  "srcHash": "sha256-0+6w7RXcjg16q7p5+CwTcmog0wcGh3Wwocc9cHa2oVQ="
+}

--- a/.flox/pkgs/skills-shipshit/publish.json
+++ b/.flox/pkgs/skills-shipshit/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/skills-shipshit/upgrade.sh
+++ b/.flox/pkgs/skills-shipshit/upgrade.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="shipshitdev"
+REPO="skills"
+BRANCH="master"
+
+current_version=$(jq -r '.version // ""' "$HASHES_FILE")
+
+# Resolve current HEAD on the default branch to a full SHA.
+rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/heads/$BRANCH" | awk '{print $1}')
+
+if [ -z "$rev" ]; then
+  echo "Failed to resolve $BRANCH on $OWNER/$REPO" >&2
+  exit 1
+fi
+
+short_sha="${rev:0:7}"
+
+# Committer date (YYYY-MM-DD) via the GitHub commits API.
+commit_json=$(curl -sfL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
+commit_date=$(echo "$commit_json" \
+  | jq -r '.commit.committer.date' \
+  | cut -c1-10)
+
+# Upstream doesn't ship a version field in any SKILL.md frontmatter,
+# so synthesize a date+sha pseudo-version.
+new_version="0+unstable-${commit_date}.${short_sha}"
+
+echo "Current: $current_version"
+echo "Latest:  $new_version"
+
+if [ "$current_version" = "$new_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating skills-shipshit to $new_version"
+
+# Prefetch the source tarball and compute SRI hash.
+sha256_base32=$(nix-prefetch-url --unpack \
+  "https://github.com/$OWNER/$REPO/archive/$rev.tar.gz")
+sri_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$sha256_base32")
+
+jq -n \
+  --arg v "$new_version" \
+  --arg r "$rev" \
+  --arg h "$sri_hash" \
+  '{version: $v, rev: $r, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Wrote $HASHES_FILE:"
+cat "$HASHES_FILE"


### PR DESCRIPTION
## Summary

- Adds new flox package `skills-shipshit` that bundles 155 agent skills from
  [shipshitdev/skills](https://github.com/shipshitdev/skills) for both
  Claude Code and OpenCode
- Follows the same pattern as `skills-taste-skill` and `skills-agent-deck`:
  installs each `skills/<name>/SKILL.md` under
  `share/claude-code/skills/<name>/` and `share/opencode/skills/<name>/`
- Pinned to `master` @ `f02a275` (2026-04-21); `upgrade.sh` is
  auto-discovered by the Upgrade Packages workflow and will track future
  upstream commits

## Test plan

- [x] `flox build skills-shipshit` succeeds locally on darwin
- [x] Built output contains 155 skill directories under
      `share/claude-code/skills/` and `share/opencode/skills/`
- [x] Spot-checked that `SKILL.md` files retain their YAML frontmatter
- [x] CI build passes on all four systems
- [x] CI publishes to FloxHub `flox` org on merge to main