### PR TITLE
feat(pkgs): add wave 2 LLM-agent packages

### DIFF
--- a/.flox/pkgs/forgecode/default.nix
+++ b/.flox/pkgs/forgecode/default.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  makeWrapper,
+  autoPatchelfHook,
+  gcc-unwrapped,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    x86_64-linux = "x86_64-unknown-linux-gnu";
+    aarch64-linux = "aarch64-unknown-linux-gnu";
+    x86_64-darwin = "x86_64-apple-darwin";
+    aarch64-darwin = "aarch64-apple-darwin";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  platformTriple = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+in
+stdenv.mkDerivation {
+  pname = "forgecode";
+  inherit version;
+
+  # The release artifact is named `forge-<triple>` (the binary's own name
+  # stays `forge`); the project itself rebranded to ForgeCode and moved
+  # from antinomyhq/forge to tailcallhq/forgecode.
+  src = fetchurl {
+    url =
+      "https://github.com/tailcallhq/forgecode/releases/download/"
+      + "v${version}/forge-${platformTriple}";
+    hash = hashes.${platform};
+  };
+
+  dontUnpack = true;
+
+  nativeBuildInputs = [
+    makeWrapper
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    gcc-unwrapped.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/bin/forge
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  meta = {
+    description = "ForgeCode - AI pair programmer supporting 300+ LLMs in your terminal";
+    homepage = "https://forgecode.dev";
+    changelog = "https://github.com/tailcallhq/forgecode/releases/tag/v${version}";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    mainProgram = "forge";
+  };
+}

--- a/.flox/pkgs/forgecode/hashes.json
+++ b/.flox/pkgs/forgecode/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "2.12.15",
+  "hashes": {
+    "aarch64-darwin": "sha256-6Pecpq7JIqWR95N8dTZWhEpwaMTSHN2SGQ2sb3HCvno=",
+    "aarch64-linux": "sha256-Pu7pntizg8qhTYLipfS0qejUaLE78UUoYRIfW9kJLA8=",
+    "x86_64-darwin": "sha256-MoVampTBrSHf9jcJTBDAaTGqYODN5oxCNm6Y08S7FQE=",
+    "x86_64-linux": "sha256-firHC+Qb5bgSwDmkDzKiV2iiseg0KQBR2hXkHYlwcxk="
+  }
+}

