### PR TITLE
fix(ci): pick runner per env in upgrade workflow

### DIFF
--- a/.github/workflows/upgrade_envs.yml
+++ b/.github/workflows/upgrade_envs.yml
@@ -36,12 +36,41 @@ jobs:
           SINGLE_ENV: "${{ inputs.environment }}"
         run: |
           if [ -n "$SINGLE_ENV" ]; then
-            # Single environment mode
+            # Single environment mode. Reuse discover-envs.sh
+            # to pick a runner compatible with the env's lock
+            # systems (avoids hard-coding ubuntu-latest for
+            # darwin-only envs like omlx).
+            LOCK="$SINGLE_ENV/.flox/env/manifest.lock"
+            if [ ! -f "$LOCK" ]; then
+              echo "Error: $LOCK not found"
+              exit 1
+            fi
+
             has_demo="false"
             if [ -d "${SINGLE_ENV}-demo/.flox/env" ]; then
               has_demo="true"
             fi
-            envs="[{\"name\":\"$SINGLE_ENV\",\"has_demo\":$has_demo}]"
+
+            systems="$(jq -r '
+              .manifest.options.systems // []
+              | map(select(. != "x86_64-darwin"))
+              | if length == 0 then
+                  ["aarch64-darwin","aarch64-linux","x86_64-linux"]
+                else . end
+              | .[]
+            ' "$LOCK")"
+            runs_on="$(
+              if   echo "$systems" | grep -qx 'x86_64-linux';   then echo "ubuntu-latest"
+              elif echo "$systems" | grep -qx 'aarch64-linux';  then echo "ubuntu-24.04-arm"
+              elif echo "$systems" | grep -qx 'aarch64-darwin'; then echo "macos-latest"
+              else echo "ERROR"; fi
+            )"
+            if [ "$runs_on" = "ERROR" ]; then
+              echo "Error: no supported runner for systems: $systems"
+              exit 1
+            fi
+
+            envs="[{\"name\":\"$SINGLE_ENV\",\"has_demo\":$has_demo,\"runs_on\":\"$runs_on\"}]"
 
             echo "-- single env --------------"
             echo "$envs" | jq .
@@ -55,7 +84,7 @@ jobs:
 
   upgrade:
     name: "Upgrade '${{ matrix.name }}'"
-    runs-on: "ubuntu-latest"
+    runs-on: "${{ matrix.runs_on }}"
     timeout-minutes: 30
 
     needs:

--- a/scripts/discover-envs.sh
+++ b/scripts/discover-envs.sh
@@ -48,6 +48,20 @@ get_systems() {
   echo "$systems"
 }
 
+# Pick a GitHub Actions runner that can build the env.
+# Prefer Linux (cheaper minutes); fall back to macOS for
+# darwin-only envs. Mirrors environment.yml.
+runner_for_systems() {
+  local systems="$1"
+  if   echo "$systems" | grep -qx 'x86_64-linux';   then echo "ubuntu-latest"
+  elif echo "$systems" | grep -qx 'aarch64-linux';  then echo "ubuntu-24.04-arm"
+  elif echo "$systems" | grep -qx 'aarch64-darwin'; then echo "macos-latest"
+  else
+    echo "no supported runner for systems: $systems" >&2
+    return 1
+  fi
+}
+
 # ── Environment discovery ──────────────────────────────────
 
 find_locks() {
@@ -226,8 +240,9 @@ mode_discover() {
 
 mode_update() {
   # Output JSON array of minimal (non-demo) envs with
-  # a has_demo flag. Used by update.yml to upgrade env
-  # and its demo together.
+  # a has_demo flag and runs_on selector. Used by
+  # upgrade_envs.yml to upgrade env + demo together on
+  # a runner compatible with the env's lockfile systems.
   local envs=()
 
   while IFS= read -r lock; do
@@ -247,7 +262,12 @@ mode_update() {
       has_demo="true"
     fi
 
-    envs+=("{\"name\":\"$name\",\"has_demo\":$has_demo}")
+    local systems
+    systems="$(get_systems "$lock")"
+    local runs_on
+    runs_on="$(runner_for_systems "$systems")"
+
+    envs+=("{\"name\":\"$name\",\"has_demo\":$has_demo,\"runs_on\":\"$runs_on\"}")
   done < <(find_locks)
 
   local json


### PR DESCRIPTION
## Summary

- `omlx` is `aarch64-darwin`-only, so `flox upgrade` on `ubuntu-latest` failed with `Lockfile is not compatible with the current system. Supported systems: aarch64-darwin` ([failing run](https://github.com/flox/floxenvs/actions/runs/26160165311/job/76949719843))
- Mirror `environment.yml`'s runner-selection logic in the upgrade workflow: read each env's lockfile systems and dispatch to `ubuntu-latest` / `ubuntu-24.04-arm` / `macos-latest` accordingly
- Locally verified: `omlx → macos-latest`, every other env still on `ubuntu-latest`

## Changes

- `scripts/discover-envs.sh`: new `runner_for_systems` helper; `mode_update` emits a `runs_on` field per env
- `.github/workflows/upgrade_envs.yml`: upgrade job uses `${{ matrix.runs_on }}`; the single-env (`workflow_dispatch`) path computes `runs_on` inline from the lockfile

## Test plan

- [ ] Trigger `Upgrade Environments` via `workflow_dispatch` with `environment: omlx` — job should dispatch to `macos-latest` and succeed
- [ ] Trigger `Upgrade Environments` via `workflow_dispatch` with any linux env (e.g. `postgresql`) — still dispatches to `ubuntu-latest`
- [ ] Next scheduled (Mon 00:30 UTC) full run picks correct runner per env