### PR TITLE
feat(pkgs): add wave 5 agent utility packages

### DIFF
--- a/.flox/pkgs/agent-browser/default.nix
+++ b/.flox/pkgs/agent-browser/default.nix
@@ -1,0 +1,152 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  fetchurl,
+  chromium,
+  makeBinaryWrapper,
+  nodejs-slim,
+  pnpmConfigHook,
+  pnpm_10,
+  rustPlatform,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData)
+    version
+    srcHash
+    cargoHash
+    pnpmDepsHash
+    ;
+
+  # Vendored Geist variable font (OFL-1.1) pinned to a specific upstream
+  # commit so the dashboard's next/font build is fully offline.
+  geistVariable = fetchurl {
+    url =
+      "https://raw.githubusercontent.com/vercel/geist-font/"
+      + "77f0563c03009d6c15c6342183fa53b352255b22/"
+      + "packages/next/dist/fonts/geist-sans/Geist-Variable.woff2";
+    hash = "sha256-L/6+mT6WkGmpeJ0VFkt3FdQkkbWDVRbF47k11fgbBfE=";
+  };
+
+  src = fetchFromGitHub {
+    owner = "vercel-labs";
+    repo = "agent-browser";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  # The dashboard is a Next.js app built with pnpm; bake it into a fixed
+  # output that the Rust CLI's build.rs and runtime asset embedder can
+  # reference via the patched paths below.
+  dashboard = stdenv.mkDerivation {
+    pname = "agent-browser-dashboard";
+    inherit version src;
+
+    nativeBuildInputs = [
+      nodejs-slim
+      pnpm_10
+      pnpmConfigHook
+    ];
+
+    pnpmDeps = fetchPnpmDeps {
+      pname = "agent-browser-dashboard";
+      inherit version src;
+      pnpm = pnpm_10;
+      hash = pnpmDepsHash;
+      fetcherVersion = 3;
+    };
+
+    # next/font/google fetches Geist from fonts.googleapis.com at build
+    # time, which the Nix sandbox blocks. Swap it for next/font/local
+    # pointing at the vendored woff2.
+    postPatch = ''
+      install -Dm644 ${geistVariable} \
+        packages/dashboard/src/app/Geist-Variable.woff2
+      substituteInPlace packages/dashboard/src/app/layout.tsx \
+        --replace-fail 'import { Geist } from "next/font/google"' \
+                        'import Geist from "next/font/local"' \
+        --replace-fail 'Geist({ subsets: ["latin"], variable: "--font-sans" })' \
+                        'Geist({ src: "./Geist-Variable.woff2", variable: "--font-sans", display: "swap" })'
+    '';
+
+    buildPhase = ''
+      runHook preBuild
+      cd packages/dashboard
+      pnpm build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r out/. $out/
+      runHook postInstall
+    '';
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = "agent-browser";
+  inherit version src;
+
+  sourceRoot = "source/cli";
+
+  inherit cargoHash;
+
+  nativeBuildInputs = lib.optional stdenv.hostPlatform.isLinux makeBinaryWrapper;
+  buildInputs = lib.optional stdenv.hostPlatform.isLinux chromium;
+
+  # Upstream pins fat LTO with codegen-units=1 while pulling in the full
+  # `image` crate (avif/webp/tiff/jpeg/png/gif). The monolithic LTO link
+  # OOMs rustc on the aarch64-linux builder; thin LTO keeps most of the
+  # optimisation at a fraction of the peak memory.
+  env.CARGO_PROFILE_RELEASE_LTO = "thin";
+
+  # cargo-auditable panics on aarch64-darwin with this crate's dep tree.
+  auditable = !stdenv.hostPlatform.isDarwin;
+
+  # Auth/credential tests want a keyring not available in the sandbox.
+  doCheck = false;
+
+  postPatch = ''
+    # Skill discovery walks up from the executable looking for a directory
+    # that contains skills/. Point it at $out/share/agent-browser so both
+    # skills/ and skill-data/ are found without polluting $out.
+    substituteInPlace src/skills.rs \
+      --replace-fail \
+        'fn find_package_root() -> Option<PathBuf> {' \
+        'fn find_package_root() -> Option<PathBuf> {
+    let nix_root = PathBuf::from("${placeholder "out"}/share/agent-browser");
+    if nix_root.join("skills").is_dir() {
+        return Some(nix_root);
+    }'
+
+    substituteInPlace build.rs \
+      --replace-fail 'Path::new("../packages/dashboard/out")' \
+                      'Path::new("${dashboard}")'
+    substituteInPlace src/native/stream/http.rs \
+      --replace-fail '#[folder = "../packages/dashboard/out/"]' \
+                      '#[folder = "${dashboard}/"]'
+  '';
+
+  postInstall = ''
+    mkdir -p $out/share/agent-browser
+    cp -r ../skills ../skill-data $out/share/agent-browser/
+  ''
+  + lib.optionalString stdenv.hostPlatform.isLinux ''
+    wrapProgram $out/bin/agent-browser \
+      --set AGENT_BROWSER_EXECUTABLE_PATH ${chromium}/bin/chromium
+  '';
+
+  meta = {
+    description = "Headless browser automation CLI for AI agents";
+    homepage = "https://github.com/vercel-labs/agent-browser";
+    changelog = "https://github.com/vercel-labs/agent-browser/releases/tag/v${version}";
+    license = lib.licenses.asl20;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = lib.platforms.all;
+    mainProgram = "agent-browser";
+  };
+}

--- a/.flox/pkgs/agent-browser/hashes.json
+++ b/.flox/pkgs/agent-browser/hashes.json
@@ -1,0 +1,6 @@
+{
+  "version": "0.27.0",
+  "srcHash": "sha256-c+AJAXMX88t+zzFsEAtFJDjDY5EbhmEyMRGFL4t63nE=",
+  "cargoHash": "sha256-2u7yokHCxIVq16370Mg+n5kf03yUDYJmctFxN1fnaAA=",
+  "pnpmDepsHash": "sha256-xNxNFvaw5sdX0ZaBIUf449wIHQNifMPK3I+qi+yp+UU="
+}

--- a/.flox/pkgs/agent-browser/publish.json
+++ b/.flox/pkgs/agent-browser/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/agent-browser/upgrade.sh
+++ b/.flox/pkgs/agent-browser/upgrade.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_tag=$(curl -sfL \
+  https://api.github.com/repos/vercel-labs/agent-browser/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating agent-browser from $current_version to $latest_version"
+
+src_url="https://github.com/vercel-labs/agent-browser/archive/refs/tags/v${latest_version}.tar.gz"
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+dummy="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg c "$dummy" \
+  --arg p "$dummy" \
+  '{version: $v, srcHash: $s, cargoHash: $c, pnpmDepsHash: $p}' > "$HASHES_FILE"
+
+echo "Building with dummy hashes to compute real ones..."
+# pnpm deps build first; capture both hashes from successive build runs.
+pnpm_hash=$(flox build agent-browser 2>&1 \
+  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep "got:" | head -1 | awk '{print $NF}') || true
+
+if [ -z "$pnpm_hash" ]; then
+  echo "ERROR: could not extract pnpmDepsHash from build output" >&2
+  exit 1
+fi
+echo "  pnpmDepsHash: $pnpm_hash"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg c "$dummy" \
+  --arg p "$pnpm_hash" \
+  '{version: $v, srcHash: $s, cargoHash: $c, pnpmDepsHash: $p}' > "$HASHES_FILE"
+
+cargo_hash=$(flox build agent-browser 2>&1 \
+  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep "got:" | head -1 | awk '{print $NF}') || true
+
+if [ -z "$cargo_hash" ]; then
+  echo "ERROR: could not extract cargoHash from build output" >&2
+  exit 1
+fi
+echo "  cargoHash: $cargo_hash"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg c "$cargo_hash" \
+  --arg p "$pnpm_hash" \
+  '{version: $v, srcHash: $s, cargoHash: $c, pnpmDepsHash: $p}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.flox/pkgs/coderabbit-cli/default.nix
+++ b/.flox/pkgs/coderabbit-cli/default.nix
@@ -1,0 +1,86 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  unzip,
+  autoPatchelfHook,
+  libsecret,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    x86_64-linux = "linux-x64";
+    aarch64-linux = "linux-arm64";
+    x86_64-darwin = "darwin-x64";
+    aarch64-darwin = "darwin-arm64";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  platformSuffix = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+in
+stdenv.mkDerivation {
+  pname = "coderabbit-cli";
+  inherit version;
+
+  src = fetchurl {
+    url = "https://cli.coderabbit.ai/releases/${version}/" + "coderabbit-${platformSuffix}.zip";
+    hash = hashes.${platform};
+  };
+
+  nativeBuildInputs = [
+    unzip
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    libsecret
+  ];
+
+  unpackPhase = ''
+    unzip $src
+  '';
+
+  # Don't strip the Bun-compiled binary or its embedded payload.
+  dontStrip = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 coderabbit $out/bin/coderabbit
+    ln -s $out/bin/coderabbit $out/bin/cr
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckProgramArg = "--version";
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  meta = {
+    description = "AI-powered code review CLI from CodeRabbit";
+    homepage = "https://coderabbit.ai";
+    changelog = "https://docs.coderabbit.ai/changelog";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    mainProgram = "coderabbit";
+  };
+}

--- a/.flox/pkgs/coderabbit-cli/hashes.json
+++ b/.flox/pkgs/coderabbit-cli/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "0.5.0",
+  "hashes": {
+    "aarch64-darwin": "sha256-XCbtsNfE4stYmI9Dtv8zrfUkL4Ag5mHbwKJgZbnzb+I=",
+    "aarch64-linux": "sha256-LojuWJTvGjWeZflIM1hKvADk6VsbCya2LDmbHizlJ3g=",
+    "x86_64-darwin": "sha256-cO0gDZDliso6R3UinIzWCjf3eqq+oibfOXiDMUVqK/E=",
+    "x86_64-linux": "sha256-QrteH/TwQySOtJvMQ61iwE2qN+kppmFIpxr8f/mYYdc="
+  }
+}

--- a/.flox/pkgs/coderabbit-cli/publish.json
+++ b/.flox/pkgs/coderabbit-cli/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/coderabbit-cli/upgrade.sh
+++ b/.flox/pkgs/coderabbit-cli/upgrade.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+# CodeRabbit publishes the current CLI version at a stable endpoint.
+VERSION_URL="https://cli.coderabbit.ai/releases/latest"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+# Follow redirect to /releases/<version> and extract the version path
+latest_version=$(curl -sILf "$VERSION_URL" \
+  | grep -i '^location:' | tail -1 \
+  | sed -E 's|.*/releases/([^/[:space:]]+).*|\1|' | tr -d '[:space:]')
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ -z "$latest_version" ] || [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date or could not detect latest"
+  exit 0
+fi
+
+echo "Updating coderabbit-cli from $current_version to $latest_version"
+
+declare -A PLATFORMS=(
+  ["aarch64-darwin"]="darwin-arm64"
+  ["aarch64-linux"]="linux-arm64"
+  ["x86_64-darwin"]="darwin-x64"
+  ["x86_64-linux"]="linux-x64"
+)
+
+hashes_json="{}"
+for system in "${!PLATFORMS[@]}"; do
+  suffix="${PLATFORMS[$system]}"
+  url="https://cli.coderabbit.ai/releases/$latest_version/coderabbit-$suffix.zip"
+  echo "  fetching $system"
+  hash=$(nix-prefetch-url "$url" 2>/dev/null)
+  sri=$(nix hash convert --hash-algo sha256 --to sri "$hash")
+  echo "    $system: $sri"
+  hashes_json=$(echo "$hashes_json" \
+    | jq --arg p "$system" --arg h "$sri" '.[$p] = $h')
+done
+
+jq -n \
+  --arg v "$latest_version" \
+  --argjson h "$hashes_json" \
+  '{version: $v, hashes: ($h | to_entries | sort_by(.key) | from_entries)}' \
+  > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.flox/pkgs/mcporter/default.nix
+++ b/.flox/pkgs/mcporter/default.nix
@@ -1,0 +1,99 @@
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  fetchPnpmDeps,
+  makeWrapper,
+  nodejs,
+  pnpm_10,
+  pnpmConfigHook,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version srcHash pnpmDepsHash;
+  pnpm = pnpm_10;
+in
+stdenv.mkDerivation (finalAttrs: {
+  pname = "mcporter";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "steipete";
+    repo = "mcporter";
+    tag = "v${version}";
+    hash = srcHash;
+  };
+
+  # Upstream's lockfile was generated before the pnpm.overrides entry for
+  # vite was applied, so newer pnpm rejects it as out of sync with
+  # package.json. Strip the caret so the specifier matches the resolved
+  # entry exactly.
+  postPatch = ''
+    sed -i 's/specifier: \^8\.0\.8/specifier: 8.0.8/' pnpm-lock.yaml
+  '';
+
+  pnpmDeps = fetchPnpmDeps {
+    inherit (finalAttrs)
+      pname
+      version
+      src
+      postPatch
+      ;
+    inherit pnpm;
+    hash = pnpmDepsHash;
+    fetcherVersion = 3;
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    nodejs
+    pnpm
+    pnpmConfigHook
+  ];
+
+  buildPhase = ''
+    runHook preBuild
+
+    pnpm build
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,lib/mcporter}
+
+    # Prune dev dependencies to reduce closure size.
+    pnpm prune --prod
+
+    cp -r dist $out/lib/mcporter/
+    cp -r node_modules $out/lib/mcporter/
+    cp package.json $out/lib/mcporter/
+
+    makeWrapper ${nodejs}/bin/node $out/bin/mcporter \
+      --add-flags "$out/lib/mcporter/dist/cli.js"
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  meta = {
+    description = "TypeScript runtime and CLI for the Model Context Protocol";
+    homepage = "https://github.com/steipete/mcporter";
+    changelog = "https://github.com/steipete/mcporter/releases";
+    license = lib.licenses.mit;
+    sourceProvenance = with lib.sourceTypes; [ fromSource ];
+    platforms = lib.platforms.all;
+    mainProgram = "mcporter";
+  };
+})

