### PR TITLE
feat(pkgs): add wave 1 LLM-agent packages

### DIFF
--- a/.flox/pkgs/amp/default.nix
+++ b/.flox/pkgs/amp/default.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  autoPatchelfHook,
+  ripgrep,
+  cctools,
+  darwin,
+  rcodesign,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version;
+  hashes = versionData.binaryHashes;
+
+  platformMap = {
+    x86_64-linux = "linux-x64";
+    aarch64-linux = "linux-arm64";
+    x86_64-darwin = "darwin-x64";
+    aarch64-darwin = "darwin-arm64";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  platformSuffix = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+in
+stdenv.mkDerivation {
+  pname = "amp";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://static.ampcode.com/cli/${version}/amp-${platformSuffix}";
+    hash = hashes.${platform};
+  };
+
+  dontUnpack = true;
+  # Do not mess with the bun runtime embedded in the binary.
+  dontStrip = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    cctools
+    rcodesign
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/bin/amp
+
+    runHook postInstall
+  '';
+
+  # Rewrite Bun's ICU dependency to Nix-provided darwin.ICU instead of
+  # /usr/lib/libicucore.A.dylib, which needs /usr/share/icu/ at runtime.
+  # This avoids __noChroot and lets the build run in the macOS sandbox.
+  # Re-signing is required after the modification invalidates the signature.
+  postFixup = ''
+    ${lib.optionalString stdenv.hostPlatform.isDarwin ''
+      ${lib.getExe' cctools "${cctools.targetPrefix}install_name_tool"} \
+        $out/bin/amp \
+        -change /usr/lib/libicucore.A.dylib \
+        '${lib.getLib darwin.ICU}/lib/libicucore.A.dylib'
+      ${lib.getExe rcodesign} sign \
+        --code-signature-flags linker-signed $out/bin/amp
+    ''}
+    wrapProgram $out/bin/amp \
+      --argv0 amp \
+      --prefix PATH : ${lib.makeBinPath [ ripgrep ]} \
+      --set AMP_SKIP_UPDATE_CHECK 1
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  meta = {
+    description = "CLI for Amp, Sourcegraph's agentic coding tool";
+    homepage = "https://ampcode.com/";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    mainProgram = "amp";
+  };
+}

--- a/.flox/pkgs/amp/hashes.json
+++ b/.flox/pkgs/amp/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.0.1779153253-gb08bda",
+  "binaryHashes": {
+    "aarch64-darwin": "sha256-Gs4UfGJFi4E9MR+XvwswhW+6DHr37nMrfH2tiMcY2Fs=",
+    "aarch64-linux": "sha256-ZhIAV2zhICoqeY5KbICPEIa4Vm5z5TJnm1r0ZIzzys4=",
+    "x86_64-darwin": "sha256-WhFC4Lu8WLI1NDB/ppPZiqK4uOcLe0HOrbpCgGwbDhI=",
+    "x86_64-linux": "sha256-PE7aEIsOxfzUqhKEN3BPfGu2XvwGq3f2b03qstWDr0Y="
+  }
+}

--- a/.flox/pkgs/amp/publish.json
+++ b/.flox/pkgs/amp/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/amp/upgrade.sh
+++ b/.flox/pkgs/amp/upgrade.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+STORAGE_BASE="https://static.ampcode.com/cli"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_version=$(curl -sfL "$STORAGE_BASE/cli-version.txt" | tr -d '[:space:]')
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating amp from $current_version to $latest_version"
+
+declare -A PLATFORMS=(
+  ["aarch64-darwin"]="darwin-arm64"
+  ["aarch64-linux"]="linux-arm64"
+  ["x86_64-darwin"]="darwin-x64"
+  ["x86_64-linux"]="linux-x64"
+)
+
+hashes_json="{}"
+for system in "${!PLATFORMS[@]}"; do
+  amp_plat="${PLATFORMS[$system]}"
+  hex=$(curl -sfL "$STORAGE_BASE/$latest_version/$amp_plat-amp.sha256" \
+    | awk '{print $1}')
+  sri=$(nix hash convert --hash-algo sha256 --to sri "$hex")
+  echo "  $system: $sri"
+  hashes_json=$(echo "$hashes_json" \
+    | jq --arg p "$system" --arg h "$sri" '.[$p] = $h')
+done
+
+jq -n \
+  --arg v "$latest_version" \
+  --argjson h "$hashes_json" \
+  '{version: $v, binaryHashes: ($h | to_entries | sort_by(.key) | from_entries)}' \
+  > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.flox/pkgs/copilot-cli/default.nix
+++ b/.flox/pkgs/copilot-cli/default.nix
@@ -1,0 +1,81 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  autoPatchelfHook,
+  cacert,
+  nodejs_24,
+  ripgrep,
+  bash,
+  versionCheckHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "copilot-cli";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://registry.npmjs.org/@github/copilot/-/copilot-${version}.tgz";
+    hash = srcHash;
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [ autoPatchelfHook ];
+
+  # Bundled mxc-bin/{x64,arm64}/lxc-exec dlopen libgcc_s.so.1 at runtime.
+  runtimeDependencies = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+  ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/lib/${finalAttrs.pname}
+    cp -r . $out/lib/${finalAttrs.pname}
+
+    mkdir -p $out/bin
+    makeWrapper ${nodejs_24}/bin/node $out/bin/copilot \
+      --add-flags "$out/lib/${finalAttrs.pname}/index.js" \
+      --set SSL_CERT_DIR "${cacert}/etc/ssl/certs" \
+      --set-default COPILOT_AUTO_UPDATE false \
+      --set-default USE_BUILTIN_RIPGREP false \
+      --prefix PATH : ${
+        lib.makeBinPath [
+          ripgrep
+          bash
+        ]
+      }
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+  versionCheckProgramArg = "--version";
+
+  meta = {
+    description = "GitHub Copilot CLI - Copilot coding agent in your terminal";
+    homepage = "https://github.com/github/copilot-cli";
+    changelog = "https://github.com/github/copilot-cli/releases/tag/v${version}";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryBytecode
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    mainProgram = "copilot";
+  };
+})

