### PR TITLE
ci: add invariant check — every env must have manifest.lock

### DIFF
--- a/.github/workflows/invariants.yml
+++ b/.github/workflows/invariants.yml
@@ -1,0 +1,52 @@
+name: "Invariants"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: "read"
+
+jobs:
+
+  lockfile-present:
+    name: "Every env has manifest.lock"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 5
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
+
+      - name: "Check every env has a manifest.lock"
+        run: |
+          set -euo pipefail
+
+          # Every dir matching <env>/.flox/env/manifest.toml must
+          # have a sibling manifest.lock. The rest of CI assumes
+          # this invariant (containerize, lockfile-freshness,
+          # composed-include resolution all jq the lockfile
+          # without guarding the read).
+          fail=0
+          for manifest in */.flox/env/manifest.toml; do
+            env_dir="${manifest%/.flox/env/manifest.toml}"
+            lock="$env_dir/.flox/env/manifest.lock"
+            if [ ! -f "$lock" ]; then
+              echo "::error file=$manifest::env '$env_dir' is missing manifest.lock"
+              fail=1
+            fi
+          done
+
+          if [ $fail -ne 0 ]; then
+            echo ""
+            echo "To fix locally:"
+            echo "  (cd <env> && flox edit -f .flox/env/manifest.toml)"
+            echo ""
+            echo "Then commit the generated manifest.lock alongside"
+            echo "manifest.toml."
+            exit 1
+          fi
+
+          echo "OK: every env has a manifest.lock"

