### PR TITLE
fix(ci): guard containerize Linux check against missing lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             | scripts/wait-should-poll.sh envs)"
           echo "should_poll=$should_poll" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
-          echo "$changed" | sed 's/^/  /'
+          awk '{print "  "$0}' <<< "$changed"
           echo "should_poll=$should_poll"
 
       - name: "Short-circuit (no env paths changed)"
@@ -288,7 +288,7 @@ jobs:
             | scripts/wait-should-poll.sh packages)"
           echo "should_poll=$should_poll" >> "$GITHUB_OUTPUT"
           echo "Changed files:"
-          echo "$changed" | sed 's/^/  /'
+          awk '{print "  "$0}' <<< "$changed"
           echo "should_poll=$should_poll"
 
       - name: "Short-circuit (no pkg paths changed)"
@@ -561,12 +561,18 @@ jobs:
           # Containers are built on ubuntu-latest (x86_64-linux). If the
           # env doesn't support x86_64-linux, skip the containerize job.
           # Empty `systems` in the manifest means "all systems" (default).
-          ENV_LINUX=$(jq -r '
-            .manifest.options.systems // []
-            | if length == 0 then "true"
-              else (index("x86_64-linux") | if . != null then "true" else "false" end)
-              end
-          ' "$LOCK")
+          # Missing lockfile = bootstrap state (env workflow exists but
+          # the env dir isn't published yet); skip containerization.
+          if [ -f "$LOCK" ]; then
+            ENV_LINUX=$(jq -r '
+              .manifest.options.systems // []
+              | if length == 0 then "true"
+                else (index("x86_64-linux") | if . != null then "true" else "false" end)
+                end
+            ' "$LOCK")
+          else
+            ENV_LINUX="false"
+          fi
           echo "env_linux=$ENV_LINUX" >> "$GITHUB_OUTPUT"
 
           DEMO_LOCK="$ENV-demo/.flox/env/manifest.lock"


### PR DESCRIPTION
## Summary

Fixes the failing `Containerize 'worktrunk'` job on `main`:
[run 26156245147 job 76942679550](https://github.com/flox/floxenvs/actions/runs/26156245147/job/76942679550).

The `containerize` matrix in `ci.yml` derives env names from
`ci_<name>.yml` workflow filenames. When PR #1875 added
`ci_worktrunk.yml` but the `worktrunk/` env dir hasn't been
bootstrapped yet (its package isn't published to the FloxHub
catalog so `manifest.lock` can't be generated), the
containerize job's first step does:

```bash
LOCK="$ENV/.flox/env/manifest.lock"
ENV_LINUX=$(jq -r '...' "$LOCK")
```

`jq` exits 2 on the missing file → step fails → main is red.

PR #1875 already added bootstrap-state handling to
`environment.yml`'s `discover` step. This applies the same fix
to `ci.yml`'s containerize step by mirroring the existing
`DEMO_LOCK` guard pattern:

```bash
if [ -f "$LOCK" ]; then
  ENV_LINUX=$(jq -r '...' "$LOCK")
else
  ENV_LINUX="false"
fi
```

Missing lockfile → `env_linux=false` → downstream steps skip via
existing `if:` gates.

Also swaps two `echo \"\$changed\" | sed 's/^/  /'` pipelines for
`awk '{print "  "\$0}' <<< \"\$changed\"` to silence pre-existing
SC2001 shellcheck warnings actionlint blocks pre-commit on.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` is clean (was flagging
      two SC2001 warnings before the awk swap)
- [x] `yamllint .github/workflows/ci.yml` is clean
- [ ] CI on this PR passes
- [ ] After merge: the next push to main does not fail
      `Containerize 'worktrunk'`