--- a/.flox/pkgs/copilot-cli/hashes.json
+++ b/.flox/pkgs/copilot-cli/hashes.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0.49",
+  "srcHash": "sha256-DHqo7cGuGISKJ+7y8wZXmDQPt6mFzfum5enLALf8mNU="
+}

--- a/.flox/pkgs/copilot-cli/publish.json
+++ b/.flox/pkgs/copilot-cli/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/copilot-cli/upgrade.sh
+++ b/.flox/pkgs/copilot-cli/upgrade.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_version=$(curl -sfL https://registry.npmjs.org/@github/copilot \
+  | jq -r '."dist-tags".latest')
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating copilot-cli from $current_version to $latest_version"
+
+src_url="https://registry.npmjs.org/@github/copilot/-/copilot-${latest_version}.tgz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url "$src_url" 2>/dev/null)
+src_sri=$(nix hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  '{version: $v, srcHash: $s}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.flox/pkgs/cursor-agent/default.nix
+++ b/.flox/pkgs/cursor-agent/default.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  coreutils,
+  autoPatchelfHook,
+  zlib,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    x86_64-linux = "linux/x64";
+    aarch64-linux = "linux/arm64";
+    x86_64-darwin = "darwin/x64";
+    aarch64-darwin = "darwin/arm64";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  platformPath = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+
+  src = fetchurl {
+    url = "https://downloads.cursor.com/lab/${version}" + "/${platformPath}/agent-cli-package.tar.gz";
+    hash = hashes.${platform};
+  };
+in
+stdenv.mkDerivation {
+  pname = "cursor-agent";
+  inherit version src;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    stdenv.cc.cc.lib
+    zlib
+  ];
+
+  unpackPhase = ''
+    runHook preUnpack
+    tar -xzf $src
+    runHook postUnpack
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out
+    cp -r dist-package/* $out/
+
+    chmod +x $out/cursor-agent
+    chmod +x $out/node
+    chmod +x $out/rg
+
+    mkdir -p $out/bin
+    makeWrapper $out/cursor-agent $out/bin/cursor-agent \
+      --prefix PATH : $out \
+      --prefix PATH : ${coreutils}/bin
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  meta = {
+    description = "CLI tool for Cursor AI code editor";
+    homepage = "https://cursor.com/";
+    changelog = "https://www.cursor.com/changelog";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    mainProgram = "cursor-agent";
+  };
+}

--- a/.flox/pkgs/cursor-agent/hashes.json
+++ b/.flox/pkgs/cursor-agent/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "2026.05.16-0338208",
+  "hashes": {
+    "aarch64-darwin": "sha256-xVwbcStx3UW89PBCE4zfAWNUSvs4NlneLPgY8yJDLag=",
+    "aarch64-linux": "sha256-WM3Ucu5ia9rlEgXtfNYea6B7ccgmpFJm/p4JpQje+Vs=",
+    "x86_64-darwin": "sha256-0/CJxz14JgrCAwhbXeSHXYwnpvh4AnbjUHOUzNxxBJw=",
+    "x86_64-linux": "sha256-E2YeEnyAjbGXe1lpcpZnb/NBWNOoQYRkCfuokvkQsaI="
+  }
+}

--- a/.flox/pkgs/cursor-agent/publish.json
+++ b/.flox/pkgs/cursor-agent/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/cursor-agent/upgrade.sh
+++ b/.flox/pkgs/cursor-agent/upgrade.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+# Cursor publishes the current agent CLI version on their install page;
+# the lab download URL embeds it as <year>.<month>.<day>-<short-sha>.
+VERSION_URL="https://cursor.com/install"
+VERSION_RE='downloads\.cursor\.com/lab/([0-9]{4}\.[0-9]{2}\.[0-9]{2}-[a-f0-9]+)'
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_version=$(curl -sfL "$VERSION_URL" \
+  | grep -oE "$VERSION_RE" | head -1 \
+  | sed -E "s|.*/lab/||")
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating cursor-agent from $current_version to $latest_version"
+
+declare -A PLATFORMS=(
+  ["aarch64-darwin"]="darwin/arm64"
+  ["aarch64-linux"]="linux/arm64"
+  ["x86_64-darwin"]="darwin/x64"
+  ["x86_64-linux"]="linux/x64"
+)
+
+hashes_json="{}"
+for system in "${!PLATFORMS[@]}"; do
+  key="${PLATFORMS[$system]}"
+  url="https://downloads.cursor.com/lab/$latest_version/$key/agent-cli-package.tar.gz"
+  echo "  fetching $system from $url"
+  hash=$(nix-prefetch-url "$url" 2>/dev/null)
+  sri=$(nix hash convert --hash-algo sha256 --to sri "$hash")
+  echo "    $system: $sri"
+  hashes_json=$(echo "$hashes_json" \
+    | jq --arg p "$system" --arg h "$sri" '.[$p] = $h')
+done
+
+jq -n \
+  --arg v "$latest_version" \
+  --argjson h "$hashes_json" \
+  '{version: $v, hashes: ($h | to_entries | sort_by(.key) | from_entries)}' \
+  > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.flox/pkgs/gemini-cli/default.nix
+++ b/.flox/pkgs/gemini-cli/default.nix
@@ -1,0 +1,207 @@
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  fetchFromGitHub,
+  ripgrep,
+  pkg-config,
+  libsecret,
+  clang_20,
+  makeBinaryWrapper,
+  makeSetupHook,
+  writeText,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  writeShellScriptBin,
+  xsel,
+  nodejs,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash npmDepsHash;
+
+  # node-gyp on macOS sometimes picks up node.js's util.h before the SDK's,
+  # so openpty()/forkpty() prototypes go missing and node-pty fails to
+  # build. Inject a shim header via -include so the prototypes are always
+  # in scope. Mirrors numtide/llm-agents.nix's darwinOpenptyHook.
+  darwinOpenptyHook =
+    let
+      shim = writeText "darwin-openpty-shim.h" ''
+        #ifndef DARWIN_OPENPTY_SHIM_H
+        #define DARWIN_OPENPTY_SHIM_H
+        #include <sys/types.h>
+        struct termios;
+        struct winsize;
+        #ifdef __cplusplus
+        extern "C" {
+        #endif
+        int openpty(int *, int *, char *, struct termios *, struct winsize *);
+        pid_t forkpty(int *, char *, struct termios *, struct winsize *);
+        #ifdef __cplusplus
+        }
+        #endif
+        #endif
+      '';
+      hookScript = writeText "darwin-openpty-hook.sh" ''
+        if [ -z "''${darwinOpenptyHookApplied-}" ]; then
+          export NIX_CFLAGS_COMPILE="''${NIX_CFLAGS_COMPILE-} -include ${shim}"
+          darwinOpenptyHookApplied=1
+        fi
+      '';
+    in
+    makeSetupHook { name = "darwin-openpty-hook"; } hookScript;
+in
+buildNpmPackage (finalAttrs: {
+  npmDepsFetcherVersion = 2;
+  pname = "gemini-cli";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "google-gemini";
+    repo = "gemini-cli";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  inherit npmDepsHash;
+  makeCacheWritable = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    makeBinaryWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # node-addon-api needs clang 20; clang 21+ fails on a constexpr issue.
+    clang_20
+    # Fixes node-pty openpty/forkpty build issue.
+    darwinOpenptyHook
+  ];
+
+  dontPatchElf = stdenv.hostPlatform.isDarwin;
+
+  buildInputs = [
+    libsecret
+  ];
+
+  preConfigure = ''
+    mkdir -p packages/generated
+    echo "export const GIT_COMMIT_INFO = { commitHash: '${finalAttrs.src.rev}' };" \
+      > packages/generated/git-commit.ts
+  '';
+
+  postPatch = ''
+    # Hardcode ripgrep path so ensureRgPath() returns our Nix-provided binary
+    # instead of downloading or finding a dynamically-linked one.
+    substituteInPlace packages/core/src/tools/ripGrep.ts \
+      --replace-fail "await ensureRgPath();" "'${lib.getExe ripgrep}';"
+
+    # Disable auto-update and the update nag - Nix manages updates.
+    sed -i "/enableAutoUpdate: {/,/}/ s/default: true/default: false/" \
+      packages/cli/src/config/settingsSchema.ts
+    sed -i "/enableAutoUpdateNotification: {/,/}/ s/default: true/default: false/" \
+      packages/cli/src/config/settingsSchema.ts
+  '';
+
+  # v0.31.0 added @google/gemini-cli-devtools as an implicit workspace
+  # dependency of cli. npm --workspaces builds packages alphabetically
+  # (cli before devtools), so tsc fails to resolve the import. Pre-build
+  # devtools so its types are available when cli compiles.
+  preBuild = ''
+    npm run build --workspace=@google/gemini-cli-devtools
+  '';
+
+  # Prevent build-only deps from leaking into the runtime closure
+  disallowedReferences = [
+    finalAttrs.npmDeps
+    nodejs.python
+  ];
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/{bin,share/gemini-cli}
+
+    npm prune --omit=dev
+
+    cp -r node_modules $out/share/gemini-cli/
+
+    # Replace workspace symlinks with the actual built packages
+    for pkg in cli:gemini-cli core:gemini-cli-core \
+               a2a-server:gemini-cli-a2a-server \
+               devtools:gemini-cli-devtools sdk:gemini-cli-sdk; do
+      dir=''${pkg%%:*}
+      name=''${pkg##*:}
+      rm -f $out/share/gemini-cli/node_modules/@google/"$name"
+      cp -r packages/"$dir" \
+        $out/share/gemini-cli/node_modules/@google/"$name"
+    done
+    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-test-utils
+    rm -f $out/share/gemini-cli/node_modules/gemini-cli-vscode-ide-companion
+
+    # Remove dangling symlinks to source directory
+    rm -f $out/share/gemini-cli/node_modules/@google/gemini-cli-core/dist/docs/CONTRIBUTING.md
+
+    makeWrapper ${lib.getExe nodejs} $out/bin/gemini \
+      --add-flags "--no-warnings=DEP0040" \
+      --add-flags "$out/share/gemini-cli/node_modules/@google/gemini-cli/dist/index.js" \
+      ${lib.optionalString stdenv.hostPlatform.isLinux "--prefix PATH : ${lib.makeBinPath [ xsel ]}"}
+
+    # Install JSON schema
+    install -Dm644 schemas/settings.schema.json \
+      $out/share/gemini-cli/settings.schema.json
+
+    runHook postInstall
+  '';
+
+  # Remove files that embed build-time store paths (python shebangs, build
+  # artifacts, lockfiles) to satisfy disallowedReferences. Must run in
+  # preFixup before patchShebangs rewrites shebangs to Nix store paths.
+  preFixup = ''
+    find $out/share/gemini-cli/node_modules \
+      -name "*.py" -o -name "gyp-mac-tool" \
+      -o -name "package-lock.json" -o -name ".package-lock.json" \
+      -o -name "config.gypi" \
+      -o -path '*/build/*.mk' -o -path '*/build/Makefile' \
+      | xargs rm -f
+    # @github/keytar/build: keep only the runtime addon. Object files and
+    # .deps/*.d embed paths to nodejs-source and -dev outputs, bloating
+    # the closure.
+    find $out/share/gemini-cli/node_modules/@github/keytar/build \
+      -type f -not -name 'keytar.node' -delete
+    find $out/share/gemini-cli/node_modules/@github/keytar/build \
+      -type d -empty -delete
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # clipboardy → system-architecture calls
+    # `sysctl -inq sysctl.proc_translated` at import time to detect
+    # Rosetta 2. In the Nix sandbox /usr/sbin/sysctl is absent, causing
+    # ENOENT and crashing the version check. Stub it to report "not
+    # translated" so the module resolves the native arch.
+    (writeShellScriptBin "sysctl" "echo 0")
+  ];
+  # versionCheckHook runs with --ignore-environment by default, stripping
+  # PATH. Preserve it so the sysctl stub (and node itself) can be found
+  # by child processes spawned during `gemini --version`.
+  versionCheckKeepEnvironment = "PATH";
+
+  meta = {
+    description = "AI agent that brings Gemini directly into your terminal";
+    homepage = "https://github.com/google-gemini/gemini-cli";
+    changelog = "https://github.com/google-gemini/gemini-cli/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    mainProgram = "gemini";
+  };
+})

