### PR TITLE
feat: add claude-code-plugin-claude-obsidian package (Claude + Obsidian)

### DIFF
--- a/.flox/pkgs/claude-code-plugin-claude-obsidian/default.nix
+++ b/.flox/pkgs/claude-code-plugin-claude-obsidian/default.nix
@@ -1,0 +1,135 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  makeBinaryWrapper,
+  python3,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash commitSha;
+in
+stdenv.mkDerivation {
+  pname = "claude-code-plugin-claude-obsidian";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "AgriciDaniel";
+    repo = "claude-obsidian";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  # makeBinaryWrapper produces a compiled C wrapper for python3 so it
+  # is exec'd directly by the kernel via shebang on Darwin, where
+  # shebang chains through a shell-script wrapper are unreliable
+  # under stripped environments.
+  nativeBuildInputs = [ makeBinaryWrapper ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    PLUGIN_DIR="$out/share/claude-code/plugins/claude-obsidian"
+    mkdir -p "$PLUGIN_DIR"
+
+    # Upstream ships the Claude Code plugin source at the repo root —
+    # `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
+    # both live at the top level. Copy the whole tree, then strip per-
+    # harness mirrors, repo-only metadata, upstream test runners, and
+    # upstream's own dogfood vault content.
+    cp -r "$src"/. "$PLUGIN_DIR/"
+    chmod -R u+w "$PLUGIN_DIR"
+
+    # Per-harness mirrors and repo/CI metadata that aren't part of the
+    # runtime plugin.
+    rm -rf "$PLUGIN_DIR/.cursor" \
+           "$PLUGIN_DIR/.windsurf" \
+           "$PLUGIN_DIR/.github" \
+           "$PLUGIN_DIR/.gitignore" \
+           "$PLUGIN_DIR/AGENTS.md" \
+           "$PLUGIN_DIR/CLAUDE.md" \
+           "$PLUGIN_DIR/GEMINI.md" \
+           "$PLUGIN_DIR/Makefile" \
+           "$PLUGIN_DIR/tests"
+
+    # Upstream's own dogfood vault: example pages, raw clips, and vault
+    # metadata. Users start with an empty vault — these would otherwise
+    # leak upstream-specific content into every install.
+    rm -rf "$PLUGIN_DIR/wiki" \
+           "$PLUGIN_DIR/.raw" \
+           "$PLUGIN_DIR/.vault-meta"
+
+    # Wrap python3 so the DragonScale scripts (boundary-score.py,
+    # tiling-check.py) resolve a working interpreter even when the
+    # consumer's flox env doesn't ship one. Both scripts use only the
+    # Python stdlib (urllib for ollama, fcntl for locking, hashlib,
+    # math, re, etc.) so no extra packages are needed.
+    mkdir -p "$PLUGIN_DIR/bin-runtime"
+    makeBinaryWrapper "${python3}/bin/python3" \
+      "$PLUGIN_DIR/bin-runtime/python3"
+
+    # Repoint every `#!/usr/bin/env python3` shebang at the wrapped
+    # python and mark executable so the kernel honors the shebang when
+    # Claude Code (or the user) invokes the script directly.
+    while IFS= read -r f; do
+      head -1 "$f" | grep -q '/usr/bin/env python3' || continue
+      substituteInPlace "$f" --replace-fail \
+        '#!/usr/bin/env python3' "#!$PLUGIN_DIR/bin-runtime/python3"
+      chmod +x "$f"
+    done < <(find "$PLUGIN_DIR" -type f -name '*.py')
+
+    # Bash scripts compute the vault root from BASH_SOURCE
+    # (`$(dirname "''${BASH_SOURCE[0]}")/..`), so they only function
+    # correctly when copied/symlinked into the user's vault — wrapping
+    # them with nix-store paths would point VAULT_ROOT at the plugin
+    # install and break the design. Just make them executable for the
+    # case where the user does copy them into their vault.
+    find "$PLUGIN_DIR/bin" "$PLUGIN_DIR/scripts" \
+      -type f -name '*.sh' -exec chmod +x {} +
+
+    # Drop an installed_plugins.json next to the plugin so claude-managed
+    # registers it in $CLAUDE_CONFIG_DIR/plugins/installed_plugins.json
+    # — without that file Claude Code lists the plugin but won't trust
+    # it. Schema follows the v2 (`plugins` wrapper) format claude-managed
+    # uses; installPath is patched to the real symlink target by
+    # `claude-managed plugins add`.
+    cat > "$PLUGIN_DIR/installed_plugins.json" <<JSON
+    {
+      "plugins": {
+        "claude-obsidian@flox": [
+          {
+            "installPath": "",
+            "scope": "project",
+            "version": "${version}",
+            "gitCommitSha": "${commitSha}"
+          }
+        ]
+      },
+      "version": 2
+    }
+    JSON
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Claude + Obsidian knowledge companion plugin for Claude Code "
+      + "— persistent compounding wiki vault (Karpathy LLM Wiki "
+      + "pattern) with /wiki, /save, /autoresearch, /canvas commands, "
+      + "agents, hooks, and the DragonScale Memory extension "
+      + "(Python runtime bundled).";
+    homepage = "https://github.com/AgriciDaniel/claude-obsidian";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/claude-code-plugin-claude-obsidian/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-claude-obsidian/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.6.0",
+  "srcHash": "sha256-aWtBj+phuaQqx4ZtnvJc/7U8nhzPP6u5UbuDv4Ve5PE=",
+  "commitSha": "442e9bfa8322c01063ecd275abe0710797442859"
+}

--- a/.flox/pkgs/claude-code-plugin-claude-obsidian/publish.json
+++ b/.flox/pkgs/claude-code-plugin-claude-obsidian/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/claude-code-plugin-claude-obsidian/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-claude-obsidian/upgrade.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="AgriciDaniel"
+REPO="claude-obsidian"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+
+# Upstream tags releases as `vX.Y.Z`. Pull the latest such tag.
+latest_tag=$(curl -sf \
+  "https://api.github.com/repos/$OWNER/$REPO/releases/latest" \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating claude-code-plugin-claude-obsidian from $current_version to $latest_version"
+
+src_url="https://github.com/$OWNER/$REPO/archive/refs/tags/v${latest_version}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+# Resolve the annotated tag to its underlying commit SHA (refs/tags/<v>^{}).
+# Claude Code's installed_plugins.json records gitCommitSha per entry, and
+# shipping the real commit SHA — not the tag-object SHA — lets users
+# reproduce or audit exactly which upstream commit they have.
+commit_sha=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/tags/v${latest_version}^{}" | awk '{print $1}')
+if [ -z "$commit_sha" ]; then
+  # Fall back to the tag ref directly for lightweight tags.
+  commit_sha=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+    "refs/tags/v${latest_version}" | awk '{print $1}')
+fi
+if [ -z "$commit_sha" ]; then
+  echo "ERROR: could not resolve v${latest_version} to a commit SHA"
+  exit 1
+fi
+echo "  commitSha: $commit_sha"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg c "$commit_sha" \
+  '{version: $v, srcHash: $s, commitSha: $c}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"


### PR DESCRIPTION
## Summary

- Package [AgriciDaniel/claude-obsidian](https://github.com/AgriciDaniel/claude-obsidian) v1.6.0 — Claude + Obsidian knowledge companion plugin (persistent compounding wiki vault based on Karpathy's LLM Wiki pattern; ships `/wiki`, `/save`, `/autoresearch`, `/canvas` commands, agents, hooks, and the DragonScale Memory extension)
- `.flox/pkgs/claude-code-plugin-claude-obsidian/{default.nix,hashes.json,publish.json,upgrade.sh}` follows the existing `claude-code-plugin-ui-ux-pro-max` pattern (plugin tree at `$out/share/claude-code/plugins/claude-obsidian/`, v2 `installed_plugins.json` for `claude-managed`, `commitSha` recorded for audit/repro)
- Bundles `python3` via `makeBinaryWrapper` for the DragonScale scripts (`boundary-score.py`, `tiling-check.py` — stdlib-only); bash scripts (`bin/setup-*.sh`, `scripts/allocate-address.sh`) stay un-wrapped because they derive `VAULT_ROOT` from `BASH_SOURCE` and must run from inside the user's vault
- Strips per-harness mirrors (`.cursor`, `.windsurf`, `.github`, `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, `Makefile`, `tests/`) and upstream's dogfood vault content (`wiki/`, `.raw/`, `.vault-meta/`) so installs start clean
- Pinned to v1.6.0; auto-upgrades via `upgrade_pkgs.yml` (resolves peeled annotated-tag commit SHA via `refs/tags/v\${V}^{}`); publishes to the `flox` org for all four systems

## Test plan

- [x] \`flox build claude-code-plugin-claude-obsidian\` succeeds locally (aarch64-darwin)
- [x] \`result/share/claude-code/plugins/claude-obsidian/.claude-plugin/plugin.json\` reads \`claude-obsidian v1.6.0\`
- [x] \`scripts/boundary-score.py --help\` runs via the bundled \`bin-runtime/python3\` wrapper
- [x] \`scripts/tiling-check.py --help\` runs via the bundled \`bin-runtime/python3\` wrapper
- [x] \`installed_plugins.json\` matches the v2 schema (\`plugins.claude-obsidian@flox\` with \`scope\`/\`version\`/\`gitCommitSha\`)
- [x] Stripped dirs absent from the build output (\`wiki/\`, \`.raw/\`, \`.vault-meta/\`, \`.cursor/\`, \`.windsurf/\`, \`.github/\`, \`AGENTS.md\`, \`CLAUDE.md\`, \`GEMINI.md\`, \`Makefile\`, \`tests/\`)
- [x] \`bash .flox/pkgs/claude-code-plugin-claude-obsidian/upgrade.sh\` correctly reports "Already up to date"
- [ ] CI \`Build 'claude-code-plugin-claude-obsidian' (<system>)\` passes for all four systems