### PR TITLE
feat(claude-code-plugin-claude-blog): package new Claude Code plugin

### DIFF
--- a/.flox/pkgs/claude-code-plugin-claude-blog/default.nix
+++ b/.flox/pkgs/claude-code-plugin-claude-blog/default.nix
@@ -1,0 +1,119 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  python3,
+  curl,
+  gh,
+  git,
+  jq,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash;
+
+  # Python interpreter pre-loaded with the core deps that
+  # `scripts/analyze_blog.py` and the skill scripts import unconditionally.
+  # The plugin uses try/except for textstat + beautifulsoup4 (graceful
+  # degradation) but the analyzer's scoring is meaningfully worse without
+  # them, so we ship them by default.
+  #
+  # Heavier opt-in deps (spacy, sentence-transformers, scikit-learn,
+  # language-tool-python, patchright, google-api-python-client, etc.)
+  # are NOT bundled here: each skill that needs them ships its own
+  # `setup_environment.py` that builds a per-skill venv on demand. That
+  # venv calls `venv.create()` against this wrapped python3 and then
+  # pip-installs from the skill's requirements.lock at runtime — so the
+  # heavy deps land in user space, not in this derivation's closure.
+  pythonEnv = python3.withPackages (ps: with ps; [
+    beautifulsoup4
+    jsonschema
+    lxml
+    requests
+    textstat
+  ]);
+in
+stdenv.mkDerivation {
+  pname = "claude-code-plugin-claude-blog";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "AgriciDaniel";
+    repo = "claude-blog";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  # makeBinaryWrapper produces a compiled C wrapper for python3 so it
+  # is exec'd directly by the kernel via shebang on Darwin, where
+  # shebang chains through a shell script wrapper are unreliable
+  # under stripped environments.
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    PLUGIN_DIR="$out/share/claude-code/plugins/claude-blog"
+    mkdir -p "$PLUGIN_DIR"
+
+    # Upstream ships the Claude Code plugin source at the repo root —
+    # `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
+    # both live there. Copy the whole tree, then strip the install
+    # scripts (Claude Code plugins don't use them — the plugin dir IS
+    # the install) and repo-only metadata that would otherwise leak
+    # into the user-facing tree.
+    cp -r "$src"/. "$PLUGIN_DIR/"
+    chmod -R u+w "$PLUGIN_DIR"
+
+    rm -rf "$PLUGIN_DIR/.github" \
+           "$PLUGIN_DIR/.gitattributes" \
+           "$PLUGIN_DIR/.gitignore" \
+           "$PLUGIN_DIR/install.sh" \
+           "$PLUGIN_DIR/install.ps1" \
+           "$PLUGIN_DIR/uninstall.sh" \
+           "$PLUGIN_DIR/uninstall.ps1" \
+           "$PLUGIN_DIR/tests"
+
+    # Wrap python3 so subprocess.run() inside plugin scripts finds
+    # gh/curl/jq/git without depending on the caller's PATH. The
+    # blog-flow sync script shells to `gh auth token`; the Google
+    # skills shell to `curl` for OAuth and `gh` for token fallback.
+    runtimeBins=${lib.makeBinPath [ curl gh git jq ]}
+    mkdir -p "$out/bin"
+    makeBinaryWrapper "${pythonEnv}/bin/python3" "$out/bin/python3" \
+      --prefix PATH : "$runtimeBins"
+
+    # Repoint every #!/usr/bin/env python3 shebang at the wrapped
+    # python3. Marks files executable so the kernel honors the
+    # shebang when Claude Code invokes the script.
+    while IFS= read -r f; do
+      head -1 "$f" | grep -q '/usr/bin/env python3' || continue
+      substituteInPlace "$f" --replace-fail \
+        '#!/usr/bin/env python3' "#!$out/bin/python3"
+      chmod +x "$f"
+    done < <(find "$PLUGIN_DIR" -name '*.py' -type f)
+
+    # Rewrite upstream-install path references in markdown files to
+    # the ''${CLAUDE_PLUGIN_ROOT}/... form that Claude Code uses for
+    # plugins. Same helper as claude-code-plugin-claude-seo (same
+    # author, same `~/.claude/skills/<name>/...` reference style).
+    "$out/bin/python3" ${./fix_md_paths.py} "$PLUGIN_DIR"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "AI blog creation plugin for Claude Code (28 skills, 5 agents) with Python + core analysis deps bundled";
+    homepage = "https://github.com/AgriciDaniel/claude-blog";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/claude-code-plugin-claude-blog/fix_md_paths.py
+++ b/.flox/pkgs/claude-code-plugin-claude-blog/fix_md_paths.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Build-time helper: rewrite upstream-install path references in
+plugin markdown files to ${CLAUDE_PLUGIN_ROOT}/<actual-path>.
+
+The upstream repo's docs reference scripts and agent files at the
+paths the upstream install.sh creates them at:
+
+    ~/.claude/skills/seo/scripts/foo.py
+    ~/.claude/skills/seo-image-gen/scripts/foo.py
+    ~/.claude/agents/seo-foo.md
+    skills/seo/scripts/foo.py            (bare relative form)
+    agents/seo-foo.md                    (bare relative form)
+
+In a Flox-managed install the same files live under the plugin root
+exposed to Claude Code via ${CLAUDE_PLUGIN_ROOT}. This script walks
+the plugin tree, indexes every file by every path suffix, and for
+each reference picks the longest unambiguous suffix that matches a
+real file. That mapping drives the rewrite.
+
+Forwards-compatible: the index is built from whatever files are in
+the plugin tree at build time, so new upstream files are picked up
+automatically. Ambiguous suffixes (e.g. bare 'SKILL.md', which
+collides 27 times) fall through to longer suffixes; if nothing
+unambiguous is found, the reference is left alone.
+
+Usage: fix_md_paths.py <plugin-dir>
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+
+SUFFIXES_INDEXED = (".py", ".md", ".sh", ".json", ".txt", ".toml")
+PREFIX = "${CLAUDE_PLUGIN_ROOT}/"
+
+# Form 1: ~/, $HOME, or ${HOME} expansion of ~/.claude/<anything>.
+HOME_REF_RE = re.compile(
+    r"(?:~|\$HOME|\$\{HOME\})/\.claude/[A-Za-z0-9_./-]+"
+)
+
+# Form 2: bare 'skills/...' or 'agents/...' starting at a word
+# boundary. Anchored to (skills|agents) on purpose so this does not
+# match arbitrary relative paths.
+BARE_REF_RE = re.compile(
+    r"(?<![A-Za-z0-9_./~$-])(?:skills|agents)/[A-Za-z0-9_./-]+"
+)
+
+
+def build_indexes(
+    plugin_dir: str,
+) -> tuple[set[str], dict[str, set[str]]]:
+    """Walk the plugin tree and build two indexes.
+
+    Returns (all_relpaths, suffix_to_relpaths) where:
+    - all_relpaths is the set of every rel-path of an indexed file
+      (relative to plugin_dir, using '/' as separator)
+    - suffix_to_relpaths maps every '/'-separated suffix of every
+      rel-path back to the set of rel-paths that end with it. For a
+      file at 'a/b/c/d.py' the suffixes are 'd.py', 'c/d.py',
+      'b/c/d.py', and 'a/b/c/d.py'.
+    """
+    all_relpaths: set[str] = set()
+    suffix_to_relpaths: dict[str, set[str]] = {}
+    for root, _, files in os.walk(plugin_dir):
+        for fn in files:
+            if not fn.endswith(SUFFIXES_INDEXED):
+                continue
+            abs_path = os.path.join(root, fn)
+            rel = os.path.relpath(abs_path, plugin_dir).replace(os.sep, "/")
+            all_relpaths.add(rel)
+            parts = rel.split("/")
+            for i in range(len(parts)):
+                suffix = "/".join(parts[i:])
+                suffix_to_relpaths.setdefault(suffix, set()).add(rel)
+    return all_relpaths, suffix_to_relpaths
+
+
+def find_rel(
+    trailing: str,
+    all_relpaths: set[str],
+    suffix_to_relpaths: dict[str, set[str]],
+) -> str | None:
+    """Resolve a reference's trailing path to a real rel-path.
+
+    Strategy: try exact rel-path match first (so e.g.
+    'skills/seo-image-gen/SKILL.md' resolves to itself even though
+    it is also a suffix of 'extensions/banana/skills/seo-image-gen/
+    SKILL.md'). Fall back to matching progressively shorter
+    suffixes; accept a suffix only if it points to exactly one
+    rel-path or to an exact rel-path.
+    """
+    if trailing in all_relpaths:
+        return trailing
+    parts = trailing.split("/")
+    for i in range(1, len(parts)):
+        suffix = "/".join(parts[i:])
+        if not suffix:
+            continue
+        if suffix in all_relpaths:
+            return suffix
+        candidates = suffix_to_relpaths.get(suffix)
+        if candidates is not None and len(candidates) == 1:
+            return next(iter(candidates))
+    return None
+
+
+def trailing_after_dotclaude(ref: str) -> str:
+    """Strip the leading '~/.claude/' (or $HOME/.claude/) prefix."""
+    for prefix in ("~/.claude/", "$HOME/.claude/", "${HOME}/.claude/"):
+        if ref.startswith(prefix):
+            return ref[len(prefix):]
+    return ref
+
+
+def rewrite_text(
+    text: str,
+    all_relpaths: set[str],
+    suffix_to_relpaths: dict[str, set[str]],
+) -> tuple[str, int]:
+    rewrites = 0
+
+    def make_resolver(strip_dotclaude: bool):
+        def resolve(match: re.Match[str]) -> str:
+            nonlocal rewrites
+            full = match.group(0)
+            trailing = (
+                trailing_after_dotclaude(full) if strip_dotclaude else full
+            )
+            rel = find_rel(trailing, all_relpaths, suffix_to_relpaths)
+            if rel is None:
+                return full
+            replacement = PREFIX + rel
+            if replacement == full:
+                return full
+            rewrites += 1
+            return replacement
+        return resolve
+
+    text = HOME_REF_RE.sub(make_resolver(strip_dotclaude=True), text)
+    text = BARE_REF_RE.sub(make_resolver(strip_dotclaude=False), text)
+    return text, rewrites
+
+
+def main(plugin_dir: str) -> None:
+    all_relpaths, suffix_to_relpaths = build_indexes(plugin_dir)
+
+    files_changed = 0
+    refs_changed = 0
+    for root, _, files in os.walk(plugin_dir):
+        for fn in files:
+            if not fn.endswith(".md"):
+                continue
+            path = os.path.join(root, fn)
+            try:
+                with open(path, "r", encoding="utf-8") as fh:
+                    content = fh.read()
+            except (UnicodeDecodeError, OSError):
+                continue
+            new_content, n = rewrite_text(
+                content, all_relpaths, suffix_to_relpaths
+            )
+            if n == 0:
+                continue
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(new_content)
+            files_changed += 1
+            refs_changed += n
+
+    print(
+        f"fix_md_paths: rewrote {refs_changed} reference(s) "
+        f"across {files_changed} markdown file(s); "
+        f"indexed {len(all_relpaths)} file(s)"
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: fix_md_paths.py <plugin-dir>", file=sys.stderr)
+        sys.exit(2)
+    main(sys.argv[1])

--- a/.flox/pkgs/claude-code-plugin-claude-blog/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-claude-blog/hashes.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.7.1",
+  "srcHash": "sha256-cnzhfgft9h8PthWZ8nlqTXOke6wpA+RgbsFCPEpRe0Q="
+}

--- a/.flox/pkgs/claude-code-plugin-claude-blog/meta.yaml
+++ b/.flox/pkgs/claude-code-plugin-claude-blog/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: plugin
+name: claude-code-plugin-claude-blog
+title: claude-code-plugin-claude-blog (Claude Code plugin)
+plugin_for: claude-code
+publisher: flox
+tagline: >
+  AI blog creation and optimization skill bundle for Claude Code
+  (28 skills + 5 agents).
+category: ai
+ai_role: tooling
+tags: [claude-code, plugin, content, seo, blog]
+status: stable
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    claude-code-plugin-claude-blog.pkg-path = "flox/claude-code-plugin-claude-blog"
+    claude-code-plugin-claude-blog.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/claude-code-plugin-claude-blog
+  floxhub: https://hub.flox.dev/flox/claude-code-plugin-claude-blog

--- a/.flox/pkgs/claude-code-plugin-claude-blog/publish.json
+++ b/.flox/pkgs/claude-code-plugin-claude-blog/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/claude-code-plugin-claude-blog/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-claude-blog/upgrade.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+
+# Authenticated API calls use Actions' 5000/hr quota. The
+# unauthenticated 60/hr is shared per egress IP and gets exhausted
+# by parallel runners, surfacing as `curl exit 22`.
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
+latest_tag=$(curl -sfL --retry 3 --retry-delay 5 \
+  -H "Accept: application/vnd.github+json" \
+  "${auth_header[@]}" \
+  https://api.github.com/repos/AgriciDaniel/claude-blog/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating claude-code-plugin-claude-blog from $current_version to $latest_version"
+
+src_url="https://github.com/AgriciDaniel/claude-blog/archive/refs/tags/v${latest_version}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  '{version: $v, srcHash: $s}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"


### PR DESCRIPTION
## Summary

Packages [AgriciDaniel/claude-blog](https://github.com/AgriciDaniel/claude-blog) v1.7.1 as `flox/claude-code-plugin-claude-blog` — a Claude Code skill suite shipping 28 blog-writing skills + 5 specialist agents (content planning, drafting, SEO, fact-checking, multilingual publishing, AI-citation optimization).

Same file shape as the sibling plugin packages (`claude-seo`, `superpowers`, `impeccable`, `ui-ux-pro-max`, `financial-services`): no env directory, install line lives in `meta.yaml`.

## Build details

- **Wrapped python3** bundles the core analyzer deps (`textstat`, `beautifulsoup4`, `lxml`, `jsonschema`, `requests`) and prepends `curl`/`gh`/`git`/`jq` onto PATH for the Google-API skills and `scripts/sync_flow.py`.
- **Heavier opt-in deps** (`spacy`, `sentence-transformers`, `scikit-learn`, `language-tool-python`, `patchright`, `google-api-python-client`, …) are left to each skill's own `setup_environment.py` to pip-install into a per-skill venv on demand. Keeps the nix closure small.
- **`fix_md_paths.py`** is reused from `claude-code-plugin-claude-seo` (same upstream author, same `~/.claude/skills/<name>/…` reference style). On v1.7.1 it rewrites refs across the doc tree; the 3 leftover `~/.claude/` refs are intentional (point at user-owned `~/.claude/settings.json` and a user-editable templates dir).
- **`installed_plugins.json` not generated** — single-plugin package, same as `claude-seo`/`superpowers`/`impeccable`. Only `financial-services` needs it because it ships 19 plugin dirs in one derivation.

## Test plan

- [x] `nix build` succeeds on `aarch64-darwin` locally
- [x] Wrapped python imports all 5 bundled deps cleanly
- [x] `scripts/analyze_blog.py --help` runs through the patched shebang
- [x] `.claude-plugin/plugin.json` survives at `name=claude-blog`, `version=1.7.1`
- [x] `upgrade.sh` dry-run reports "Already up to date" at v1.7.1
- [ ] `ci_pkgs` builds for all 4 systems
- [ ] FloxHub publish on merge