--- a/.flox/pkgs/gemini-cli/hashes.json
+++ b/.flox/pkgs/gemini-cli/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.42.0",
+  "srcHash": "sha256-QYSzJdyjJ5SvPkI/uf/wu8MdM76W+djai6zD38IJpos=",
+  "npmDepsHash": "sha256-1Kl3Km61kKCxTVTVr8n0w/Wh75Cml7zrUI6Fq9yfBW4="
+}

--- a/.flox/pkgs/gemini-cli/publish.json
+++ b/.flox/pkgs/gemini-cli/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/gemini-cli/upgrade.sh
+++ b/.flox/pkgs/gemini-cli/upgrade.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_tag=$(curl -sfL \
+  https://api.github.com/repos/google-gemini/gemini-cli/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating gemini-cli from $current_version to $latest_version"
+
+src_url="https://github.com/google-gemini/gemini-cli/archive/refs/tags/v${latest_version}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+# Write with a dummy npmDepsHash so flox build reports the real one.
+dummy_hash="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg n "$dummy_hash" \
+  '{version: $v, srcHash: $s, npmDepsHash: $n}' > "$HASHES_FILE"
+
+echo "Building with dummy npmDepsHash to compute real one..."
+npm_hash=$(flox build gemini-cli 2>&1 \
+  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep "got:" | head -1 | awk '{print $NF}') || true
+
+if [ -z "$npm_hash" ]; then
+  echo "ERROR: could not extract npmDepsHash from build output" >&2
+  exit 1
+fi
+
+echo "  npmDepsHash: $npm_hash"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg n "$npm_hash" \
+  '{version: $v, srcHash: $s, npmDepsHash: $n}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.flox/pkgs/grok/default.nix
+++ b/.flox/pkgs/grok/default.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  autoPatchelfHook,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+  bashInteractive,
+  bubblewrap,
+  zsh,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    x86_64-linux = "linux-x86_64";
+    aarch64-linux = "linux-aarch64";
+    aarch64-darwin = "macos-aarch64";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  platformSuffix = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+
+  # Grok's run_command tool spawns shells via portable_pty which execve's
+  # absolute paths like /bin/bash and /bin/zsh (derived from $SHELL, with
+  # /bin/bash as the hardcoded fallback). NixOS only ships /bin/sh, so
+  # every shell tool call fails before any user command runs.
+  #
+  # As a transitional workaround, wrap the Linux entry points with
+  # bubblewrap so /bin is replaced by a tmpfs containing symlinks to the
+  # matching shells from the Nix store. Remove once upstream grok honors
+  # $SHELL (or PATH) instead of fixed /bin/* paths.
+  bwrapFlags = lib.concatStringsSep " " [
+    "--dev-bind / /"
+    "--tmpfs /bin"
+    "--symlink ${bashInteractive}/bin/bash /bin/bash"
+    "--symlink ${zsh}/bin/zsh /bin/zsh"
+    "--symlink ${bashInteractive}/bin/sh /bin/sh"
+  ];
+in
+stdenv.mkDerivation {
+  pname = "grok";
+  inherit version;
+
+  src = fetchurl {
+    url =
+      "https://storage.googleapis.com/grok-build-public-artifacts"
+      + "/cli/grok-${version}-${platformSuffix}";
+    hash = hashes.${platform};
+  };
+
+  dontUnpack = true;
+  dontStrip = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/libexec/grok/grok
+
+    makeWrapper $out/libexec/grok/grok $out/libexec/grok/grok-launcher \
+      --argv0 grok \
+      --add-flags --no-auto-update
+
+    makeWrapper $out/libexec/grok/grok $out/libexec/grok/agent-launcher \
+      --argv0 agent \
+      --add-flags --no-auto-update
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    install -d $out/bin
+    for name in grok agent; do
+      {
+        printf '#!%s\n' '${stdenv.shell}'
+        printf 'exec %s %s -- %s/libexec/grok/%s-launcher "$@"\n' \
+          '${bubblewrap}/bin/bwrap' \
+          '${bwrapFlags}' \
+          "$out" \
+          "$name"
+      } > $out/bin/$name
+      chmod +x $out/bin/$name
+    done
+  ''
+  + lib.optionalString (!stdenv.hostPlatform.isLinux) ''
+    install -d $out/bin
+    ln -s $out/libexec/grok/grok-launcher $out/bin/grok
+    ln -s $out/libexec/grok/agent-launcher $out/bin/agent
+  ''
+  + ''
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  meta = {
+    description = "Grok Build, xAI's agentic coding tool";
+    homepage = "https://x.ai";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-linux"
+    ];
+    mainProgram = "grok";
+  };
+}

