### PR TITLE
feat(claude-ads): add claude-code-plugin-claude-ads package

### DIFF
--- a/.flox/pkgs/claude-code-plugin-claude-ads/default.nix
+++ b/.flox/pkgs/claude-code-plugin-claude-ads/default.nix
@@ -1,0 +1,122 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  python3,
+  curl,
+  git,
+  jq,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash;
+
+  # Python interpreter pre-loaded with every third-party module the
+  # plugin's scripts/ tree imports. requirements.txt lists optional
+  # AI image providers (google-genai, openai, stability-sdk, replicate)
+  # but those are gated behind ADS_IMAGE_PROVIDER env var — skip them
+  # at build time, the user can install via their own flox env if
+  # they want to drive generate_image.py directly (banana-claude is
+  # the default and lives outside this package).
+  pythonEnv = python3.withPackages (
+    ps: with ps; [
+      matplotlib
+      pillow
+      playwright
+      reportlab
+      requests
+      urllib3
+    ]
+  );
+in
+stdenv.mkDerivation {
+  pname = "claude-code-plugin-claude-ads";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "AgriciDaniel";
+    repo = "claude-ads";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  # makeBinaryWrapper produces a compiled C wrapper for python3 so it
+  # is exec'd directly by the kernel via shebang on Darwin, where
+  # shebang chains through a shell script wrapper are unreliable
+  # under stripped environments.
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  installPhase = ''
+    runHook preInstall
+
+    PLUGIN_DIR="$out/share/claude-code/plugins/claude-ads"
+    mkdir -p "$PLUGIN_DIR"
+    cp -r "$src"/. "$PLUGIN_DIR/"
+    chmod -R u+w "$PLUGIN_DIR"
+
+    # Strip dev/CI and user-install bootstrap files — the plugin
+    # consumer drives everything via Claude Code, not these.
+    rm -rf "$PLUGIN_DIR/.github" \
+           "$PLUGIN_DIR/install.sh" \
+           "$PLUGIN_DIR/install.ps1" \
+           "$PLUGIN_DIR/uninstall.sh" \
+           "$PLUGIN_DIR/uninstall.ps1" \
+           "$PLUGIN_DIR/requirements.txt" \
+           "$PLUGIN_DIR/requirements-dev.txt" \
+           "$PLUGIN_DIR/tests" \
+           "$PLUGIN_DIR/evals" \
+           "$PLUGIN_DIR/research"
+
+    # Wrap python3 so subprocess.run() inside plugin scripts finds
+    # curl/git/jq without depending on the caller's PATH. The scripts
+    # mostly call playwright (bundled with the pythonEnv) and optional
+    # `mmdc` (mermaid-cli, looked up via shutil.which and skipped if
+    # absent), but bundling these matches the claude-seo pattern so
+    # any future subprocess call surface keeps working.
+    runtimeBins=${
+      lib.makeBinPath [
+        curl
+        git
+        jq
+      ]
+    }
+    mkdir -p "$out/bin"
+    makeBinaryWrapper "${pythonEnv}/bin/python3" "$out/bin/python3" \
+      --prefix PATH : "$runtimeBins"
+
+    # Repoint every #!/usr/bin/env python3 shebang at the wrapped
+    # python3. Marks files executable so the kernel honors the
+    # shebang when Claude Code invokes them.
+    while IFS= read -r f; do
+      head -1 "$f" | grep -q '/usr/bin/env python3' || continue
+      substituteInPlace "$f" --replace-fail \
+        '#!/usr/bin/env python3' "#!$out/bin/python3"
+      chmod +x "$f"
+    done < <(find "$PLUGIN_DIR" -name '*.py' -type f)
+
+    # Rewrite upstream-install path references in markdown files to
+    # the ''${CLAUDE_PLUGIN_ROOT}/... form that Claude Code uses for
+    # plugins. Driven by a basename index of the plugin tree, so new
+    # upstream files added in future versions are picked up without
+    # changing this derivation.
+    "$out/bin/python3" ${./fix_md_paths.py} "$PLUGIN_DIR"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Paid advertising audit & optimization plugin for Claude Code "
+      + "(22 sub-skills, 10 agents) with Python + binaries bundled";
+    homepage = "https://github.com/AgriciDaniel/claude-ads";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/claude-code-plugin-claude-ads/fix_md_paths.py
+++ b/.flox/pkgs/claude-code-plugin-claude-ads/fix_md_paths.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Build-time helper: rewrite upstream-install path references in
+plugin markdown files to ${CLAUDE_PLUGIN_ROOT}/<actual-path>.
+
+The upstream repo's docs reference scripts and agent files at the
+paths the upstream install.sh creates them at:
+
+    ~/.claude/skills/seo/scripts/foo.py
+    ~/.claude/skills/seo-image-gen/scripts/foo.py
+    ~/.claude/agents/seo-foo.md
+    skills/seo/scripts/foo.py            (bare relative form)
+    agents/seo-foo.md                    (bare relative form)
+
+In a Flox-managed install the same files live under the plugin root
+exposed to Claude Code via ${CLAUDE_PLUGIN_ROOT}. This script walks
+the plugin tree, indexes every file by every path suffix, and for
+each reference picks the longest unambiguous suffix that matches a
+real file. That mapping drives the rewrite.
+
+Forwards-compatible: the index is built from whatever files are in
+the plugin tree at build time, so new upstream files are picked up
+automatically. Ambiguous suffixes (e.g. bare 'SKILL.md', which
+collides 27 times) fall through to longer suffixes; if nothing
+unambiguous is found, the reference is left alone.
+
+Usage: fix_md_paths.py <plugin-dir>
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+
+SUFFIXES_INDEXED = (".py", ".md", ".sh", ".json", ".txt", ".toml")
+PREFIX = "${CLAUDE_PLUGIN_ROOT}/"
+
+# Form 1: ~/, $HOME, or ${HOME} expansion of ~/.claude/<anything>.
+HOME_REF_RE = re.compile(
+    r"(?:~|\$HOME|\$\{HOME\})/\.claude/[A-Za-z0-9_./-]+"
+)
+
+# Form 2: bare 'skills/...' or 'agents/...' starting at a word
+# boundary. Anchored to (skills|agents) on purpose so this does not
+# match arbitrary relative paths.
+BARE_REF_RE = re.compile(
+    r"(?<![A-Za-z0-9_./~$-])(?:skills|agents)/[A-Za-z0-9_./-]+"
+)
+
+
+def build_indexes(
+    plugin_dir: str,
+) -> tuple[set[str], dict[str, set[str]]]:
+    """Walk the plugin tree and build two indexes.
+
+    Returns (all_relpaths, suffix_to_relpaths) where:
+    - all_relpaths is the set of every rel-path of an indexed file
+      (relative to plugin_dir, using '/' as separator)
+    - suffix_to_relpaths maps every '/'-separated suffix of every
+      rel-path back to the set of rel-paths that end with it. For a
+      file at 'a/b/c/d.py' the suffixes are 'd.py', 'c/d.py',
+      'b/c/d.py', and 'a/b/c/d.py'.
+    """
+    all_relpaths: set[str] = set()
+    suffix_to_relpaths: dict[str, set[str]] = {}
+    for root, _, files in os.walk(plugin_dir):
+        for fn in files:
+            if not fn.endswith(SUFFIXES_INDEXED):
+                continue
+            abs_path = os.path.join(root, fn)
+            rel = os.path.relpath(abs_path, plugin_dir).replace(os.sep, "/")
+            all_relpaths.add(rel)
+            parts = rel.split("/")
+            for i in range(len(parts)):
+                suffix = "/".join(parts[i:])
+                suffix_to_relpaths.setdefault(suffix, set()).add(rel)
+    return all_relpaths, suffix_to_relpaths
+
+
+def find_rel(
+    trailing: str,
+    all_relpaths: set[str],
+    suffix_to_relpaths: dict[str, set[str]],
+) -> str | None:
+    """Resolve a reference's trailing path to a real rel-path.
+
+    Strategy: try exact rel-path match first (so e.g.
+    'skills/seo-image-gen/SKILL.md' resolves to itself even though
+    it is also a suffix of 'extensions/banana/skills/seo-image-gen/
+    SKILL.md'). Fall back to matching progressively shorter
+    suffixes; accept a suffix only if it points to exactly one
+    rel-path or to an exact rel-path.
+    """
+    if trailing in all_relpaths:
+        return trailing
+    parts = trailing.split("/")
+    for i in range(1, len(parts)):
+        suffix = "/".join(parts[i:])
+        if not suffix:
+            continue
+        if suffix in all_relpaths:
+            return suffix
+        candidates = suffix_to_relpaths.get(suffix)
+        if candidates is not None and len(candidates) == 1:
+            return next(iter(candidates))
+    return None
+
+
+def trailing_after_dotclaude(ref: str) -> str:
+    """Strip the leading '~/.claude/' (or $HOME/.claude/) prefix."""
+    for prefix in ("~/.claude/", "$HOME/.claude/", "${HOME}/.claude/"):
+        if ref.startswith(prefix):
+            return ref[len(prefix):]
+    return ref
+
+
+def rewrite_text(
+    text: str,
+    all_relpaths: set[str],
+    suffix_to_relpaths: dict[str, set[str]],
+) -> tuple[str, int]:
+    rewrites = 0
+
+    def make_resolver(strip_dotclaude: bool):
+        def resolve(match: re.Match[str]) -> str:
+            nonlocal rewrites
+            full = match.group(0)
+            trailing = (
+                trailing_after_dotclaude(full) if strip_dotclaude else full
+            )
+            rel = find_rel(trailing, all_relpaths, suffix_to_relpaths)
+            if rel is None:
+                return full
+            replacement = PREFIX + rel
+            if replacement == full:
+                return full
+            rewrites += 1
+            return replacement
+        return resolve
+
+    text = HOME_REF_RE.sub(make_resolver(strip_dotclaude=True), text)
+    text = BARE_REF_RE.sub(make_resolver(strip_dotclaude=False), text)
+    return text, rewrites
+
+
+def main(plugin_dir: str) -> None:
+    all_relpaths, suffix_to_relpaths = build_indexes(plugin_dir)
+
+    files_changed = 0
+    refs_changed = 0
+    for root, _, files in os.walk(plugin_dir):
+        for fn in files:
+            if not fn.endswith(".md"):
+                continue
+            path = os.path.join(root, fn)
+            try:
+                with open(path, "r", encoding="utf-8") as fh:
+                    content = fh.read()
+            except (UnicodeDecodeError, OSError):
+                continue
+            new_content, n = rewrite_text(
+                content, all_relpaths, suffix_to_relpaths
+            )
+            if n == 0:
+                continue
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(new_content)
+            files_changed += 1
+            refs_changed += n
+
+    print(
+        f"fix_md_paths: rewrote {refs_changed} reference(s) "
+        f"across {files_changed} markdown file(s); "
+        f"indexed {len(all_relpaths)} file(s)"
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: fix_md_paths.py <plugin-dir>", file=sys.stderr)
+        sys.exit(2)
+    main(sys.argv[1])

--- a/.flox/pkgs/claude-code-plugin-claude-ads/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-claude-ads/hashes.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.7.1",
+  "srcHash": "sha256-iIN+JP7zOYrktVe8kc+09bQkRvM6/+J/H5SdU8YqzgQ="
+}

--- a/.flox/pkgs/claude-code-plugin-claude-ads/publish.json
+++ b/.flox/pkgs/claude-code-plugin-claude-ads/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/claude-code-plugin-claude-ads/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-claude-ads/upgrade.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+
+# Authenticated API calls use Actions' 5000/hr quota. The
+# unauthenticated 60/hr is shared per egress IP and gets exhausted
+# by parallel runners, surfacing as `curl exit 22`.
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
+latest_tag=$(curl -sfL --retry 3 --retry-delay 5 \
+  -H "Accept: application/vnd.github+json" \
+  "${auth_header[@]}" \
+  https://api.github.com/repos/AgriciDaniel/claude-ads/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating claude-code-plugin-claude-ads from $current_version to $latest_version"
+
+src_url="https://github.com/AgriciDaniel/claude-ads/archive/refs/tags/v${latest_version}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  '{version: $v, srcHash: $s}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"


### PR DESCRIPTION
## Summary

- Wraps [AgriciDaniel/claude-ads](https://github.com/AgriciDaniel/claude-ads) v1.7.1 as a Flox-published Claude Code plugin under `share/claude-code/plugins/claude-ads/`.
- Bundles `python3` with the upstream `requirements.txt` runtime deps (`requests`, `urllib3`, `playwright`, `pillow`, `reportlab`, `matplotlib`) and wraps it with `curl`/`git`/`jq` on PATH. Optional AI image providers (gemini/openai/stability/replicate) are skipped — they're gated behind `ADS_IMAGE_PROVIDER` and the default (banana-claude) lives outside this package.
- Patches `#!/usr/bin/env python3` shebangs to the bundled python, strips dev/CI/installer files, and runs the same `fix_md_paths.py` as `claude-code-plugin-claude-seo` (same upstream author) — rewrites 41 path refs across 11 markdown files from `~/.claude/skills/ads/...` / bare `agents/...` to `${CLAUDE_PLUGIN_ROOT}/...`.

## Test plan

- [x] `nix-build` succeeds on `aarch64-darwin`.
- [x] `fix_md_paths` reports `rewrote 41 reference(s) across 11 markdown file(s); indexed 93 file(s)`.
- [x] Wrapped `$out/bin/python3 -c 'import requests, urllib3, PIL, playwright, reportlab, matplotlib'` resolves clean.
- [x] `.claude-plugin/{plugin,marketplace}.json` preserved in the install tree.
- [x] Patched shebangs point at the bundled `python3`.
- [x] Verify CI builds on the other three systems.