--- a/.flox/pkgs/forgecode/publish.json
+++ b/.flox/pkgs/forgecode/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/forgecode/upgrade.sh
+++ b/.flox/pkgs/forgecode/upgrade.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_tag=$(curl -sfL \
+  https://api.github.com/repos/tailcallhq/forgecode/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating forgecode from $current_version to $latest_version"
+
+declare -A PLATFORMS=(
+  ["aarch64-darwin"]="aarch64-apple-darwin"
+  ["aarch64-linux"]="aarch64-unknown-linux-gnu"
+  ["x86_64-darwin"]="x86_64-apple-darwin"
+  ["x86_64-linux"]="x86_64-unknown-linux-gnu"
+)
+
+hashes_json="{}"
+for system in "${!PLATFORMS[@]}"; do
+  triple="${PLATFORMS[$system]}"
+  url="https://github.com/tailcallhq/forgecode/releases/download/v$latest_version/forge-$triple"
+  echo "  fetching $system"
+  hash=$(nix-prefetch-url "$url" 2>/dev/null)
+  sri=$(nix hash convert --hash-algo sha256 --to sri "$hash")
+  echo "    $system: $sri"
+  hashes_json=$(echo "$hashes_json" \
+    | jq --arg p "$system" --arg h "$sri" '.[$p] = $h')
+done
+
+jq -n \
+  --arg v "$latest_version" \
+  --argjson h "$hashes_json" \
+  '{version: $v, hashes: ($h | to_entries | sort_by(.key) | from_entries)}' \
+  > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.flox/pkgs/goose-cli/default.nix
+++ b/.flox/pkgs/goose-cli/default.nix
@@ -1,0 +1,92 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchurl,
+  rustPlatform,
+  pkg-config,
+  openssl,
+  libxcb,
+  dbus,
+  versionCheckHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash cargoHash;
+
+  # The v8 crate downloads a prebuilt static library at build time.
+  # Fetch it as a fixed-output derivation so the build stays sandboxed.
+  librusty_v8 = fetchurl {
+    name = "librusty_v8-${versionData.librusty_v8.version}";
+    url =
+      "https://github.com/denoland/rusty_v8/releases/download/"
+      + "v${versionData.librusty_v8.version}/librusty_v8_release_"
+      + "${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
+    hash = versionData.librusty_v8.hashes.${stdenv.hostPlatform.system};
+    meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "goose-cli";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "block";
+    repo = "goose";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  inherit cargoHash;
+
+  nativeBuildInputs = [ pkg-config ];
+
+  buildInputs = [
+    openssl
+    libxcb
+    dbus
+  ];
+
+  env.RUSTY_V8_ARCHIVE = librusty_v8;
+
+  cargoBuildFlags = [
+    "--package"
+    "goose-cli"
+  ];
+
+  # Tests need writable XDG dirs and run only goose-cli's test target.
+  doCheck = true;
+  checkPhase = ''
+    runHook preCheck
+
+    export HOME=$(mktemp -d)
+    export XDG_CONFIG_HOME=$HOME/.config
+    export XDG_DATA_HOME=$HOME/.local/share
+    export XDG_STATE_HOME=$HOME/.local/state
+    export XDG_CACHE_HOME=$HOME/.cache
+    mkdir -p \
+      $XDG_CONFIG_HOME $XDG_DATA_HOME \
+      $XDG_STATE_HOME $XDG_CACHE_HOME
+
+    cargo test --package goose-cli --release
+
+    runHook postCheck
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [ versionCheckHook ];
+
+  meta = {
+    description = "Block's local, extensible, open source AI engineering agent";
+    homepage = "https://github.com/block/goose";
+    changelog = "https://github.com/block/goose/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [
+      fromSource
+      binaryNativeCode
+    ];
+    platforms = lib.platforms.unix;
+    mainProgram = "goose";
+  };
+}

--- a/.flox/pkgs/goose-cli/hashes.json
+++ b/.flox/pkgs/goose-cli/hashes.json
@@ -1,0 +1,14 @@
+{
+  "version": "1.24.0",
+  "srcHash": "sha256-98psnT7hmnLav7pYFN55fj04R+avjzoc2lVpXsFN6M8=",
+  "cargoHash": "sha256-jZpk9x0d4JXfFGSmgi51uO774boOlUEyNhkSQMZZmSM=",
+  "librusty_v8": {
+    "version": "145.0.0",
+    "hashes": {
+      "aarch64-darwin": "sha256-yHa1eydVCrfYGgrZANbzgmmf25p7ui1VMas2A7BhG6k=",
+      "aarch64-linux": "sha256-4IivYskhUSsMLZY97+g23UtUYh4p5jk7CzhMbMyqXyY=",
+      "x86_64-darwin": "sha256-1jUuC+z7saQfPYILNyRJanD4+zOOhXU2ac/LFoytwho=",
+      "x86_64-linux": "sha256-chV1PAx40UH3Ute5k3lLrgfhih39Rm3KqE+mTna6ysE="
+    }
+  }
+}