--- a/.flox/pkgs/grok/hashes.json
+++ b/.flox/pkgs/grok/hashes.json
@@ -1,0 +1,8 @@
+{
+  "version": "0.1.212",
+  "hashes": {
+    "aarch64-darwin": "sha256-1irr1El/rtwctihfuUGP375fXY4owQRBDbLQgGcW4x0=",
+    "aarch64-linux": "sha256-mi7VA/PndRbeiQNPYhoaid8ug0ToeDl21J8MyiPhhYM=",
+    "x86_64-linux": "sha256-/bZPr87i9I/6DBkFjmcQjcqAK1eIO9AHRH/2Z+ZPg9g="
+  }
+}

--- a/.flox/pkgs/grok/publish.json
+++ b/.flox/pkgs/grok/publish.json
@@ -1,0 +1,4 @@
+{
+  "org": "flox",
+  "systems": ["aarch64-darwin", "aarch64-linux", "x86_64-linux"]
+}

--- a/.flox/pkgs/grok/upgrade.sh
+++ b/.flox/pkgs/grok/upgrade.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+BASE_URL="https://storage.googleapis.com/grok-build-public-artifacts/cli"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_version=$(curl -sfL "$BASE_URL/stable" | tr -d '[:space:]')
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating grok from $current_version to $latest_version"
+
+declare -A PLATFORMS=(
+  ["aarch64-darwin"]="macos-aarch64"
+  ["aarch64-linux"]="linux-aarch64"
+  ["x86_64-linux"]="linux-x86_64"
+)
+
+hashes_json="{}"
+for system in "${!PLATFORMS[@]}"; do
+  suffix="${PLATFORMS[$system]}"
+  url="$BASE_URL/grok-$latest_version-$suffix"
+  echo "  fetching $system"
+  hash=$(nix-prefetch-url "$url" 2>/dev/null)
+  sri=$(nix hash convert --hash-algo sha256 --to sri "$hash")
+  echo "    $system: $sri"
+  hashes_json=$(echo "$hashes_json" \
+    | jq --arg p "$system" --arg h "$sri" '.[$p] = $h')
+done
+
+jq -n \
+  --arg v "$latest_version" \
+  --argjson h "$hashes_json" \
+  '{version: $v, hashes: ($h | to_entries | sort_by(.key) | from_entries)}' \
+  > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.flox/pkgs/mistral-vibe/agent-client-protocol.nix
+++ b/.flox/pkgs/mistral-vibe/agent-client-protocol.nix
@@ -1,0 +1,34 @@
+{
+  lib,
+  python3,
+  fetchPypi,
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "agent-client-protocol";
+  version = "0.9.0";
+  pyproject = true;
+
+  src = fetchPypi {
+    pname = "agent_client_protocol";
+    inherit version;
+    hash = "sha256-90TEirmvDwtEUuWrVJjWG8q5fCbb59b+7F/TbeSb4ws=";
+  };
+
+  build-system = with python3.pkgs; [ pdm-backend ];
+
+  dependencies = with python3.pkgs; [
+    pydantic
+  ];
+
+  pythonImportsCheck = [ "acp" ];
+
+  meta = with lib; {
+    description = "Agent Client Protocol - protocol for AI agent communication";
+    homepage = "https://github.com/agentclientprotocol/agent-client-protocol";
+    changelog = "https://github.com/agentclientprotocol/agent-client-protocol/releases/tag/v${version}";
+    license = licenses.mit;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    platforms = platforms.all;
+  };
+}