--- a/.flox/pkgs/mcporter/hashes.json
+++ b/.flox/pkgs/mcporter/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.11.1",
+  "srcHash": "sha256-fhIU5z0H6piHNNHSQ3UQW6IqCdpCTjTxngT7AwQm5S0=",
+  "pnpmDepsHash": "sha256-TZfEoUSjba8cRz6L9uY2PGskYsR7S/xAahiKLd8dhFM="
+}

--- a/.flox/pkgs/mcporter/publish.json
+++ b/.flox/pkgs/mcporter/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/mcporter/upgrade.sh
+++ b/.flox/pkgs/mcporter/upgrade.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_tag=$(curl -sfL \
+  https://api.github.com/repos/steipete/mcporter/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating mcporter from $current_version to $latest_version"
+
+src_url="https://github.com/steipete/mcporter/archive/refs/tags/v${latest_version}.tar.gz"
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+dummy="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg p "$dummy" \
+  '{version: $v, srcHash: $s, pnpmDepsHash: $p}' > "$HASHES_FILE"
+
+echo "Building with dummy pnpmDepsHash to compute real one..."
+pnpm_hash=$(flox build mcporter 2>&1 \
+  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep "got:" | head -1 | awk '{print $NF}') || true
+
+if [ -z "$pnpm_hash" ]; then
+  echo "ERROR: could not extract pnpmDepsHash from build output" >&2
+  exit 1
+fi
+
+echo "  pnpmDepsHash: $pnpm_hash"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg s "$src_sri" \
+  --arg p "$pnpm_hash" \
+  '{version: $v, srcHash: $s, pnpmDepsHash: $p}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"


### PR DESCRIPTION
## Summary

Wave 5: three utility tools that complement the agent
ecosystem.

- `coderabbit-cli` 0.5.0 — CodeRabbit's AI code review
  CLI (Bun-compiled). Exposes both `coderabbit` and the
  `cr` shorthand. autoPatchelfHook on Linux; libsecret
  for keychain on Linux.
- `mcporter` 0.11.1 — TypeScript runtime + CLI for the
  Model Context Protocol. pnpm source build via
  fetchPnpmDeps + pnpmConfigHook; a small postPatch
  strips a stale caret in pnpm-lock.yaml so pnpm 10's
  stricter overrides validation accepts it.
- `agent-browser` 0.27.0 — Vercel Labs' headless
  browser automation CLI for AI agents. Two-stage
  build: a Next.js dashboard (pnpm) is baked into a
  fixed output, then the Rust CLI consumes it via
  embedded assets and a patched skill-discovery path.
  Geist variable woff2 is vendored from a pinned
  upstream commit so next/font resolves offline.
  Linux wraps the binary with
  `AGENT_BROWSER_EXECUTABLE_PATH` → chromium. Uses thin
  LTO instead of upstream's fat LTO to keep
  aarch64-linux rustc memory in bounds, and disables
  cargo-auditable on aarch64-darwin where the crate
  tree trips it.

All three build clean locally on `aarch64-darwin`.

## Skipped from the original wave 5 plan

- `handy` — Tauri-based local-transcription GUI app,
  not a CLI. Upstream itself disables installCheck
  because it tries to launch the GUI. Doesn't fit the
  floxenvs CLI/service pattern.

## Test plan

- [ ] CI builds pass for all four matrix systems
- [ ] `flox publish` succeeds on `main` for each
      package
- [ ] Confirm `agent-browser` finds chromium on Linux
      via the `AGENT_BROWSER_EXECUTABLE_PATH` wrapper
- [ ] Spot-check the other binaries on Linux once CI
      artifacts land