--- a/worktrunk-demo/.flox/env/manifest.lock
+++ b/worktrunk-demo/.flox/env/manifest.lock
@@ -1,0 +1,435 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "schema-version": "1.10.0",
+    "install": {
+      "git": {
+        "pkg-path": "git",
+        "pkg-group": "worktrunk"
+      },
+      "gum": {
+        "pkg-path": "gum",
+        "pkg-group": "demo-tools"
+      },
+      "worktrunk": {
+        "pkg-path": "flox/worktrunk",
+        "pkg-group": "worktrunk"
+      }
+    },
+    "hook": {
+      "on-activate": "export WORKTRUNK_CACHE=\"$FLOX_ENV_CACHE/worktrunk\"\nmkdir -p \"$WORKTRUNK_CACHE\"\n\nif [ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]; then\n  gum style \\\n    --foreground 212 --border-foreground 212 \\\n    --border double --align center \\\n    --width 60 --margin \"1 2\" --padding \"1 2\" \\\n    \"Worktrunk\" \"git worktrees, made easy\"\n  echo \"\"\n  echo \"  wt switch <branch>        — switch / create worktree\"\n  echo \"  wt switch -c -x claude X  — create + start coding agent\"\n  echo \"  wt list                   — list worktrees with status\"\n  echo \"  wt merge                  — merge + clean up\"\n  echo \"  wt remove                 — remove worktree + branch\"\n  echo \"\"\n  echo \"  Docs: https://worktrunk.dev\"\n  echo \"\"\nfi\n"
+    },
+    "options": {}
+  },
+  "packages": [
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/3if65h5mjjgjwgvd18srmm35cn3w6xs8-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T07:05:52.142375Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/ba53aq5kpjm2qb817qgxswy2hvnkxnyj-gum-0.17.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/ka558hvp8n0vhw8lzwsw66zw3g3lavzd-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T07:33:31.643735Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/3hlyv3x7jjn5364f08jw0bic3zddqhxc-gum-0.17.0"
+      },
+      "system": "aarch64-linux",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/z2rm91h36jx1ym7gpl3avxqqxc407pn2-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T08:01:18.656478Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/qkwxvmldb9a8nmqq6aqqd47gj3pxwx42-gum-0.17.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "gum",
+      "broken": false,
+      "derivation": "/nix/store/835d9xq5q9w2hv6dzlsc3yjbh44kmpjn-gum-0.17.0.drv",
+      "description": "Tasty Bubble Gum for your shell",
+      "install_id": "gum",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=d233902339c02a9c334e7e593de68855ad26c4cb",
+      "name": "gum-0.17.0",
+      "pname": "gum",
+      "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+      "rev_count": 998534,
+      "rev_date": "2026-05-15T18:21:44Z",
+      "scrape_date": "2026-05-17T08:32:12.167065Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.17.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/c149nbx8xh8knvply95623gnwqds19xr-gum-0.17.0"
+      },
+      "system": "x86_64-linux",
+      "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "git",
+      "broken": false,
+      "derivation": "/nix/store/9n758xnd7s67zz9naiivygz24pv7zpr4-git-2.53.0.drv",
+      "description": "Distributed version control system",
+      "install_id": "git",
+      "license": "GPL-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "git-2.53.0",
+      "pname": "git",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:10:23.305052Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.53.0",
+      "outputs_to_install": [
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "doc": "/nix/store/0kjpgj1grgba239ykdnv1cjc61xqk3aa-git-2.53.0-doc",
+        "out": "/nix/store/5y6cp247hspkqa7pp6cbc4540ygx0249-git-2.53.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "git",
+      "broken": false,
+      "derivation": "/nix/store/y0zdc38hb5flnbzx9a8sia7azv917jvc-git-2.53.0.drv",
+      "description": "Distributed version control system",
+      "install_id": "git",
+      "license": "GPL-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "git-2.53.0",
+      "pname": "git",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:44:35.350650Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.53.0",
+      "outputs_to_install": [
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "debug": "/nix/store/rc56a3l2wby94gk9gvirpwi9hv9v15gi-git-2.53.0-debug",
+        "doc": "/nix/store/q8j5mwix1g75xyq025d3hmringklm52z-git-2.53.0-doc",
+        "out": "/nix/store/gx9r7g2kyrjhh0zhgxz91f5nbczxh1ac-git-2.53.0"
+      },
+      "system": "aarch64-linux",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "git",
+      "broken": false,
+      "derivation": "/nix/store/mpa3y57ch7a3rz55183a886hq2g4h9wm-git-2.53.0.drv",
+      "description": "Distributed version control system",
+      "install_id": "git",
+      "license": "GPL-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "git-2.53.0",
+      "pname": "git",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:15:56.219055Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.53.0",
+      "outputs_to_install": [
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "doc": "/nix/store/9jcm7zadfi5wsic3kizs4x71a8dqlj83-git-2.53.0-doc",
+        "out": "/nix/store/zar16r8w28c6qjdh3xqnkjcmvjjqwi77-git-2.53.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "git",
+      "broken": false,
+      "derivation": "/nix/store/gz2q1wq6ckyphg0q08nq9q93g1a6x561-git-2.53.0.drv",
+      "description": "Distributed version control system",
+      "install_id": "git",
+      "license": "GPL-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "git-2.53.0",
+      "pname": "git",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:52:12.669197Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.53.0",
+      "outputs_to_install": [
+        "out",
+        "out",
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "debug": "/nix/store/qyqya20z59d164d6692hlyb9pkq10ykk-git-2.53.0-debug",
+        "doc": "/nix/store/vv1ap6qaxdzpa4jqg71myxh5wcvnlqv8-git-2.53.0-doc",
+        "out": "/nix/store/c0277k5giric1mn9dklllavbzvxl6hzb-git-2.53.0"
+      },
+      "system": "x86_64-linux",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "worktrunk",
+      "broken": false,
+      "derivation": "/nix/store/rf0sfh0gk9g6xw7gr14lnal8wzwlj81p-worktrunk-0.51.0.drv",
+      "description": "CLI for git worktree management, designed for parallel AI agent workflows",
+      "install_id": "worktrunk",
+      "license": "[ MIT, Apache-2.0 ]",
+      "locked_url": "https://github.com/flox/floxenvs?rev=19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "name": "worktrunk-0.51.0",
+      "pname": "worktrunk",
+      "rev": "19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "rev_count": 3536,
+      "rev_date": "2026-05-20T10:17:17Z",
+      "scrape_date": "2026-05-20T12:27:56.010862Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.51.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/2ja23377dqc6jg3h33vxzyya4icxd45y-worktrunk-0.51.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "worktrunk",
+      "broken": false,
+      "derivation": "/nix/store/cy70fnidrqiqhm45h672xc2nc0m733mx-worktrunk-0.51.0.drv",
+      "description": "CLI for git worktree management, designed for parallel AI agent workflows",
+      "install_id": "worktrunk",
+      "license": "[ MIT, Apache-2.0 ]",
+      "locked_url": "https://github.com/flox/floxenvs?rev=19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "name": "worktrunk-0.51.0",
+      "pname": "worktrunk",
+      "rev": "19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "rev_count": 3536,
+      "rev_date": "2026-05-20T10:17:17Z",
+      "scrape_date": "2026-05-20T12:27:56.010862Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.51.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/dz5pmrdjqhbpawimzi2kzsk16854454n-worktrunk-0.51.0"
+      },
+      "system": "aarch64-linux",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "worktrunk",
+      "broken": false,
+      "derivation": "/nix/store/r891gv5nbwrccsjn77iql8br616frgqh-worktrunk-0.51.0.drv",
+      "description": "CLI for git worktree management, designed for parallel AI agent workflows",
+      "install_id": "worktrunk",
+      "license": "[ MIT, Apache-2.0 ]",
+      "locked_url": "https://github.com/flox/floxenvs?rev=19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "name": "worktrunk-0.51.0",
+      "pname": "worktrunk",
+      "rev": "19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "rev_count": 3536,
+      "rev_date": "2026-05-20T10:17:17Z",
+      "scrape_date": "2026-05-20T12:27:56.010863Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.51.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/dcnf3smqnvf855561cs9vz5hygkw6yb3-worktrunk-0.51.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "worktrunk",
+      "broken": false,
+      "derivation": "/nix/store/a0h4jpqf23xvvfax57f78x2gg1va0jhg-worktrunk-0.51.0.drv",
+      "description": "CLI for git worktree management, designed for parallel AI agent workflows",
+      "install_id": "worktrunk",
+      "license": "[ MIT, Apache-2.0 ]",
+      "locked_url": "https://github.com/flox/floxenvs?rev=19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "name": "worktrunk-0.51.0",
+      "pname": "worktrunk",
+      "rev": "19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "rev_count": 3536,
+      "rev_date": "2026-05-20T10:17:17Z",
+      "scrape_date": "2026-05-20T12:27:56.010863Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.51.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/zzhnlffx1i6a7q8rcx43grzyvh4zhm0a-worktrunk-0.51.0"
+      },
+      "system": "x86_64-linux",
+      "group": "worktrunk",
+      "priority": 5
+    }
+  ],
+  "compose": {
+    "composer": {
+      "schema-version": "1.10.0",
+      "install": {
+        "gum": {
+          "pkg-path": "gum",
+          "pkg-group": "demo-tools"
+        }
+      },
+      "hook": {
+        "on-activate": "if [ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]; then\n  gum style \\\n    --foreground 212 --border-foreground 212 \\\n    --border double --align center \\\n    --width 60 --margin \"1 2\" --padding \"1 2\" \\\n    \"Worktrunk\" \"git worktrees, made easy\"\n  echo \"\"\n  echo \"  wt switch <branch>        — switch / create worktree\"\n  echo \"  wt switch -c -x claude X  — create + start coding agent\"\n  echo \"  wt list                   — list worktrees with status\"\n  echo \"  wt merge                  — merge + clean up\"\n  echo \"  wt remove                 — remove worktree + branch\"\n  echo \"\"\n  echo \"  Docs: https://worktrunk.dev\"\n  echo \"\"\nfi\n"
+      },
+      "options": {},
+      "include": {
+        "environments": [
+          {
+            "dir": "../worktrunk"
+          }
+        ]
+      }
+    },
+    "include": [
+      {
+        "manifest": {
+          "schema-version": "1.10.0",
+          "install": {
+            "git": {
+              "pkg-path": "git",
+              "pkg-group": "worktrunk"
+            },
+            "worktrunk": {
+              "pkg-path": "flox/worktrunk",
+              "pkg-group": "worktrunk"
+            }
+          },
+          "hook": {
+            "on-activate": "export WORKTRUNK_CACHE=\"$FLOX_ENV_CACHE/worktrunk\"\nmkdir -p \"$WORKTRUNK_CACHE\"\n"
+          },
+          "options": {}
+        },
+        "name": "worktrunk",
+        "descriptor": {
+          "dir": "../worktrunk"
+        }
+      }
+    ],
+    "warnings": []
+  }
+}