--- a/.flox/pkgs/mistral-vibe/default.nix
+++ b/.flox/pkgs/mistral-vibe/default.nix
@@ -1,0 +1,268 @@
+{
+  lib,
+  python3,
+  fetchFromGitHub,
+  fetchPypi,
+  callPackage,
+  rustPlatform,
+  cargo,
+  rustc,
+  maturin,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash;
+
+  textual-speedups = python3.pkgs.buildPythonPackage rec {
+    pname = "textual-speedups";
+    version = "0.2.1";
+    pyproject = true;
+
+    src = fetchPypi {
+      pname = "textual_speedups";
+      inherit version;
+      hash = "sha256-cs8Pe97t4BU2e1m3C89yS6LDCAqGQevF65SzatFTaCQ=";
+    };
+
+    cargoDeps = rustPlatform.fetchCargoVendor {
+      inherit src;
+      name = "${pname}-${version}";
+      hash = "sha256-Bz4ocEziOlOX4z5F9EDry99YofeGyxL/6OTIf/WEgK4=";
+    };
+
+    nativeBuildInputs = [
+      rustPlatform.cargoSetupHook
+      rustPlatform.maturinBuildHook
+      cargo
+      rustc
+      maturin
+    ];
+
+    pythonImportsCheck = [ "textual_speedups" ];
+
+    meta = with lib; {
+      description = "Optional Rust speedups for Textual TUI framework";
+      homepage = "https://github.com/willmcgugan/textual-speedups";
+      license = licenses.mit;
+      sourceProvenance = with sourceTypes; [ fromSource ];
+      platforms = platforms.all;
+    };
+  };
+
+  tree-sitter-bash = python3.pkgs.buildPythonPackage rec {
+    pname = "tree-sitter-bash";
+    version = "0.25.1";
+    pyproject = true;
+
+    src = fetchPypi {
+      pname = "tree_sitter_bash";
+      inherit version;
+      hash = "sha256-v8C9qne8HobjxmUuWm4UDEDAoWuEGFwrY6182Am4jxQ=";
+    };
+
+    build-system = with python3.pkgs; [
+      setuptools
+    ];
+
+    pythonImportsCheck = [ "tree_sitter_bash" ];
+
+    meta = with lib; {
+      description = "Bash grammar for tree-sitter";
+      homepage = "https://github.com/tree-sitter/tree-sitter-bash";
+      license = licenses.mit;
+      sourceProvenance = with sourceTypes; [ fromSource ];
+      platforms = platforms.all;
+    };
+  };
+
+  # mistral-vibe >=2.6 requires opentelemetry-semantic-conventions>=0.60b1
+  # for GEN_AI_PROVIDER_NAME. nixpkgs ships 0.55b0. The otel packages are
+  # versioned in lockstep from a monorepo and all inherit src from
+  # opentelemetry-api, so bumping that one source bumps the whole stack.
+  otelVersion = "1.40.0";
+  otelContribVersion = "0.61b0";
+  otelSrc = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python";
+    tag = "v${otelVersion}";
+    hash = "sha256-1KVy9s+zjlB4w7E45PMCWRxPus24bgBmmM3k2R9d+Jg=";
+  };
+  otelContribSrc = fetchFromGitHub {
+    owner = "open-telemetry";
+    repo = "opentelemetry-python-contrib";
+    tag = "v${otelContribVersion}";
+    hash = "sha256-DT13gcYPNYXBPnf622WsA16C+7sabJfOshDquHn06Ok=";
+  };
+
+  python = python3.override {
+    self = python;
+    packageOverrides = _pyfinal: pyprev: {
+      inherit textual-speedups tree-sitter-bash;
+
+      # mistral-vibe pins textual==8.2.4. Textual 8.2.5 removed the
+      # built-in "textual-ansi" theme that vibe sets at startup,
+      # causing "Theme 'textual-ansi' has not been registered".
+      textual = pyprev.textual.overridePythonAttrs (old: rec {
+        version = "8.2.4";
+        src = old.src.override {
+          tag = "v${version}";
+          hash = "sha256-827cm9pcj1o1FYeaoWKCJ6dEyXeDop4kYd205cySTfg=";
+        };
+      });
+
+      # mistral-vibe 2.7.5 imports `deep_update` from
+      # `pydantic_settings.sources.base`, a re-export added in 2.13.
+      pydantic-settings = pyprev.pydantic-settings.overridePythonAttrs (_: rec {
+        version = "2.13.1";
+        src = fetchPypi {
+          pname = "pydantic_settings";
+          inherit version;
+          hash = "sha256-tMEYR7FSN/sBceFGK/VA4pSv+5uG202apcAXML2+QCU=";
+        };
+      });
+
+      # Build mistralai/acp inside this set so they link against the
+      # overridden opentelemetry packages rather than stock python3.pkgs.
+      mistralai = callPackage ./mistralai.nix {
+        python3 = python;
+      };
+      agent-client-protocol = callPackage ./agent-client-protocol.nix {
+        python3 = python;
+      };
+
+      opentelemetry-api = pyprev.opentelemetry-api.overridePythonAttrs (_: {
+        version = otelVersion;
+        src = otelSrc;
+        sourceRoot = "${otelSrc.name}/opentelemetry-api";
+      });
+
+      # 1.40.0 added timing-sensitive tests that flake on loaded
+      # builders (assertions like `after - before < 0.2` fail by
+      # milliseconds on darwin).
+      opentelemetry-exporter-otlp-proto-http =
+        pyprev.opentelemetry-exporter-otlp-proto-http.overridePythonAttrs
+          (old: {
+            disabledTests = (old.disabledTests or [ ]) ++ [
+              "test_retry_timeout"
+              "test_shutdown_interrupts_retry_backoff"
+            ];
+          });
+
+      opentelemetry-instrumentation = pyprev.opentelemetry-instrumentation.overridePythonAttrs (_: {
+        version = otelContribVersion;
+        src = otelContribSrc;
+        sourceRoot = "${otelContribSrc.name}/opentelemetry-instrumentation";
+      });
+
+      # In nixpkgs this inherits version from opentelemetry-instrumentation,
+      # but overridePythonAttrs doesn't re-evaluate that reference, so set
+      # it explicitly to keep the dist-info version in sync with src.
+      opentelemetry-semantic-conventions =
+        pyprev.opentelemetry-semantic-conventions.overridePythonAttrs
+          (_: {
+            version = otelContribVersion;
+          });
+    };
+  };
+in
+python.pkgs.buildPythonApplication {
+  pname = "mistral-vibe";
+  inherit version;
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mistralai";
+    repo = "mistral-vibe";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  build-system = with python.pkgs; [
+    hatchling
+    hatch-vcs
+  ];
+
+  dependencies = with python.pkgs; [
+    agent-client-protocol
+    anyio
+    cachetools
+    cryptography
+    gitpython
+    giturlparse
+    google-auth
+    httpx
+    jsonpatch
+    keyring
+    markdownify
+    mcp
+    mistralai
+    opentelemetry-api
+    opentelemetry-exporter-otlp-proto-http
+    opentelemetry-sdk
+    opentelemetry-semantic-conventions
+    packaging
+    pexpect
+    pydantic
+    pydantic-settings
+    pyperclip
+    python-dotenv
+    pyyaml
+    requests
+    rich
+    sounddevice
+    textual
+    textual-speedups
+    tomli-w
+    tree-sitter
+    tree-sitter-bash
+    watchfiles
+    websockets
+    zstandard
+  ];
+
+  # Relax version constraints — nixpkgs versions are slightly older but
+  # compatible. NOTE: do NOT relax opentelemetry-* here; those constraints
+  # encode real API requirements and are satisfied by the overrides above.
+  pythonRelaxDeps = [
+    "agent-client-protocol"
+    "certifi"
+    "cryptography"
+    "gitpython"
+    "giturlparse"
+    "keyring"
+    "mistralai"
+    "pydantic"
+    "pydantic-settings"
+    "pyyaml"
+    "watchfiles"
+    "zstandard"
+  ];
+
+  pythonImportsCheck = [ "vibe" ];
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  meta = {
+    description = "Mistral AI's minimal CLI coding agent powered by Devstral";
+    homepage = "https://github.com/mistralai/mistral-vibe";
+    changelog = "https://github.com/mistralai/mistral-vibe/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    mainProgram = "vibe";
+  };
+}