--- a/.flox/pkgs/goose-cli/publish.json
+++ b/.flox/pkgs/goose-cli/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/goose-cli/upgrade.sh
+++ b/.flox/pkgs/goose-cli/upgrade.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+# This script only bumps the goose-cli source. The librusty_v8 pin is
+# updated separately when the v8 crate in goose-cli's lockfile shifts;
+# upgrading the source without also refreshing librusty_v8 may still
+# build but will skew the v8 ABI from what goose-cli was tested against.
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_tag=$(curl -sfL \
+  https://api.github.com/repos/block/goose/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating goose-cli from $current_version to $latest_version"
+
+src_url="https://github.com/block/goose/archive/refs/tags/v${latest_version}.tar.gz"
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+dummy="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+jq \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg d "$dummy" \
+  '.version = $v | .srcHash = $s | .cargoHash = $d' \
+  "$HASHES_FILE" > "$HASHES_FILE.tmp"
+mv "$HASHES_FILE.tmp" "$HASHES_FILE"
+
+echo "Building with dummy cargoHash to compute real one..."
+cargo_hash=$(flox build goose-cli 2>&1 \
+  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep "got:" | head -1 | awk '{print $NF}') || true
+
+if [ -z "$cargo_hash" ]; then
+  echo "ERROR: could not extract cargoHash from build output" >&2
+  exit 1
+fi
+
+echo "  cargoHash: $cargo_hash"
+
+jq \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg c "$cargo_hash" \
+  '.version = $v | .srcHash = $s | .cargoHash = $c' \
+  "$HASHES_FILE" > "$HASHES_FILE.tmp"
+mv "$HASHES_FILE.tmp" "$HASHES_FILE"
+
+echo "Updated to $latest_version"
+echo "WARNING: librusty_v8 hashes in hashes.json may also need a refresh" \
+  "if upstream's v8 crate version shifted." >&2

--- a/.flox/pkgs/qwen-code/default.nix
+++ b/.flox/pkgs/qwen-code/default.nix
@@ -1,0 +1,143 @@
+{
+  lib,
+  stdenv,
+  buildNpmPackage,
+  fetchFromGitHub,
+  git,
+  ripgrep,
+  pkg-config,
+  glib,
+  libsecret,
+  clang_20,
+  makeSetupHook,
+  writeText,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash npmDepsHash;
+
+  # node-gyp on macOS sometimes picks up node.js's util.h before the SDK's,
+  # so openpty()/forkpty() prototypes go missing and node-pty fails to
+  # build. Inject a shim header via -include so the prototypes are always
+  # in scope.
+  darwinOpenptyHook =
+    let
+      shim = writeText "darwin-openpty-shim.h" ''
+        #ifndef DARWIN_OPENPTY_SHIM_H
+        #define DARWIN_OPENPTY_SHIM_H
+        #include <sys/types.h>
+        struct termios;
+        struct winsize;
+        #ifdef __cplusplus
+        extern "C" {
+        #endif
+        int openpty(int *, int *, char *, struct termios *, struct winsize *);
+        pid_t forkpty(int *, char *, struct termios *, struct winsize *);
+        #ifdef __cplusplus
+        }
+        #endif
+        #endif
+      '';
+      hookScript = writeText "darwin-openpty-hook.sh" ''
+        if [ -z "''${darwinOpenptyHookApplied-}" ]; then
+          export NIX_CFLAGS_COMPILE="''${NIX_CFLAGS_COMPILE-} -include ${shim}"
+          darwinOpenptyHookApplied=1
+        fi
+      '';
+    in
+    makeSetupHook { name = "darwin-openpty-hook"; } hookScript;
+in
+buildNpmPackage (finalAttrs: {
+  npmDepsFetcherVersion = 2;
+  pname = "qwen-code";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "QwenLM";
+    repo = "qwen-code";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  inherit npmDepsHash;
+  makeCacheWritable = true;
+
+  nativeBuildInputs = [
+    pkg-config
+    git
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isDarwin [
+    # node-addon-api (keytar) needs clang 20; clang 21+ trips on a
+    # constexpr issue.
+    clang_20
+    darwinOpenptyHook
+  ];
+
+  buildInputs = [
+    ripgrep
+    glib
+    libsecret
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    npm run generate
+    # The CLI esbuild bundle resolves imports against workspace dist/
+    # output, so build the workspaces it depends on first (subset of
+    # upstream's scripts/build.js buildOrder; the bundled CLI does not
+    # pull in webui/sdk/vscode/plugin-example).
+    for ws in \
+      packages/web-templates \
+      packages/channels/base \
+      packages/channels/telegram \
+      packages/channels/weixin \
+      packages/channels/dingtalk
+    do
+      npm run build --workspace=$ws
+    done
+    npm run bundle
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin $out/share/qwen-code
+    cp -r dist/* $out/share/qwen-code/
+    npm prune --production
+    cp -r node_modules $out/share/qwen-code/
+    # Remove broken symlinks that confuse Nix tooling.
+    find $out/share/qwen-code/node_modules -type l -delete || true
+    patchShebangs $out/share/qwen-code
+    ln -s $out/share/qwen-code/cli.js $out/bin/qwen
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  meta = {
+    description = "Command-line AI workflow tool for Qwen3-Coder models";
+    homepage = "https://github.com/QwenLM/qwen-code";
+    changelog = "https://github.com/QwenLM/qwen-code/releases";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    mainProgram = "qwen";
+  };
+})

--- a/.flox/pkgs/qwen-code/hashes.json
+++ b/.flox/pkgs/qwen-code/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.15.11",
+  "srcHash": "sha256-6ArEbnJOAKexoSy7Epis5OC8XYmmQpZPILtUEv4E0k4=",
+  "npmDepsHash": "sha256-5c9p/kMmD0AEYj/uDMtr2w+Jb0jR00tIzde8KcDB5R4="
+}

--- a/.flox/pkgs/qwen-code/publish.json
+++ b/.flox/pkgs/qwen-code/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/qwen-code/upgrade.sh
+++ b/.flox/pkgs/qwen-code/upgrade.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_tag=$(curl -sfL \
+  https://api.github.com/repos/QwenLM/qwen-code/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating qwen-code from $current_version to $latest_version"
+
+src_url="https://github.com/QwenLM/qwen-code/archive/refs/tags/v${latest_version}.tar.gz"
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+dummy="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg n "$dummy" \
+  '{version: $v, srcHash: $s, npmDepsHash: $n}' > "$HASHES_FILE"
+
+echo "Building with dummy npmDepsHash to compute real one..."
+npm_hash=$(flox build qwen-code 2>&1 \
+  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep "got:" | head -1 | awk '{print $NF}') || true
+
+if [ -z "$npm_hash" ]; then
+  echo "ERROR: could not extract npmDepsHash from build output" >&2
+  exit 1
+fi
+
+echo "  npmDepsHash: $npm_hash"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg n "$npm_hash" \
+  '{version: $v, srcHash: $s, npmDepsHash: $n}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"


### PR DESCRIPTION
## Summary

Wave 2: three open-source LLM coding agents.

- `goose-cli` 1.24.0 — Block's local, extensible AI
  engineering agent. Rust build; prefetches librusty_v8
  v145.0.0 as a fixed-output derivation since the v8
  crate would otherwise try to download it at build time.
- `qwen-code` 0.15.11 — Alibaba's CLI for Qwen3-Coder
  models. NPM source build via `buildNpmPackage`. Inlines
  the same darwin openpty shim setupHook that `gemini-cli`
  uses (keeps `openpty`/`forkpty` prototypes in scope
  during node-pty's node-gyp build). Bundles a subset of
  upstream's workspace build because the CLI's esbuild
  bundle imports from those dist/ outputs.
- `forgecode` 2.12.15 — AI pair programmer that targets
  300+ models across providers. Binary distribution for
  all four systems. The project recently rebranded from
  `antinomyhq/forge` to `tailcallhq/forgecode`; the
  release artifact and binary keep the legacy name
  `forge`. Uses `autoPatchelfHook` on Linux.

All three build and pass their version checks locally on
`aarch64-darwin`.

## Test plan

- [ ] CI builds pass for all four matrix systems
- [ ] `flox publish` succeeds on `main` for each package
- [ ] Spot-check one binary per package on Linux once
      CI artifacts are available