--- a/worktrunk/.flox/env/manifest.lock
+++ b/worktrunk/.flox/env/manifest.lock
@@ -1,0 +1,266 @@
+{
+  "lockfile-version": 1,
+  "manifest": {
+    "schema-version": "1.10.0",
+    "install": {
+      "git": {
+        "pkg-path": "git",
+        "pkg-group": "worktrunk"
+      },
+      "worktrunk": {
+        "pkg-path": "flox/worktrunk",
+        "pkg-group": "worktrunk"
+      }
+    },
+    "hook": {
+      "on-activate": "export WORKTRUNK_CACHE=\"$FLOX_ENV_CACHE/worktrunk\"\nmkdir -p \"$WORKTRUNK_CACHE\"\n"
+    },
+    "options": {}
+  },
+  "packages": [
+    {
+      "attr_path": "git",
+      "broken": false,
+      "derivation": "/nix/store/9n758xnd7s67zz9naiivygz24pv7zpr4-git-2.53.0.drv",
+      "description": "Distributed version control system",
+      "install_id": "git",
+      "license": "GPL-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "git-2.53.0",
+      "pname": "git",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:10:23.305052Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.53.0",
+      "outputs_to_install": [
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "doc": "/nix/store/0kjpgj1grgba239ykdnv1cjc61xqk3aa-git-2.53.0-doc",
+        "out": "/nix/store/5y6cp247hspkqa7pp6cbc4540ygx0249-git-2.53.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "git",
+      "broken": false,
+      "derivation": "/nix/store/y0zdc38hb5flnbzx9a8sia7azv917jvc-git-2.53.0.drv",
+      "description": "Distributed version control system",
+      "install_id": "git",
+      "license": "GPL-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "git-2.53.0",
+      "pname": "git",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T08:44:35.350650Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.53.0",
+      "outputs_to_install": [
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "debug": "/nix/store/rc56a3l2wby94gk9gvirpwi9hv9v15gi-git-2.53.0-debug",
+        "doc": "/nix/store/q8j5mwix1g75xyq025d3hmringklm52z-git-2.53.0-doc",
+        "out": "/nix/store/gx9r7g2kyrjhh0zhgxz91f5nbczxh1ac-git-2.53.0"
+      },
+      "system": "aarch64-linux",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "git",
+      "broken": false,
+      "derivation": "/nix/store/mpa3y57ch7a3rz55183a886hq2g4h9wm-git-2.53.0.drv",
+      "description": "Distributed version control system",
+      "install_id": "git",
+      "license": "GPL-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "git-2.53.0",
+      "pname": "git",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:15:56.219055Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.53.0",
+      "outputs_to_install": [
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "doc": "/nix/store/9jcm7zadfi5wsic3kizs4x71a8dqlj83-git-2.53.0-doc",
+        "out": "/nix/store/zar16r8w28c6qjdh3xqnkjcmvjjqwi77-git-2.53.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "git",
+      "broken": false,
+      "derivation": "/nix/store/gz2q1wq6ckyphg0q08nq9q93g1a6x561-git-2.53.0.drv",
+      "description": "Distributed version control system",
+      "install_id": "git",
+      "license": "GPL-2.0",
+      "locked_url": "https://github.com/flox/nixpkgs?rev=15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "name": "git-2.53.0",
+      "pname": "git",
+      "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+      "rev_count": 990025,
+      "rev_date": "2026-04-30T19:45:37Z",
+      "scrape_date": "2026-05-03T09:52:12.669197Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "2.53.0",
+      "outputs_to_install": [
+        "out",
+        "out",
+        "out",
+        "out"
+      ],
+      "outputs": {
+        "debug": "/nix/store/qyqya20z59d164d6692hlyb9pkq10ykk-git-2.53.0-debug",
+        "doc": "/nix/store/vv1ap6qaxdzpa4jqg71myxh5wcvnlqv8-git-2.53.0-doc",
+        "out": "/nix/store/c0277k5giric1mn9dklllavbzvxl6hzb-git-2.53.0"
+      },
+      "system": "x86_64-linux",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "worktrunk",
+      "broken": false,
+      "derivation": "/nix/store/rf0sfh0gk9g6xw7gr14lnal8wzwlj81p-worktrunk-0.51.0.drv",
+      "description": "CLI for git worktree management, designed for parallel AI agent workflows",
+      "install_id": "worktrunk",
+      "license": "[ MIT, Apache-2.0 ]",
+      "locked_url": "https://github.com/flox/floxenvs?rev=19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "name": "worktrunk-0.51.0",
+      "pname": "worktrunk",
+      "rev": "19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "rev_count": 3536,
+      "rev_date": "2026-05-20T10:17:17Z",
+      "scrape_date": "2026-05-20T12:22:44.774092Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.51.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/2ja23377dqc6jg3h33vxzyya4icxd45y-worktrunk-0.51.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "worktrunk",
+      "broken": false,
+      "derivation": "/nix/store/cy70fnidrqiqhm45h672xc2nc0m733mx-worktrunk-0.51.0.drv",
+      "description": "CLI for git worktree management, designed for parallel AI agent workflows",
+      "install_id": "worktrunk",
+      "license": "[ MIT, Apache-2.0 ]",
+      "locked_url": "https://github.com/flox/floxenvs?rev=19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "name": "worktrunk-0.51.0",
+      "pname": "worktrunk",
+      "rev": "19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "rev_count": 3536,
+      "rev_date": "2026-05-20T10:17:17Z",
+      "scrape_date": "2026-05-20T12:22:44.774095Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.51.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/dz5pmrdjqhbpawimzi2kzsk16854454n-worktrunk-0.51.0"
+      },
+      "system": "aarch64-linux",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "worktrunk",
+      "broken": false,
+      "derivation": "/nix/store/r891gv5nbwrccsjn77iql8br616frgqh-worktrunk-0.51.0.drv",
+      "description": "CLI for git worktree management, designed for parallel AI agent workflows",
+      "install_id": "worktrunk",
+      "license": "[ MIT, Apache-2.0 ]",
+      "locked_url": "https://github.com/flox/floxenvs?rev=19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "name": "worktrunk-0.51.0",
+      "pname": "worktrunk",
+      "rev": "19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "rev_count": 3536,
+      "rev_date": "2026-05-20T10:17:17Z",
+      "scrape_date": "2026-05-20T12:22:44.774096Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.51.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/dcnf3smqnvf855561cs9vz5hygkw6yb3-worktrunk-0.51.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "worktrunk",
+      "priority": 5
+    },
+    {
+      "attr_path": "worktrunk",
+      "broken": false,
+      "derivation": "/nix/store/a0h4jpqf23xvvfax57f78x2gg1va0jhg-worktrunk-0.51.0.drv",
+      "description": "CLI for git worktree management, designed for parallel AI agent workflows",
+      "install_id": "worktrunk",
+      "license": "[ MIT, Apache-2.0 ]",
+      "locked_url": "https://github.com/flox/floxenvs?rev=19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "name": "worktrunk-0.51.0",
+      "pname": "worktrunk",
+      "rev": "19c87d16bdf4ae8432cda0b7e5f42ab2704d323f",
+      "rev_count": 3536,
+      "rev_date": "2026-05-20T10:17:17Z",
+      "scrape_date": "2026-05-20T12:22:44.774098Z",
+      "stabilities": [
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.51.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/zzhnlffx1i6a7q8rcx43grzyvh4zhm0a-worktrunk-0.51.0"
+      },
+      "system": "x86_64-linux",
+      "group": "worktrunk",
+      "priority": 5
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Follow-up to #1891. Adds a small PR-blocking workflow that
prevents the "env merged without a lockfile" class of regression.

For each top-level `<env>/.flox/env/manifest.toml`, the workflow
checks that a sibling `manifest.lock` exists. If any are missing,
it emits a GitHub `::error file=...::` annotation pointing at the
offending manifest and fails the check.

## Why

The rest of CI silently assumes every env has a lockfile:

- `ci.yml` containerize matrix `jq`'s
  `<env>/.flox/env/manifest.lock` directly
- `environment.yml` discover step regenerates lockfiles and
  fails on drift (assumes there's a lockfile to compare)
- Composed `[include]` resolution reads the included env's
  lockfile

#1875 violated the invariant (worktrunk landed without
lockfiles because its package wasn't in the catalog yet). The
violation was silent on the feature PR and only failed on the
next push to main, taking out unrelated containerize work.
#1891 restored the invariant; this PR enforces it.

## Verified

- `actionlint` + `yamllint` clean
- Dry-run against `main` state (no worktrunk lockfiles) correctly
  reports `MISSING: worktrunk` and `MISSING: worktrunk-demo`
- Dry-run against this branch (lockfiles in place via #1891)
  reports OK

## Depends on

This branch is based on #1891 so its own CI passes. Merge #1891
first, then rebase + merge this.

## Test plan

- [ ] CI: this workflow runs green on the PR (with #1891
  ancestor)
- [ ] Future PR adding an env without a lockfile is rejected at
  PR time