--- a/.flox/pkgs/mistral-vibe/hashes.json
+++ b/.flox/pkgs/mistral-vibe/hashes.json
@@ -1,0 +1,4 @@
+{
+  "version": "2.9.6",
+  "srcHash": "sha256-4zfeMbqM43Gd/s7EDROEHste1+0+X9Qs3LUIxCp2Clg="
+}

--- a/.flox/pkgs/mistral-vibe/mistralai.nix
+++ b/.flox/pkgs/mistral-vibe/mistralai.nix
@@ -1,0 +1,47 @@
+{
+  lib,
+  python3,
+  fetchPypi,
+}:
+
+python3.pkgs.buildPythonPackage rec {
+  pname = "mistralai";
+  version = "2.1.3";
+  pyproject = true;
+
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-DF3khVsEPNBYJAbVwd39keF29IShWObuC0oAVCMb4mY=";
+  };
+
+  build-system = with python3.pkgs; [ hatchling ];
+
+  dependencies = with python3.pkgs; [
+    eval-type-backport
+    httpx
+    jsonpath-python
+    opentelemetry-api
+    opentelemetry-semantic-conventions
+    pydantic
+    python-dateutil
+    typing-inspection
+  ];
+
+  # mistralai pins opentelemetry-semantic-conventions<0.61 but the
+  # mistral-vibe override supplies 0.61b0; the upper bound is
+  # precautionary, not an actual API break.
+  pythonRelaxDeps = [
+    "opentelemetry-semantic-conventions"
+  ];
+
+  pythonImportsCheck = [ "mistralai" ];
+
+  meta = with lib; {
+    description = "Python Client SDK for the Mistral AI API";
+    homepage = "https://github.com/mistralai/client-python";
+    changelog = "https://github.com/mistralai/client-python/releases/tag/v${version}";
+    license = licenses.asl20;
+    sourceProvenance = with sourceTypes; [ fromSource ];
+    platforms = platforms.all;
+  };
+}

--- a/.flox/pkgs/mistral-vibe/publish.json
+++ b/.flox/pkgs/mistral-vibe/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/mistral-vibe/upgrade.sh
+++ b/.flox/pkgs/mistral-vibe/upgrade.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+# This script only bumps the main mistral-vibe version + srcHash.
+# Python dep overrides in default.nix (textual, pydantic-settings,
+# mistralai, agent-client-protocol, otel) are pinned to versions that
+# match the API contract upstream pins. If a new mistral-vibe release
+# requires different dep versions, those hashes must be updated by
+# hand alongside this script's output.
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_tag=$(curl -sfL \
+  https://api.github.com/repos/mistralai/mistral-vibe/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating mistral-vibe from $current_version to $latest_version"
+
+src_url="https://github.com/mistralai/mistral-vibe/archive/refs/tags/v${latest_version}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  '{version: $v, srcHash: $s}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"
+echo "WARNING: Python dep overrides in default.nix may need" \
+  "hand-updating to match new upstream constraints." >&2


### PR DESCRIPTION
## Summary

Adds six AI coding-agent packages:

- `amp` 0.0.1779153253 — Sourcegraph
- `copilot-cli` 1.0.49 — GitHub
- `cursor-agent` 2026.05.16-0338208 — Cursor
- `gemini-cli` 0.42.0 — Google
- `grok` 0.1.212 — xAI (3 systems, no x86_64-darwin
  upstream artifact)
- `mistral-vibe` 2.9.6 — Mistral AI (with `mistralai`
  and `agent-client-protocol` companions)

All six build and pass their version checks locally
on `aarch64-darwin`. CI will validate the other three
systems.

## Notes

- No environments yet — these are the package
  derivations only. Envs come in a follow-up once the
  pkgs are published to FloxHub.
- `mistral-vibe`'s `upgrade.sh` only bumps the main
  version and `srcHash`. The Python dep overrides
  (`textual` 8.2.4, `pydantic-settings` 2.13.1, OTel
  1.40.0 / 0.61b0) are pinned by upstream's
  contract and may need manual maintenance when a new
  release shifts those constraints.
- `grok` Linux entrypoints are wrapped with bubblewrap
  to fake `/bin/{bash,zsh,sh}` (workaround for grok's
  `portable_pty`).
- `amp` on darwin re-signs the binary after rewriting
  the ICU dylib path.
- `gemini-cli` inlines a small darwin openpty shim
  setupHook to fix node-pty's missing
  `openpty`/`forkpty` prototypes.

## Test plan

- [ ] CI builds pass for all four matrix systems
      (only `grok` skips `x86_64-darwin`)
- [ ] `flox publish` succeeds on `main` for each
      package
- [ ] Spot-check one binary per package on Linux once
      CI artifacts are available