### PR TITLE
feat: complete catalog coverage + cross-env package showcase

### DIFF
--- a/.flox/pkgs/agent-browser/meta.yaml
+++ b/.flox/pkgs/agent-browser/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: agent-browser
+title: Agent Browser
+publisher: flox
+tagline: >
+  Headless browser automation CLI for AI agents — Vercel's
+  Chromium-driven dashboard for tool-using LLMs.
+category: ai
+ai_role: tooling
+tags: [agent, browser, automation, chromium, vercel]
+stack: [nodejs, rust, typescript]
+featured: false
+combines_well_with:
+  - env:claude
+  - env:playwright
+status: beta
+license: Apache-2.0
+upstream:
+  name: agent-browser
+  url: https://github.com/vercel-labs/agent-browser
+  license: Apache-2.0
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    agent-browser.pkg-path = "flox/agent-browser"
+    agent-browser.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/agent-browser
+  floxhub: https://hub.flox.dev/flox/agent-browser

--- a/.flox/pkgs/amp/meta.yaml
+++ b/.flox/pkgs/amp/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: amp
+title: Amp
+publisher: flox
+tagline: >
+  Sourcegraph's agentic coding CLI — drop-in alternative to
+  Claude Code with multi-model support.
+category: ai
+ai_role: agent
+tags: [agent, cli, sourcegraph, coding-agent]
+stack: [typescript]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:claude-code
+status: stable
+license: Unfree
+upstream:
+  name: Amp
+  url: https://ampcode.com/
+  license: Unfree
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    amp.pkg-path = "flox/amp"
+    amp.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/amp
+  floxhub: https://hub.flox.dev/flox/amp

--- a/.flox/pkgs/basic-memory/meta.yaml
+++ b/.flox/pkgs/basic-memory/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: basic-memory
+title: Basic Memory
+publisher: flox
+tagline: >
+  Local-first Markdown knowledge graph with an MCP server
+  for any AI assistant.
+category: ai
+ai_role: rag
+tags: [memory, knowledge-graph, mcp, markdown, rag]
+stack: [python]
+featured: false
+combines_well_with:
+  - env:basic-memory
+  - env:claude
+status: stable
+license: AGPL-3.0
+upstream:
+  name: Basic Memory
+  url: https://github.com/basicmachines-co/basic-memory
+  license: AGPL-3.0
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    basic-memory.pkg-path = "flox/basic-memory"
+    basic-memory.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/basic-memory
+  floxhub: https://hub.flox.dev/flox/basic-memory

--- a/.flox/pkgs/ccstatusline/meta.yaml
+++ b/.flox/pkgs/ccstatusline/meta.yaml
@@ -1,0 +1,30 @@
+kind: pkg
+subkind: plain
+name: ccstatusline
+title: ccstatusline
+publisher: flox
+tagline: >
+  Customizable status line formatter for Claude Code.
+category: ai
+ai_role: tooling
+tags: [claude-code, statusline, terminal, tui]
+stack: [nodejs, typescript]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:claude-code
+status: stable
+license: MIT
+upstream:
+  name: ccstatusline
+  url: https://github.com/sirmalloc/ccstatusline
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    ccstatusline.pkg-path = "flox/ccstatusline"
+    ccstatusline.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/ccstatusline
+  floxhub: https://hub.flox.dev/flox/ccstatusline

--- a/.flox/pkgs/ccusage/meta.yaml
+++ b/.flox/pkgs/ccusage/meta.yaml
@@ -1,0 +1,32 @@
+kind: pkg
+subkind: plain
+name: ccusage
+title: ccusage
+publisher: flox
+tagline: >
+  Local-first token-usage and cost analyzer for AI coding
+  agents.
+category: ai
+ai_role: tooling
+tags: [observability, cost, claude-code, token-usage]
+stack: [rust]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:claude-code
+  - pkg:codex
+status: stable
+license: MIT
+upstream:
+  name: ccusage
+  url: https://github.com/ryoppippi/ccusage
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    ccusage.pkg-path = "flox/ccusage"
+    ccusage.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/ccusage
+  floxhub: https://hub.flox.dev/flox/ccusage

--- a/.flox/pkgs/claude-code-plugin-agentmemory/meta.yaml
+++ b/.flox/pkgs/claude-code-plugin-agentmemory/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: plugin
+name: claude-code-plugin-agentmemory
+title: AgentMemory
+plugin_for: claude-code
+publisher: flox
+tagline: >
+  Persistent agent memory plugin for Claude Code — 13 hooks
+  and 8 skills, backed by a REST/MCP service.
+category: ai
+ai_role: tooling
+tags: [claude-code, plugin, memory, mcp, agent]
+status: beta
+license: Apache-2.0
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    claude-code-plugin-agentmemory.pkg-path = "flox/claude-code-plugin-agentmemory"
+    claude-code-plugin-agentmemory.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/claude-code-plugin-agentmemory
+  floxhub: https://hub.flox.dev/flox/claude-code-plugin-agentmemory

--- a/.flox/pkgs/claude-code-plugin-caveman/meta.yaml
+++ b/.flox/pkgs/claude-code-plugin-caveman/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: plugin
+name: claude-code-plugin-caveman
+title: Caveman
+plugin_for: claude-code
+publisher: flox
+tagline: >
+  Ultra-compressed agent communication plugin — cuts ~75%
+  of tokens with full technical accuracy.
+category: ai
+ai_role: tooling
+tags: [claude-code, plugin, compression, token-saving]
+status: beta
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    claude-code-plugin-caveman.pkg-path = "flox/claude-code-plugin-caveman"
+    claude-code-plugin-caveman.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/claude-code-plugin-caveman
+  floxhub: https://hub.flox.dev/flox/claude-code-plugin-caveman

--- a/.flox/pkgs/claude-code-plugin-claude-ads/meta.yaml
+++ b/.flox/pkgs/claude-code-plugin-claude-ads/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: plugin
+name: claude-code-plugin-claude-ads
+title: Claude Ads
+plugin_for: claude-code
+publisher: flox
+tagline: >
+  Paid advertising audit & optimization plugin for Claude
+  Code — Google Ads, Meta, LinkedIn workflows.
+category: ai
+ai_role: tooling
+tags: [claude-code, plugin, ads, marketing, workflow]
+status: beta
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    claude-code-plugin-claude-ads.pkg-path = "flox/claude-code-plugin-claude-ads"
+    claude-code-plugin-claude-ads.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/claude-code-plugin-claude-ads
+  floxhub: https://hub.flox.dev/flox/claude-code-plugin-claude-ads

--- a/.flox/pkgs/claude-code-plugin-claude-obsidian/meta.yaml
+++ b/.flox/pkgs/claude-code-plugin-claude-obsidian/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: plugin
+name: claude-code-plugin-claude-obsidian
+title: Claude Obsidian
+plugin_for: claude-code
+publisher: flox
+tagline: >
+  Claude + Obsidian knowledge companion plugin — turn the
+  agent into a second-brain operator.
+category: ai
+ai_role: tooling
+tags: [claude-code, plugin, obsidian, knowledge-management, notes]
+status: beta
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    claude-code-plugin-claude-obsidian.pkg-path = "flox/claude-code-plugin-claude-obsidian"
+    claude-code-plugin-claude-obsidian.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/claude-code-plugin-claude-obsidian
+  floxhub: https://hub.flox.dev/flox/claude-code-plugin-claude-obsidian

--- a/.flox/pkgs/claude-code-plugin-gstack/meta.yaml
+++ b/.flox/pkgs/claude-code-plugin-gstack/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: plugin
+name: claude-code-plugin-gstack
+title: gstack
+plugin_for: claude-code
+publisher: flox
+tagline: >
+  Garry Tan's 45-skill Claude Code stack — planning, design,
+  QA, review, security, shipping.
+category: ai
+ai_role: tooling
+tags: [claude-code, plugin, workflow, skills, shipping]
+status: beta
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    claude-code-plugin-gstack.pkg-path = "flox/claude-code-plugin-gstack"
+    claude-code-plugin-gstack.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/claude-code-plugin-gstack
+  floxhub: https://hub.flox.dev/flox/claude-code-plugin-gstack

--- a/.flox/pkgs/claude-code-plugin-remotion/meta.yaml
+++ b/.flox/pkgs/claude-code-plugin-remotion/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: plugin
+name: claude-code-plugin-remotion
+title: Remotion Best Practices
+plugin_for: claude-code
+publisher: flox
+tagline: >
+  Remotion best-practices skill for Claude Code — loads
+  automatically on Remotion projects.
+category: ai
+ai_role: tooling
+tags: [claude-code, plugin, remotion, video, react]
+status: beta
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    claude-code-plugin-remotion.pkg-path = "flox/claude-code-plugin-remotion"
+    claude-code-plugin-remotion.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/claude-code-plugin-remotion
+  floxhub: https://hub.flox.dev/flox/claude-code-plugin-remotion

--- a/.flox/pkgs/claude-code-router/meta.yaml
+++ b/.flox/pkgs/claude-code-router/meta.yaml
@@ -1,0 +1,32 @@
+kind: pkg
+subkind: plain
+name: claude-code-router
+title: Claude Code Router
+publisher: flox
+tagline: >
+  Routing proxy that lets Claude Code talk to any LLM
+  provider — local models, OpenAI, Gemini, DeepSeek.
+category: ai
+ai_role: tooling
+tags: [claude-code, router, proxy, multi-model]
+stack: [nodejs, typescript]
+featured: false
+combines_well_with:
+  - env:claude
+  - env:lmstudio
+  - pkg:ollama
+status: beta
+license: MIT
+upstream:
+  name: claude-code-router
+  url: https://github.com/musistudio/claude-code-router
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    claude-code-router.pkg-path = "flox/claude-code-router"
+    claude-code-router.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/claude-code-router
+  floxhub: https://hub.flox.dev/flox/claude-code-router

--- a/.flox/pkgs/claudebox/meta.yaml
+++ b/.flox/pkgs/claudebox/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: claudebox
+title: ClaudeBox
+publisher: flox
+tagline: >
+  Sandboxed environment for running Claude Code — bundles
+  shell, git, ripgrep, fd, jq, curl, and more.
+category: ai
+ai_role: tooling
+tags: [claude-code, sandbox, isolation, security]
+stack: [bun, bash]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:claude-code
+status: beta
+license: MIT
+upstream:
+  name: claudebox
+  url: https://github.com/numtide/claudebox
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    claudebox.pkg-path = "flox/claudebox"
+    claudebox.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/claudebox
+  floxhub: https://hub.flox.dev/flox/claudebox

--- a/.flox/pkgs/codeburn/meta.yaml
+++ b/.flox/pkgs/codeburn/meta.yaml
@@ -1,0 +1,32 @@
+kind: pkg
+subkind: plain
+name: codeburn
+title: CodeBurn
+publisher: flox
+tagline: >
+  Local-first TUI dashboard for AI coding token spend —
+  Claude, Codex, Cursor, 17+ others.
+category: ai
+ai_role: tooling
+tags: [observability, cost, tui, agent, pricing]
+stack: [nodejs]
+featured: false
+combines_well_with:
+  - env:codeburn
+  - env:claude
+  - pkg:codex
+status: beta
+license: MIT
+upstream:
+  name: CodeBurn
+  url: https://github.com/getagentseal/codeburn
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    codeburn.pkg-path = "flox/codeburn"
+    codeburn.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/codeburn
+  floxhub: https://hub.flox.dev/flox/codeburn

--- a/.flox/pkgs/coderabbit-cli/meta.yaml
+++ b/.flox/pkgs/coderabbit-cli/meta.yaml
@@ -1,0 +1,30 @@
+kind: pkg
+subkind: plain
+name: coderabbit-cli
+title: CodeRabbit CLI
+publisher: flox
+tagline: >
+  AI-powered code review CLI from CodeRabbit.
+category: ai
+ai_role: tooling
+tags: [code-review, agent, cli, ci]
+stack: [typescript]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:claude-code
+status: stable
+license: Unfree
+upstream:
+  name: CodeRabbit CLI
+  url: https://coderabbit.ai
+  license: Unfree
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    coderabbit-cli.pkg-path = "flox/coderabbit-cli"
+    coderabbit-cli.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/coderabbit-cli
+  floxhub: https://hub.flox.dev/flox/coderabbit-cli

--- a/.flox/pkgs/copilot-cli/meta.yaml
+++ b/.flox/pkgs/copilot-cli/meta.yaml
@@ -1,0 +1,30 @@
+kind: pkg
+subkind: plain
+name: copilot-cli
+title: GitHub Copilot CLI
+publisher: flox
+tagline: >
+  GitHub Copilot's agentic coding CLI for the terminal.
+category: ai
+ai_role: agent
+tags: [agent, cli, github, copilot, coding-agent]
+stack: [nodejs, typescript]
+featured: true
+combines_well_with:
+  - env:claude
+  - pkg:codex
+status: stable
+license: Unfree
+upstream:
+  name: GitHub Copilot CLI
+  url: https://github.com/github/copilot-cli
+  license: Unfree
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    copilot-cli.pkg-path = "flox/copilot-cli"
+    copilot-cli.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/copilot-cli
+  floxhub: https://hub.flox.dev/flox/copilot-cli

--- a/.flox/pkgs/cursor-agent/meta.yaml
+++ b/.flox/pkgs/cursor-agent/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: cursor-agent
+title: Cursor Agent
+publisher: flox
+tagline: >
+  Cursor's headless coding agent CLI — the same model behind
+  the editor, in your terminal.
+category: ai
+ai_role: agent
+tags: [agent, cli, cursor, coding-agent]
+stack: [typescript]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:claude-code
+status: stable
+license: Unfree
+upstream:
+  name: Cursor Agent
+  url: https://cursor.com/
+  license: Unfree
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    cursor-agent.pkg-path = "flox/cursor-agent"
+    cursor-agent.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/cursor-agent
+  floxhub: https://hub.flox.dev/flox/cursor-agent

--- a/.flox/pkgs/deepseek-tui/meta.yaml
+++ b/.flox/pkgs/deepseek-tui/meta.yaml
@@ -1,0 +1,30 @@
+kind: pkg
+subkind: plain
+name: deepseek-tui
+title: DeepSeek TUI
+publisher: flox
+tagline: >
+  Coding agent for DeepSeek models that runs in your
+  terminal.
+category: ai
+ai_role: agent
+tags: [agent, cli, deepseek, coding-agent, tui]
+stack: [rust]
+featured: false
+combines_well_with:
+  - env:claude
+status: beta
+license: MIT
+upstream:
+  name: DeepSeek TUI
+  url: https://github.com/Hmbown/DeepSeek-TUI
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    deepseek-tui.pkg-path = "flox/deepseek-tui"
+    deepseek-tui.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/deepseek-tui
+  floxhub: https://hub.flox.dev/flox/deepseek-tui

--- a/.flox/pkgs/fnox/meta.yaml
+++ b/.flox/pkgs/fnox/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: fnox
+title: fnox
+publisher: flox
+tagline: >
+  "Fort Knox" — pluggable secret manager: age, KMS,
+  1Password, Vault, password-store, OS keychain.
+category: tool
+tags: [secrets, security, age, kms, vault]
+stack: [rust]
+featured: false
+combines_well_with:
+  - env:fnox
+  - env:1password
+  - env:dotenv
+status: stable
+license: MIT
+upstream:
+  name: fnox
+  url: https://fnox.jdx.dev/
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    fnox.pkg-path = "flox/fnox"
+    fnox.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/fnox
+  floxhub: https://hub.flox.dev/flox/fnox

--- a/.flox/pkgs/forgecode/meta.yaml
+++ b/.flox/pkgs/forgecode/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: forgecode
+title: ForgeCode
+publisher: flox
+tagline: >
+  AI pair programmer for 300+ LLM providers — runs entirely
+  in your terminal.
+category: ai
+ai_role: agent
+tags: [agent, cli, coding-agent, multi-model]
+stack: []
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:claude-code
+status: beta
+license: MIT
+upstream:
+  name: ForgeCode
+  url: https://forgecode.dev
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    forgecode.pkg-path = "flox/forgecode"
+    forgecode.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/forgecode
+  floxhub: https://hub.flox.dev/flox/forgecode

--- a/.flox/pkgs/gemini-cli/meta.yaml
+++ b/.flox/pkgs/gemini-cli/meta.yaml
@@ -1,0 +1,32 @@
+kind: pkg
+subkind: plain
+name: gemini-cli
+title: Gemini CLI
+publisher: flox
+tagline: >
+  Google's Gemini coding agent — same model as Gemini in the
+  browser, in your terminal.
+category: ai
+ai_role: agent
+tags: [agent, cli, google, gemini, coding-agent]
+stack: [nodejs, typescript]
+featured: true
+combines_well_with:
+  - env:claude
+  - pkg:codex
+  - env:worktrunk
+status: stable
+license: Apache-2.0
+upstream:
+  name: Gemini CLI
+  url: https://github.com/google-gemini/gemini-cli
+  license: Apache-2.0
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    gemini-cli.pkg-path = "flox/gemini-cli"
+    gemini-cli.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/gemini-cli
+  floxhub: https://hub.flox.dev/flox/gemini-cli

--- a/.flox/pkgs/goose-cli/meta.yaml
+++ b/.flox/pkgs/goose-cli/meta.yaml
@@ -1,0 +1,30 @@
+kind: pkg
+subkind: plain
+name: goose-cli
+title: Goose
+publisher: flox
+tagline: >
+  Block's open-source local-first AI engineering agent.
+category: ai
+ai_role: agent
+tags: [agent, cli, coding-agent, block, open-source]
+stack: [rust]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:ollama
+status: stable
+license: Apache-2.0
+upstream:
+  name: Goose
+  url: https://github.com/block/goose
+  license: Apache-2.0
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    goose-cli.pkg-path = "flox/goose-cli"
+    goose-cli.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/goose-cli
+  floxhub: https://hub.flox.dev/flox/goose-cli

--- a/.flox/pkgs/grok/meta.yaml
+++ b/.flox/pkgs/grok/meta.yaml
@@ -1,0 +1,30 @@
+kind: pkg
+subkind: plain
+name: grok
+title: Grok
+publisher: flox
+tagline: >
+  xAI's agentic coding tool — Grok Build in your terminal.
+category: ai
+ai_role: agent
+tags: [agent, cli, xai, grok, coding-agent]
+stack: []
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:claude-code
+status: beta
+license: Unfree
+upstream:
+  name: Grok
+  url: https://x.ai
+  license: Unfree
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    grok.pkg-path = "flox/grok"
+    grok.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/grok
+  floxhub: https://hub.flox.dev/flox/grok

--- a/.flox/pkgs/herdr/meta.yaml
+++ b/.flox/pkgs/herdr/meta.yaml
@@ -1,0 +1,32 @@
+kind: pkg
+subkind: plain
+name: herdr
+title: Herdr
+publisher: flox
+tagline: >
+  Agent multiplexer for the terminal — drive many coding
+  agents from one TUI.
+category: ai
+ai_role: orchestrator
+tags: [agent, multiplexer, tui, orchestrator]
+stack: []
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:codex
+  - pkg:opencode
+status: beta
+license: AGPL-3.0
+upstream:
+  name: herdr
+  url: https://github.com/ogulcancelik/herdr
+  license: AGPL-3.0
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    herdr.pkg-path = "flox/herdr"
+    herdr.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/herdr
+  floxhub: https://hub.flox.dev/flox/herdr

--- a/.flox/pkgs/iloom-cli/meta.yaml
+++ b/.flox/pkgs/iloom-cli/meta.yaml
@@ -1,0 +1,32 @@
+kind: pkg
+subkind: plain
+name: iloom-cli
+title: iloom CLI
+publisher: flox
+tagline: >
+  Control plane for AI-assisted development — Claude Code
+  in isolated worktrees, reasoning persisted to your tracker.
+category: ai
+ai_role: orchestrator
+tags: [agent, workflow, claude-code, worktree, orchestrator]
+stack: [nodejs, typescript]
+featured: false
+combines_well_with:
+  - env:iloom
+  - env:claude
+  - env:worktrunk
+status: beta
+license: BSL-1.1
+upstream:
+  name: iloom-cli
+  url: https://github.com/iloom-ai/iloom-cli
+  license: BSL-1.1
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    iloom-cli.pkg-path = "flox/iloom-cli"
+    iloom-cli.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/iloom-cli
+  floxhub: https://hub.flox.dev/flox/iloom-cli

--- a/.flox/pkgs/lmstudio/meta.yaml
+++ b/.flox/pkgs/lmstudio/meta.yaml
@@ -1,0 +1,32 @@
+kind: pkg
+subkind: plain
+name: lmstudio
+title: LM Studio
+publisher: flox
+tagline: >
+  Desktop + CLI for local LLMs with an OpenAI-compatible
+  API.
+category: ai
+ai_role: llm-runtime
+tags: [llm, local-inference, openai-api, macos, linux]
+stack: [c++]
+featured: false
+combines_well_with:
+  - env:lmstudio
+  - pkg:omlx
+  - pkg:ollama
+status: stable
+license: Unfree
+upstream:
+  name: LM Studio
+  url: https://lmstudio.ai/
+  license: Unfree
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    lmstudio.pkg-path = "flox/lmstudio"
+    lmstudio.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/lmstudio
+  floxhub: https://hub.flox.dev/flox/lmstudio

--- a/.flox/pkgs/mcporter/meta.yaml
+++ b/.flox/pkgs/mcporter/meta.yaml
@@ -1,0 +1,30 @@
+kind: pkg
+subkind: plain
+name: mcporter
+title: mcporter
+publisher: flox
+tagline: >
+  TypeScript runtime and CLI for the Model Context Protocol.
+category: ai
+ai_role: tooling
+tags: [mcp, runtime, cli, model-context-protocol]
+stack: [nodejs, typescript]
+featured: false
+combines_well_with:
+  - env:claude
+  - env:serena
+status: beta
+license: MIT
+upstream:
+  name: mcporter
+  url: https://github.com/steipete/mcporter
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    mcporter.pkg-path = "flox/mcporter"
+    mcporter.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/mcporter
+  floxhub: https://hub.flox.dev/flox/mcporter

--- a/.flox/pkgs/mistral-vibe/meta.yaml
+++ b/.flox/pkgs/mistral-vibe/meta.yaml
@@ -1,0 +1,30 @@
+kind: pkg
+subkind: plain
+name: mistral-vibe
+title: Mistral Vibe
+publisher: flox
+tagline: >
+  Mistral AI's minimal CLI coding agent powered by Devstral.
+category: ai
+ai_role: agent
+tags: [agent, cli, mistral, devstral, coding-agent]
+stack: [python, rust]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:codex
+status: beta
+license: MIT
+upstream:
+  name: mistral-vibe
+  url: https://github.com/mistralai/mistral-vibe
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    mistral-vibe.pkg-path = "flox/mistral-vibe"
+    mistral-vibe.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/mistral-vibe
+  floxhub: https://hub.flox.dev/flox/mistral-vibe

--- a/.flox/pkgs/ollama-cuda/meta.yaml
+++ b/.flox/pkgs/ollama-cuda/meta.yaml
@@ -1,0 +1,33 @@
+kind: pkg
+subkind: plain
+name: ollama-cuda
+title: Ollama (CUDA)
+publisher: flox
+tagline: >
+  Ollama with NVIDIA CUDA acceleration enabled — Linux only.
+category: ai
+ai_role: llm-runtime
+tags: [llm, ollama, cuda, nvidia, local-inference]
+stack: [go, cuda]
+featured: false
+combines_well_with:
+  - pkg:ollama
+  - env:verba
+  - env:langchain
+status: stable
+license: MIT
+upstream:
+  name: Ollama
+  url: https://ollama.com
+  license: MIT
+maintainer: "@rok"
+systems: [x86_64-linux]
+install:
+  pkg: |
+    [install]
+    ollama-cuda.pkg-path = "flox/ollama-cuda"
+    ollama-cuda.publisher = "flox"
+    ollama-cuda.systems = ["x86_64-linux"]
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/ollama-cuda
+  floxhub: https://hub.flox.dev/flox/ollama-cuda

--- a/.flox/pkgs/openspec/meta.yaml
+++ b/.flox/pkgs/openspec/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: openspec
+title: OpenSpec
+publisher: flox
+tagline: >
+  Spec-driven development workflow for AI coding assistants.
+category: ai
+ai_role: tooling
+tags: [agent, workflow, spec-driven, planning]
+stack: [nodejs, typescript]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:claude-code
+  - pkg:spec-kit
+status: beta
+license: MIT
+upstream:
+  name: OpenSpec
+  url: https://github.com/Fission-AI/OpenSpec
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    openspec.pkg-path = "flox/openspec"
+    openspec.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/openspec
+  floxhub: https://hub.flox.dev/flox/openspec

--- a/.flox/pkgs/qwen-code/meta.yaml
+++ b/.flox/pkgs/qwen-code/meta.yaml
@@ -1,0 +1,30 @@
+kind: pkg
+subkind: plain
+name: qwen-code
+title: Qwen Code
+publisher: flox
+tagline: >
+  CLI agent for Qwen3-Coder models.
+category: ai
+ai_role: agent
+tags: [agent, cli, qwen, alibaba, coding-agent]
+stack: [nodejs, typescript]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:claude-code
+status: beta
+license: Apache-2.0
+upstream:
+  name: Qwen Code
+  url: https://github.com/QwenLM/qwen-code
+  license: Apache-2.0
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    qwen-code.pkg-path = "flox/qwen-code"
+    qwen-code.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/qwen-code
+  floxhub: https://hub.flox.dev/flox/qwen-code

--- a/.flox/pkgs/sandbox-runtime/meta.yaml
+++ b/.flox/pkgs/sandbox-runtime/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: sandbox-runtime
+title: Sandbox Runtime
+publisher: flox
+tagline: >
+  Anthropic's lightweight filesystem + network sandbox for
+  AI agents — exposed as `srt`.
+category: ai
+ai_role: tooling
+tags: [sandbox, security, agent, anthropic, bubblewrap]
+stack: [nodejs, typescript]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:claude-code
+status: beta
+license: Apache-2.0
+upstream:
+  name: sandbox-runtime
+  url: https://github.com/anthropic-experimental/sandbox-runtime
+  license: Apache-2.0
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    sandbox-runtime.pkg-path = "flox/sandbox-runtime"
+    sandbox-runtime.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/sandbox-runtime
+  floxhub: https://hub.flox.dev/flox/sandbox-runtime

--- a/.flox/pkgs/serena/meta.yaml
+++ b/.flox/pkgs/serena/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: serena
+title: Serena
+publisher: flox
+tagline: >
+  MCP toolkit for coding agents — IDE-grade semantic tools
+  (find-symbol, find-references, rename, symbolic edit).
+category: ai
+ai_role: tooling
+tags: [mcp, lsp, ide, refactor, agent]
+stack: [python, nodejs]
+featured: false
+combines_well_with:
+  - env:serena
+  - env:claude
+status: beta
+license: MIT
+upstream:
+  name: Serena
+  url: https://github.com/oraios/serena
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    serena.pkg-path = "flox/serena"
+    serena.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/serena
+  floxhub: https://hub.flox.dev/flox/serena

--- a/.flox/pkgs/skills-shipshit/meta.yaml
+++ b/.flox/pkgs/skills-shipshit/meta.yaml
@@ -1,0 +1,24 @@
+kind: pkg
+subkind: skill
+name: skills-shipshit
+title: Ship Shit Dev
+skill_for: claude-code
+publisher: flox
+tagline: >
+  Ship Shit Dev skills bundle for Claude Code and OpenCode.
+category: ai
+ai_role: tooling
+tags: [claude-code, skill, shipping, workflow]
+status: beta
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    skills-shipshit.pkg-path = "flox/skills-shipshit"
+    skills-shipshit.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/skills-shipshit
+  floxhub: https://hub.flox.dev/flox/skills-shipshit

--- a/.flox/pkgs/skillspector/meta.yaml
+++ b/.flox/pkgs/skillspector/meta.yaml
@@ -1,0 +1,32 @@
+kind: pkg
+subkind: plain
+name: skillspector
+title: SkillSpector
+publisher: flox
+tagline: >
+  Security scanner for AI agent skills — NVIDIA's static
+  analysis for prompt-injected skill bundles.
+category: ai
+ai_role: tooling
+tags: [security, skills, scanner, nvidia, static-analysis]
+stack: [python]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:skills-frontend-design
+  - pkg:skills-skill-creator
+status: beta
+license: Apache-2.0
+upstream:
+  name: SkillSpector
+  url: https://github.com/NVIDIA/SkillSpector
+  license: Apache-2.0
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    skillspector.pkg-path = "flox/skillspector"
+    skillspector.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/skillspector
+  floxhub: https://hub.flox.dev/flox/skillspector

--- a/.flox/pkgs/spec-kit/meta.yaml
+++ b/.flox/pkgs/spec-kit/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: spec-kit
+title: Spec Kit
+publisher: flox
+tagline: >
+  GitHub Spec Kit's `specify` CLI — bootstrap spec-driven
+  dev projects for AI agents.
+category: ai
+ai_role: tooling
+tags: [agent, workflow, spec-driven, github, scaffold]
+stack: [python]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:openspec
+status: beta
+license: MIT
+upstream:
+  name: Spec Kit
+  url: https://github.com/github/spec-kit
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    spec-kit.pkg-path = "flox/spec-kit"
+    spec-kit.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/spec-kit
+  floxhub: https://hub.flox.dev/flox/spec-kit

--- a/.flox/pkgs/temporal-cli/meta.yaml
+++ b/.flox/pkgs/temporal-cli/meta.yaml
@@ -1,0 +1,29 @@
+kind: pkg
+subkind: plain
+name: temporal-cli
+title: Temporal CLI
+publisher: flox
+tagline: >
+  Temporal CLI — dev server, workflow management, namespaces.
+category: service
+tags: [temporal, workflow, orchestration, cli]
+stack: [go]
+featured: false
+combines_well_with:
+  - env:temporal
+  - pkg:temporal
+status: stable
+license: MIT
+upstream:
+  name: Temporal CLI
+  url: https://docs.temporal.io/cli
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    temporal-cli.pkg-path = "flox/temporal-cli"
+    temporal-cli.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/temporal-cli
+  floxhub: https://hub.flox.dev/flox/temporal-cli

--- a/.flox/pkgs/temporal/meta.yaml
+++ b/.flox/pkgs/temporal/meta.yaml
@@ -1,0 +1,29 @@
+kind: pkg
+subkind: plain
+name: temporal
+title: Temporal Server
+publisher: flox
+tagline: >
+  Temporal orchestration platform — server and tools.
+category: service
+tags: [temporal, workflow, orchestration, server, durable-execution]
+stack: [go]
+featured: false
+combines_well_with:
+  - env:temporal
+  - pkg:temporal-cli
+status: stable
+license: MIT
+upstream:
+  name: Temporal
+  url: https://temporal.io
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    temporal.pkg-path = "flox/temporal"
+    temporal.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/temporal
+  floxhub: https://hub.flox.dev/flox/temporal

--- a/.flox/pkgs/workmux/meta.yaml
+++ b/.flox/pkgs/workmux/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: workmux
+title: workmux
+publisher: flox
+tagline: >
+  Git worktrees + tmux windows for zero-friction parallel
+  development.
+category: tool
+tags: [git, worktree, tmux, workflow, parallel]
+stack: [rust]
+featured: false
+combines_well_with:
+  - env:worktrunk
+  - env:claude
+  - pkg:worktrunk
+status: stable
+license: MIT
+upstream:
+  name: workmux
+  url: https://github.com/raine/workmux
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    workmux.pkg-path = "flox/workmux"
+    workmux.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/workmux
+  floxhub: https://hub.flox.dev/flox/workmux

--- a/.flox/pkgs/worktrunk/meta.yaml
+++ b/.flox/pkgs/worktrunk/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: worktrunk
+title: Worktrunk
+publisher: flox
+tagline: >
+  CLI for git worktree management — built for parallel AI
+  agent workflows.
+category: tool
+tags: [git, worktree, agent, workflow, parallel]
+stack: [go]
+featured: false
+combines_well_with:
+  - env:worktrunk
+  - env:claude
+  - pkg:workmux
+status: stable
+license: MIT
+upstream:
+  name: Worktrunk
+  url: https://worktrunk.dev
+  license: MIT
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    worktrunk.pkg-path = "flox/worktrunk"
+    worktrunk.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/worktrunk
+  floxhub: https://hub.flox.dev/flox/worktrunk

--- a/.website/src/components/PackagesInstalled.astro
+++ b/.website/src/components/PackagesInstalled.astro
@@ -1,0 +1,80 @@
+---
+interface InstalledPkg {
+  name: string;
+  path: string;
+}
+interface Props {
+  pkgs: InstalledPkg[];
+  catalog: Set<string>;
+  base: string;
+}
+const { pkgs, catalog, base } = Astro.props as Props;
+
+function nixSearchUrl(path: string): string {
+  return `https://search.nixos.org/packages?query=${encodeURIComponent(path)}`;
+}
+
+function floxhubUrl(path: string): string {
+  return `https://hub.flox.dev/${path}`;
+}
+
+function isFloxPkg(path: string): boolean {
+  return path.startsWith("flox/");
+}
+
+function floxPkgName(path: string): string {
+  return path.slice("flox/".length);
+}
+---
+{pkgs.length === 0 ? null : (
+  <div class="rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+    <table class="w-full text-sm">
+      <thead class="bg-slate-50 dark:bg-slate-900 text-left">
+        <tr>
+          <th class="px-3 py-2 font-medium text-slate-500 text-xs uppercase tracking-wide">Name</th>
+          <th class="px-3 py-2 font-medium text-slate-500 text-xs uppercase tracking-wide">Path</th>
+          <th class="px-3 py-2 font-medium text-slate-500 text-xs uppercase tracking-wide">Source</th>
+        </tr>
+      </thead>
+      <tbody>
+        {pkgs.map((p) => {
+          const flox = isFloxPkg(p.path);
+          const catalogName = flox ? floxPkgName(p.path) : null;
+          const inCatalog = catalogName !== null && catalog.has(catalogName);
+          return (
+            <tr class="border-t border-slate-100 dark:border-slate-900">
+              <td class="px-3 py-2 font-mono text-xs">{p.name}</td>
+              <td class="px-3 py-2 font-mono text-xs">
+                {inCatalog && catalogName ? (
+                  <a class="underline decoration-slate-300 dark:decoration-slate-700 hover:decoration-slate-700 dark:hover:decoration-slate-300" href={`${base}packages/${catalogName}/`}>{p.path}</a>
+                ) : flox ? (
+                  <a class="underline decoration-slate-300 dark:decoration-slate-700 hover:decoration-slate-700 dark:hover:decoration-slate-300" href={floxhubUrl(p.path)}>{p.path}</a>
+                ) : (
+                  <a class="underline decoration-slate-300 dark:decoration-slate-700 hover:decoration-slate-700 dark:hover:decoration-slate-300" href={nixSearchUrl(p.path)}>{p.path}</a>
+                )}
+              </td>
+              <td class="px-3 py-2 text-xs">
+                {inCatalog ? (
+                  <span class="inline-flex items-center gap-1.5 text-kind-env">
+                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-kind-env"></span>
+                    catalog
+                  </span>
+                ) : flox ? (
+                  <span class="inline-flex items-center gap-1.5 text-slate-500">
+                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-slate-400"></span>
+                    floxhub
+                  </span>
+                ) : (
+                  <span class="inline-flex items-center gap-1.5 text-slate-500">
+                    <span class="inline-block w-1.5 h-1.5 rounded-full bg-slate-400"></span>
+                    nixpkgs
+                  </span>
+                )}
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  </div>
+)}

--- a/.website/src/pages/envs/[name].astro
+++ b/.website/src/pages/envs/[name].astro
@@ -7,6 +7,7 @@ import InstallTabs from "../../components/InstallTabs.astro";
 import RecipeSection from "../../components/RecipeSection.astro";
 import Markdown from "../../components/Markdown.astro";
 import SidebarEntry from "../../components/SidebarEntry.astro";
+import PackagesInstalled from "../../components/PackagesInstalled.astro";
 import { deriveBundling } from "../../lib/derive";
 
 export async function getStaticPaths() {
@@ -17,6 +18,7 @@ export async function getStaticPaths() {
 const { env } = Astro.props as { env: { data: any } };
 const base = import.meta.env.BASE_URL;
 const pkgs = await getCollection("packages");
+const catalogPkgNames = new Set(pkgs.map((p) => p.data.name));
 
 const { envs: dEnvs, pkgs: dPkgs } = deriveBundling(
   [{
@@ -181,6 +183,25 @@ const jsonLd = [
         readme={env.data.recipe_readme}
         manifestToml={env.data.recipe_manifest}
       />
+
+      {env.data.manifest_install.length > 0 && (
+        <section class="mt-12">
+          <h2 class="text-xl font-semibold">Packages installed</h2>
+          <p class="text-sm text-slate-500 mt-1">
+            Everything <strong>flox/{env.data.name}</strong> brings into a
+            consumer manifest via <code class="text-xs font-mono">[install]</code>.
+            Catalog packages link to their detail page; everything else
+            links to FloxHub or nixpkgs.
+          </p>
+          <div class="mt-4">
+            <PackagesInstalled
+              pkgs={env.data.manifest_install}
+              catalog={catalogPkgNames}
+              base={base}
+            />
+          </div>
+        </section>
+      )}
 
       {recommendedPkgs.length > 0 && (
         <section class="mt-12">

--- a/.website/src/pages/envs/index.astro
+++ b/.website/src/pages/envs/index.astro
@@ -61,6 +61,9 @@ const jsonLd = [collectionPage, { ...itemList, "@id": `${pageUrl}#items` }, brea
   <p class="mt-1 text-sm text-slate-500">
     {envs.length} environments
   </p>
+  <div class="mt-4 flex gap-2 text-sm">
+    <a href={`${base}envs/packages/`} class="underline">Packages across envs →</a>
+  </div>
   <div class="mt-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
     {envs.map((e) => (
       <ItemCard

--- a/.website/src/pages/envs/packages.astro
+++ b/.website/src/pages/envs/packages.astro
@@ -1,0 +1,212 @@
+---
+import { getCollection } from "astro:content";
+import Layout from "../../layouts/Layout.astro";
+import KindBadge from "../../components/KindBadge.astro";
+
+const base = import.meta.env.BASE_URL;
+const envs = (await getCollection("envs")).sort((a, b) =>
+  a.data.name.localeCompare(b.data.name),
+);
+const pkgs = await getCollection("packages");
+const catalog = new Set(pkgs.map((p) => p.data.name));
+
+interface Row {
+  env: string;
+  title: string;
+  tagline: string;
+  category: string;
+  count: number;
+  catalogCount: number;
+  packages: { name: string; path: string }[];
+}
+
+const rows: Row[] = envs.map((e) => {
+  const list = (e.data.manifest_install ?? []) as { name: string; path: string }[];
+  const catalogCount = list.filter(
+    (p) => p.path.startsWith("flox/") &&
+           catalog.has(p.path.slice("flox/".length)),
+  ).length;
+  return {
+    env: e.data.name,
+    title: e.data.title,
+    tagline: e.data.tagline,
+    category: e.data.category,
+    count: list.length,
+    catalogCount,
+    packages: list,
+  };
+}).filter((r) => r.count > 0);
+
+// Build the reverse index — which envs install each package.
+type PathInfo = { envs: string[]; flox: boolean; catalog: boolean };
+const reverse = new Map<string, PathInfo>();
+for (const r of rows) {
+  for (const p of r.packages) {
+    const key = p.path;
+    if (!reverse.has(key)) {
+      const flox = key.startsWith("flox/");
+      const catalogHit = flox && catalog.has(key.slice("flox/".length));
+      reverse.set(key, { envs: [], flox, catalog: catalogHit });
+    }
+    reverse.get(key)!.envs.push(r.env);
+  }
+}
+const reverseRows = Array.from(reverse.entries())
+  .map(([path, info]) => ({ path, ...info }))
+  .sort((a, b) => b.envs.length - a.envs.length || a.path.localeCompare(b.path));
+
+const totalInstalls = rows.reduce((acc, r) => acc + r.count, 0);
+const uniquePaths = reverse.size;
+
+const origin = (Astro.site?.toString() ?? "").replace(/\/$/, "");
+const pageUrl = `${origin}${base}envs/packages/`;
+const breadcrumb = {
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  itemListElement: [
+    { "@type": "ListItem", position: 1, name: "flox / envs", item: `${origin}${base}` },
+    { "@type": "ListItem", position: 2, name: "Environments", item: `${origin}${base}envs/` },
+    { "@type": "ListItem", position: 3, name: "Packages across envs", item: pageUrl },
+  ],
+};
+
+function nixSearchUrl(path: string): string {
+  return `https://search.nixos.org/packages?query=${encodeURIComponent(path)}`;
+}
+function floxhubUrl(path: string): string {
+  return `https://hub.flox.dev/${path}`;
+}
+---
+<Layout
+  title="Packages installed across every Flox env — full cross-env package matrix"
+  description="See every package every Flox environment installs, with reverse-lookup for which envs pull in each package. Catalog packages link to their detail page; everything else to FloxHub or nixpkgs."
+  jsonLd={breadcrumb}
+>
+  <nav class="text-sm text-slate-500 mb-4">
+    <a href={`${base}envs/`} class="underline">Environments</a> / packages
+  </nav>
+  <h1 class="text-3xl font-bold">Packages across environments</h1>
+  <p class="mt-2 text-slate-600 dark:text-slate-300 max-w-3xl">
+    Every package every Flox environment in this catalog installs into a
+    consumer manifest. Each entry shows where the package resolves from —
+    the <strong>flox/envs</strong> catalog itself (green), the FloxHub
+    publisher namespace (grey), or upstream nixpkgs (grey).
+  </p>
+  <div class="mt-4 flex flex-wrap gap-x-6 gap-y-1 text-sm text-slate-500">
+    <span><strong class="text-slate-700 dark:text-slate-200">{rows.length}</strong> environments</span>
+    <span><strong class="text-slate-700 dark:text-slate-200">{totalInstalls}</strong> package installs</span>
+    <span><strong class="text-slate-700 dark:text-slate-200">{uniquePaths}</strong> unique pkg-paths</span>
+  </div>
+
+  <section class="mt-12">
+    <h2 class="text-2xl font-semibold">By environment</h2>
+    <p class="text-sm text-slate-500 mt-1">
+      What each env brings in via its <code class="text-xs font-mono">[install]</code> block.
+    </p>
+    <div class="mt-6 space-y-6">
+      {rows.map((r) => (
+        <article id={`env-${r.env}`} class="rounded-lg border border-slate-200 dark:border-slate-800 p-5">
+          <header class="flex flex-wrap items-baseline gap-3">
+            <KindBadge kind="env" />
+            <a href={`${base}envs/${r.env}/`} class="text-lg font-semibold underline-offset-2 hover:underline">
+              {r.title}
+            </a>
+            <span class="text-xs font-mono text-slate-500">{r.env}</span>
+            <span class="ml-auto text-sm text-slate-500">
+              {r.count} package{r.count === 1 ? "" : "s"}
+              {r.catalogCount > 0 && (
+                <span class="ml-2 text-kind-env">· {r.catalogCount} from catalog</span>
+              )}
+            </span>
+          </header>
+          <p class="mt-2 text-sm text-slate-600 dark:text-slate-300">{r.tagline}</p>
+          <ul class="mt-4 flex flex-wrap gap-1.5">
+            {r.packages.map((p) => {
+              const flox = p.path.startsWith("flox/");
+              const catalogName = flox ? p.path.slice("flox/".length) : null;
+              const inCatalog = catalogName !== null && catalog.has(catalogName);
+              const href = inCatalog && catalogName
+                ? `${base}packages/${catalogName}/`
+                : flox
+                ? floxhubUrl(p.path)
+                : nixSearchUrl(p.path);
+              const cls = inCatalog
+                ? "border-kind-env/40 bg-kind-env/5 text-kind-env hover:border-kind-env"
+                : "border-slate-200 dark:border-slate-800 text-slate-600 dark:text-slate-300 hover:border-slate-400";
+              return (
+                <li>
+                  <a href={href} class={`inline-flex items-center gap-1.5 px-2 py-0.5 rounded border text-xs font-mono ${cls}`}>
+                    <span>{p.name}</span>
+                    {p.name !== p.path && (
+                      <span class="text-[10px] opacity-60">{p.path}</span>
+                    )}
+                  </a>
+                </li>
+              );
+            })}
+          </ul>
+        </article>
+      ))}
+    </div>
+  </section>
+
+  <section class="mt-16">
+    <h2 class="text-2xl font-semibold">By package — reverse lookup</h2>
+    <p class="text-sm text-slate-500 mt-1">
+      Which envs install each pkg-path, sorted by how many envs share it.
+    </p>
+    <div class="mt-6 rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+      <table class="w-full text-sm">
+        <thead class="bg-slate-50 dark:bg-slate-900 text-left">
+          <tr>
+            <th class="px-3 py-2 font-medium text-slate-500 text-xs uppercase tracking-wide">Path</th>
+            <th class="px-3 py-2 font-medium text-slate-500 text-xs uppercase tracking-wide">Source</th>
+            <th class="px-3 py-2 font-medium text-slate-500 text-xs uppercase tracking-wide">Installed in</th>
+          </tr>
+        </thead>
+        <tbody>
+          {reverseRows.map((row) => {
+            const catalogName = row.catalog ? row.path.slice("flox/".length) : null;
+            const href = row.catalog && catalogName
+              ? `${base}packages/${catalogName}/`
+              : row.flox
+              ? floxhubUrl(row.path)
+              : nixSearchUrl(row.path);
+            return (
+              <tr class="border-t border-slate-100 dark:border-slate-900 align-top">
+                <td class="px-3 py-2 font-mono text-xs">
+                  <a class="underline decoration-slate-300 dark:decoration-slate-700 hover:decoration-slate-700 dark:hover:decoration-slate-300" href={href}>{row.path}</a>
+                </td>
+                <td class="px-3 py-2 text-xs whitespace-nowrap">
+                  {row.catalog ? (
+                    <span class="inline-flex items-center gap-1.5 text-kind-env">
+                      <span class="inline-block w-1.5 h-1.5 rounded-full bg-kind-env"></span>
+                      catalog
+                    </span>
+                  ) : row.flox ? (
+                    <span class="inline-flex items-center gap-1.5 text-slate-500">
+                      <span class="inline-block w-1.5 h-1.5 rounded-full bg-slate-400"></span>
+                      floxhub
+                    </span>
+                  ) : (
+                    <span class="inline-flex items-center gap-1.5 text-slate-500">
+                      <span class="inline-block w-1.5 h-1.5 rounded-full bg-slate-400"></span>
+                      nixpkgs
+                    </span>
+                  )}
+                </td>
+                <td class="px-3 py-2 text-xs">
+                  <span class="inline-flex flex-wrap gap-x-1.5 gap-y-1">
+                    {row.envs.map((envName) => (
+                      <a href={`${base}envs/${envName}/`} class="underline decoration-slate-300 dark:decoration-slate-700 hover:decoration-slate-700 dark:hover:decoration-slate-300">{envName}</a>
+                    ))}
+                  </span>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  </section>
+</Layout>

--- a/.website/src/pages/index.astro
+++ b/.website/src/pages/index.astro
@@ -238,6 +238,7 @@ ollama.publisher    = <span class="text-kind-plugin">"flox"</span></code></pre>
     <div class="mt-3 flex gap-4 justify-center text-sm flex-wrap">
       <a href={`${base}envs/`} class="underline">All environments →</a>
       <a href={`${base}packages/`} class="underline">All packages →</a>
+      <a href={`${base}envs/packages/`} class="underline">Packages across envs →</a>
       <a href={`${base}compare/ai-coding-agents/`} class="underline">Compare AI agents →</a>
     </div>
   </section>

--- a/Justfile
+++ b/Justfile
@@ -21,23 +21,23 @@ validate:
 
 # Website: start the Astro dev server with hot reload
 website-dev:
-    cd .website && npm run dev
+    cd .website && npm ci && npm run dev
 
 # Website: produce the static build in .website/dist
 website-build:
-    cd .website && npm run build
+    cd .website && npm ci && npm run build
 
 # Website: run vitest unit tests for content libs
 website-test:
-    cd .website && npm run test
+    cd .website && npm ci && npm run test
 
 # Website: run astro check (TypeScript + Astro diagnostics)
 website-check:
-    cd .website && npm run check
+    cd .website && npm ci && npm run check
 
 # Website: build and push .website/dist to the gh-pages branch
 website-push:
-    cd .website && npm run build
+    cd .website && npm ci && npm run build
     cd .website && npx gh-pages \
         --dist dist \
         --branch gh-pages \

--- a/agentmemory/meta.yaml
+++ b/agentmemory/meta.yaml
@@ -1,0 +1,68 @@
+kind: env
+name: agentmemory
+title: AgentMemory
+publisher: flox
+tagline: >
+  Persistent memory for Claude Code — hooks, skills, and a REST/MCP
+  backend service in one include line.
+seo_title: >
+  AgentMemory dev environment for Claude Code — persistent agent
+  memory backed by a local service
+seo_description: >
+  Flox-packaged AgentMemory: 13 hooks, 8 skills, and the REST/MCP
+  backend on port 3111. One include line wires Claude Code to a
+  persistent, project-scoped memory store.
+intro: >
+  flox/agentmemory composes flox/claude with the
+  claude-code-plugin-agentmemory bundle and the matching
+  AgentMemory REST/MCP backend, so every new Claude Code session
+  starts with relevant prior context already injected.
+  AgentMemory captures tool usage, compresses observations into
+  long-lived facts, and exposes recall/remember/handoff skills to
+  the agent. The backend boots as a Flox service on
+  http://localhost:3111 — no global daemons, no shared state with
+  other projects. Includes the node runtime so the REST shim runs
+  without the consumer env supplying nodejs. Combines well with
+  graphify for graph-shaped retrieval and with vibe-kanban for
+  cross-session task continuity.
+summary:
+  - "Plugin tree + REST/MCP backend in one include"
+  - "13 hooks fire automatically — no per-session wiring"
+  - "8 skills: /recall, /remember, /handoff, /recap, …"
+  - "Backend boots as a Flox service on port 3111"
+category: ai
+ai_role: tooling
+tags: [agent, claude-code, memory, mcp, rag]
+stack: [nodejs, typescript]
+featured: false
+combines_well_with:
+  - env:claude
+  - env:graphify
+  - pkg:vibe-kanban
+status: beta
+license: MIT
+upstream:
+  name: agentmemory
+  url: https://github.com/rohitg00/agentmemory
+  license: MIT
+maintainer: "@rok"
+install:
+  include: |
+    [include]
+    environments = [{ remote = "flox/agentmemory" }]
+  activate: |
+    flox activate -r flox/agentmemory --start-services
+  docker: |
+    docker run -it ghcr.io/flox/floxenvs/agentmemory-latest
+recipes:
+  - name: agentmemory-demo
+    title: Quick start
+    start_services: true
+    features:
+      - "Wires Claude Code with the agentmemory plugin"
+      - "REST/MCP backend launches automatically on :3111"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/agentmemory
+  floxhub: https://hub.flox.dev/flox/agentmemory
+  docker: https://github.com/flox/floxenvs/pkgs/container/floxenvs/agentmemory-latest
+  issues: https://github.com/flox/floxenvs/issues?q=label%3Aagentmemory

--- a/basic-memory/meta.yaml
+++ b/basic-memory/meta.yaml
@@ -1,0 +1,66 @@
+kind: env
+name: basic-memory
+title: Basic Memory
+publisher: flox
+tagline: >
+  Local-first knowledge graph backed by Markdown notes, exposed
+  as an MCP server.
+seo_title: >
+  Basic Memory dev environment — local-first Markdown knowledge
+  graph with MCP server
+seo_description: >
+  Flox-packaged Basic Memory: Markdown-backed knowledge graph
+  with FastEmbed semantic search and an MCP server for Claude
+  Code, Cursor, ChatGPT. One include line, no daemons.
+intro: >
+  flox/basic-memory packages Basic Memory — Basic Machines' open
+  source, local-first knowledge graph built on plain Markdown
+  files — with FastEmbed and sqlite-vec already in the Nix
+  closure so semantic search works on first run. The env
+  exposes the `basic-memory` CLI (with the short alias `bm`) and
+  can be wired as an MCP server for any MCP client. Pair with
+  flox/claude or flox/basic-memory-demo to get the MCP wiring
+  written into a project-scoped `.mcp.json` for you. Useful as
+  a personal second-brain that agents can read and write, or as
+  a shared project log that survives chat compaction.
+summary:
+  - "Markdown notes form a local knowledge graph"
+  - "MCP server for Claude Code, Cursor, ChatGPT"
+  - "FastEmbed + sqlite-vec bundled for semantic search"
+  - "All state under per-user config dir — nothing global"
+category: ai
+ai_role: rag
+tags: [mcp, memory, knowledge-graph, markdown, rag]
+stack: [python]
+featured: false
+combines_well_with:
+  - env:claude
+  - env:graphify
+  - env:verba
+status: beta
+license: AGPL-3.0
+upstream:
+  name: Basic Memory
+  url: https://github.com/basicmachines-co/basic-memory
+  license: AGPL-3.0
+maintainer: "@rok"
+install:
+  include: |
+    [include]
+    environments = [{ remote = "flox/basic-memory" }]
+  activate: |
+    flox activate -r flox/basic-memory
+  docker: |
+    docker run -it ghcr.io/flox/floxenvs/basic-memory-latest
+recipes:
+  - name: basic-memory-demo
+    title: Quick start
+    start_services: false
+    features:
+      - "Composes Basic Memory with flox/claude"
+      - "Writes project-scoped .mcp.json for Claude Code"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/basic-memory
+  floxhub: https://hub.flox.dev/flox/basic-memory
+  docker: https://github.com/flox/floxenvs/pkgs/container/floxenvs/basic-memory-latest
+  issues: https://github.com/flox/floxenvs/issues?q=label%3Abasic-memory

--- a/caveman/meta.yaml
+++ b/caveman/meta.yaml
@@ -1,0 +1,70 @@
+kind: env
+name: caveman
+title: Caveman
+publisher: flox
+tagline: >
+  Claude Code with the caveman plugin pre-wired —
+  ultra-compressed agent communication, ~75% fewer tokens.
+seo_title: >
+  Caveman dev environment for Claude Code — compress agent
+  output by 75% with zero accuracy loss
+seo_description: >
+  Flox-packaged caveman: 7 skills, SessionStart hook, and a
+  /caveman intensity switch (lite/full/ultra). Composes with
+  flox/claude in one include line.
+intro: >
+  flox/caveman layers the caveman plugin on top of flox/claude
+  so the Claude Code agent talks back in a hyper-compressed
+  style that strips filler tokens while keeping full technical
+  accuracy. A SessionStart hook activates the mode on every new
+  session, and a UserPromptSubmit hook handles
+  `/caveman lite|full|ultra` to dial intensity up or down at
+  will. Includes seven skills — caveman, caveman-commit,
+  caveman-review, caveman-compress, caveman-stats,
+  caveman-help, cavecrew — so commits, PR reviews, memory
+  files, and subagent delegation all benefit from the
+  compression. Node.js and Python are bundled inside the
+  plugin tree, so the hooks run without the consumer env
+  having to install either runtime. Useful for long agent
+  sessions where the model spends too much of its window on
+  prose.
+summary:
+  - "~75% token reduction with full technical accuracy"
+  - "7 caveman-* skills wired through claude-managed"
+  - "SessionStart hook + /caveman intensity switch"
+  - "Self-contained — bundled node and python"
+category: ai
+ai_role: tooling
+tags: [agent, claude-code, plugin, compression, token-saving]
+stack: [nodejs, python]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:claude-code-plugin-superpowers
+status: beta
+license: MIT
+upstream:
+  name: caveman
+  url: https://github.com/JuliusBrussee/caveman
+  license: MIT
+maintainer: "@rok"
+install:
+  include: |
+    [include]
+    environments = [{ remote = "flox/caveman" }]
+  activate: |
+    flox activate -r flox/caveman
+  docker: |
+    docker run -it ghcr.io/flox/floxenvs/caveman-latest
+recipes:
+  - name: caveman-demo
+    title: Quick start
+    start_services: false
+    features:
+      - "Activates caveman mode for every Claude session"
+      - "Switch intensity with /caveman ultra"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/caveman
+  floxhub: https://hub.flox.dev/flox/caveman
+  docker: https://github.com/flox/floxenvs/pkgs/container/floxenvs/caveman-latest
+  issues: https://github.com/flox/floxenvs/issues?q=label%3Acaveman

--- a/codeburn/meta.yaml
+++ b/codeburn/meta.yaml
@@ -1,0 +1,68 @@
+kind: env
+name: codeburn
+title: CodeBurn
+publisher: flox
+tagline: >
+  Local-first TUI dashboard for AI coding tool spend — by task,
+  model, project, and provider.
+seo_title: >
+  CodeBurn dev environment — local TUI for Claude/Codex/Cursor
+  token spend, no API keys
+seo_description: >
+  Flox-packaged CodeBurn: an interactive TUI that auto-detects
+  sessions across 20+ AI coding tools, prices every call via
+  LiteLLM, and runs entirely on disk — no proxy, no keys.
+intro: >
+  flox/codeburn ships CodeBurn — getagentseal's local-first
+  AI coding token dashboard — ready to run in any Flox
+  environment. CodeBurn reads session data straight off disk
+  from 20+ AI coding tools (Claude Code, Codex, Cursor, Gemini
+  CLI, Aider, Continue, Roo Code, …) and prices every call
+  using LiteLLM's model pricing tables. No proxy, no
+  wrapping, no API keys — your traffic never leaves the
+  machine. The TUI covers daily / weekly / monthly windows,
+  side-by-side model comparisons, "yield" (productive vs
+  reverted spend), and one-line copy-paste optimizations. Pair
+  with any flox env that runs a coding agent (claude, codex,
+  crush, opencode) to keep an eye on the bill while you build.
+summary:
+  - "Interactive TUI for AI coding tool spend"
+  - "Reads session data locally — no proxy, no API keys"
+  - "Auto-detects Claude Code, Codex, Cursor, 17+ others"
+  - "Prices every call via LiteLLM tables"
+category: ai
+ai_role: tooling
+tags: [agent, observability, tui, cost, pricing]
+stack: [python]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:codex
+  - pkg:opencode
+status: beta
+license: MIT
+upstream:
+  name: CodeBurn
+  url: https://github.com/getagentseal/codeburn
+  license: MIT
+maintainer: "@rok"
+install:
+  include: |
+    [include]
+    environments = [{ remote = "flox/codeburn" }]
+  activate: |
+    flox activate -r flox/codeburn
+  docker: |
+    docker run -it ghcr.io/flox/floxenvs/codeburn-latest
+recipes:
+  - name: codeburn-demo
+    title: Quick start
+    start_services: false
+    features:
+      - "Boots the codeburn TUI on top of flox/claude"
+      - "Reports today + month spend in one screen"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/codeburn
+  floxhub: https://hub.flox.dev/flox/codeburn
+  docker: https://github.com/flox/floxenvs/pkgs/container/floxenvs/codeburn-latest
+  issues: https://github.com/flox/floxenvs/issues?q=label%3Acodeburn

--- a/fnox/meta.yaml
+++ b/fnox/meta.yaml
@@ -1,0 +1,67 @@
+kind: env
+name: fnox
+title: fnox
+publisher: flox
+tagline: >
+  "Fort Knox" — pluggable secrets layer for any Flox environment.
+seo_title: >
+  fnox dev environment — secrets in age, 1Password, Vault, KMS,
+  keychain, exposed as env vars
+seo_description: >
+  Flox-packaged fnox: one include line gives any env a
+  secrets layer backed by age, AWS/Azure/GCP KMS, 1Password,
+  Vault, password-store, OS keychain, and more.
+intro: >
+  flox/fnox layers jdx's fnox ("Fort Knox") secret manager
+  underneath any Flox env so secrets resolve at activation
+  time and reach your app as plain environment variables
+  without ever landing in shell history or git. fnox speaks
+  age-encrypted files, AWS/Azure/GCP KMS, 1Password,
+  Bitwarden, HashiCorp Vault, AWS Secrets Manager, GCP
+  Secret Manager, Doppler, Infisical, password-store, and the
+  OS keychain — pick a provider per-secret in `fnox.toml`,
+  no per-team daemon required. Use the `on-activate` hook
+  recipe to export all secrets into the env, or wrap
+  individual commands with `fnox exec` to scope leakage.
+  Pairs cleanly with env:1password for first-party secret
+  vaulting, and with env:dotenv during migration off
+  long-lived `.env` files.
+summary:
+  - "Pluggable providers — age, KMS, 1Password, Vault, ..."
+  - "Secrets load on activation or per-command via fnox exec"
+  - "Lives as a base layer — include into any env"
+  - "No daemon — secrets resolve on demand"
+category: tool
+tags: [secrets, security, age, kms, vault]
+stack: [rust]
+featured: false
+combines_well_with:
+  - env:1password
+  - env:dotenv
+status: beta
+license: MIT
+upstream:
+  name: fnox
+  url: https://fnox.jdx.dev/
+  license: MIT
+maintainer: "@rok"
+install:
+  include: |
+    [include]
+    environments = [{ remote = "flox/fnox" }]
+  activate: |
+    flox activate -r flox/fnox
+  docker: |
+    docker run -it ghcr.io/flox/floxenvs/fnox-latest
+recipes:
+  - name: fnox-demo
+    title: Quick start
+    start_services: false
+    features:
+      - "Demonstrates age-encrypted secrets in git"
+      - "Loads secrets via on-activate hook"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/fnox
+  floxhub: https://hub.flox.dev/flox/fnox
+  docker: https://github.com/flox/floxenvs/pkgs/container/floxenvs/fnox-latest
+  issues: https://github.com/flox/floxenvs/issues?q=label%3Afnox

--- a/gstack/meta.yaml
+++ b/gstack/meta.yaml
@@ -1,0 +1,70 @@
+kind: env
+name: gstack
+title: gstack
+publisher: flox
+tagline: >
+  Garry Tan's 45-skill Claude Code stack — planning, design,
+  QA, review, security, shipping — in one include line.
+seo_title: >
+  gstack dev environment for Claude Code — Garry Tan's 45
+  opinionated skills for planning, design, QA, and shipping
+seo_description: >
+  Flox-packaged gstack: 45 skills for Claude Code covering
+  the full product loop, layered on flox/claude through the
+  managed config. Self-contained — bundled bun, node, jq.
+intro: >
+  flox/gstack composes flox/claude with the
+  claude-code-plugin-gstack bundle — Garry Tan's
+  opinionated 45-skill Claude Code stack — so the agent has
+  ready-to-run workflows for every phase of the product
+  loop. The skill catalog covers planning (`/office-hours`,
+  `/plan-ceo-review`, `/plan-eng-review`, `/autoplan`),
+  design (`/design-consultation`, `/design-html`,
+  `/design-review`), QA (`/qa`, `/review`, `/security`),
+  and shipping (`/ship`, `/release-notes`). Bun, node, git,
+  jq, and curl are bundled inside the plugin tree so the
+  skill commands work regardless of what the consumer env
+  exposes. Pair with vibe-kanban for cross-session task
+  continuity, or with env:graphify for richer codebase
+  context.
+summary:
+  - "45 Claude Code skills wired through managed config"
+  - "Covers planning, design, QA, review, security, shipping"
+  - "Self-contained — bundled bun, node, git, jq, curl"
+  - "Skills resolved via $CLAUDE_PLUGIN_ROOT"
+category: ai
+ai_role: tooling
+tags: [agent, claude-code, plugin, workflow, skills]
+stack: [bun, nodejs]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:vibe-kanban
+  - env:graphify
+status: beta
+license: MIT
+upstream:
+  name: gstack
+  url: https://github.com/garrytan/gstack
+  license: MIT
+maintainer: "@rok"
+install:
+  include: |
+    [include]
+    environments = [{ remote = "flox/gstack" }]
+  activate: |
+    flox activate -r flox/gstack
+  docker: |
+    docker run -it ghcr.io/flox/floxenvs/gstack-latest
+recipes:
+  - name: gstack-demo
+    title: Quick start
+    start_services: false
+    features:
+      - "Loads the gstack skill catalog into Claude Code"
+      - "Demonstrates /office-hours and /ship"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/gstack
+  floxhub: https://hub.flox.dev/flox/gstack
+  docker: https://github.com/flox/floxenvs/pkgs/container/floxenvs/gstack-latest
+  issues: https://github.com/flox/floxenvs/issues?q=label%3Agstack

--- a/iloom/meta.yaml
+++ b/iloom/meta.yaml
@@ -1,0 +1,68 @@
+kind: env
+name: iloom
+title: iloom
+publisher: flox
+tagline: >
+  Run Claude Code in isolated git worktrees and persist its
+  reasoning to your issue tracker.
+seo_title: >
+  iloom dev environment — Claude Code in git worktrees, plans
+  persisted to GitHub/Linear/Jira/BitBucket
+seo_description: >
+  Flox-packaged iloom: spins Claude Code up inside an
+  isolated worktree per issue and writes its analysis, plans,
+  and decisions back to the tracker. GitHub CLI bundled.
+intro: >
+  flox/iloom packages iloom — the workflow CLI that runs
+  Claude Code inside a fresh git worktree per issue and
+  persists every plan, decision, and review back to your
+  tracker. Supports GitHub, Linear, Jira, and BitBucket out
+  of the box. The env bundles `gh` for GitHub auth and wraps
+  the binary so `git` is always on its PATH, regardless of
+  what the consumer env provides. Bring your own coding
+  agent: layer flox/claude alongside this env for a managed
+  Claude CLI, or pair with pkg:codex / pkg:opencode for
+  alternative agents. Useful when one repo needs many
+  parallel agent sessions without trampling each other's
+  worktrees.
+summary:
+  - "Per-issue git worktree, no manual setup"
+  - "Persists agent reasoning to your issue tracker"
+  - "GitHub, Linear, Jira, BitBucket — pick one"
+  - "Bundled gh CLI and git PATH wiring"
+category: ai
+ai_role: orchestrator
+tags: [agent, worktree, git, workflow, claude-code]
+stack: [rust]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:vibe-kanban
+  - env:graphify
+status: beta
+license: MIT
+upstream:
+  name: iloom-cli
+  url: https://github.com/iloom-ai/iloom-cli
+  license: MIT
+maintainer: "@rok"
+install:
+  include: |
+    [include]
+    environments = [{ remote = "flox/iloom" }]
+  activate: |
+    flox activate -r flox/iloom
+  docker: |
+    docker run -it ghcr.io/flox/floxenvs/iloom-latest
+recipes:
+  - name: iloom-demo
+    title: Quick start
+    start_services: false
+    features:
+      - "Composes iloom with flox/claude"
+      - "Demonstrates `il start <issue-number>`"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/iloom
+  floxhub: https://hub.flox.dev/flox/iloom
+  docker: https://github.com/flox/floxenvs/pkgs/container/floxenvs/iloom-latest
+  issues: https://github.com/flox/floxenvs/issues?q=label%3Ailoom

--- a/lmstudio/meta.yaml
+++ b/lmstudio/meta.yaml
@@ -1,0 +1,71 @@
+kind: env
+name: lmstudio
+title: LM Studio
+publisher: flox
+tagline: >
+  Headless LM Studio with an OpenAI-compatible local API on
+  port 11234.
+seo_title: >
+  LM Studio dev environment — local LLMs with an
+  OpenAI-compatible API, GPU-accelerated
+seo_description: >
+  Flox-packaged LM Studio: `lms`, `lm-studio`, headless
+  API on 127.0.0.1:11234. macOS Metal, Linux CUDA/Vulkan.
+  Includes Claude/Codex/OpenCode launchers.
+intro: >
+  flox/lmstudio packages LM Studio as a Flox service so a
+  local OpenAI-compatible LLM endpoint is one
+  `flox activate --start-services` away. The env exposes
+  `lms` (load / serve / get / chat), the `lm-studio` GUI
+  launcher on macOS, and `lms-launch` — a helper that points
+  claude / codex / opencode at the local API in one
+  command. Headless API serves on http://127.0.0.1:11234/v1
+  by default. Requires a Metal-capable GPU on macOS or a
+  CUDA / Vulkan-capable discrete GPU on Linux; the binary
+  hard-exits without one (override with
+  `LMS_SKIP_GPU_CHECK=1` for install-only CI). Pairs well
+  with env:omlx for Apple Silicon MLX inference, with
+  env:verba for local RAG, and with env:claude for
+  Claude-Code-against-local-models workflows.
+summary:
+  - "Headless API on 127.0.0.1:11234 — OpenAI-compatible"
+  - "`lms`, `lm-studio`, `lms-launch` — local model lifecycle"
+  - "macOS Metal, Linux CUDA/Vulkan; aarch64-darwin/linux + x86_64-linux"
+  - "Boots as a Flox service"
+category: ai
+ai_role: llm-runtime
+tags: [llm, local-inference, openai-api, macos, linux]
+stack: [c++]
+featured: false
+combines_well_with:
+  - pkg:omlx
+  - env:omlx
+  - env:verba
+  - env:claude
+status: beta
+license: Unfree
+upstream:
+  name: LM Studio
+  url: https://lmstudio.ai
+  license: Unfree
+maintainer: "@rok"
+install:
+  include: |
+    [include]
+    environments = [{ remote = "flox/lmstudio" }]
+  activate: |
+    flox activate -r flox/lmstudio --start-services
+  docker: |
+    docker run -it ghcr.io/flox/floxenvs/lmstudio-latest
+recipes:
+  - name: lmstudio-demo
+    title: Quick start
+    start_services: true
+    features:
+      - "Boots the headless API server"
+      - "Pings /v1/models to confirm a loaded model"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/lmstudio
+  floxhub: https://hub.flox.dev/flox/lmstudio
+  docker: https://github.com/flox/floxenvs/pkgs/container/floxenvs/lmstudio-latest
+  issues: https://github.com/flox/floxenvs/issues?q=label%3Almstudio

--- a/remotion/meta.yaml
+++ b/remotion/meta.yaml
@@ -1,0 +1,69 @@
+kind: env
+name: remotion
+title: Remotion
+publisher: flox
+tagline: >
+  React-based programmatic video toolkit with the Remotion
+  best-practices skill pre-wired into Claude Code.
+seo_title: >
+  Remotion dev environment — React video toolkit with Claude
+  Code best-practices skill
+seo_description: >
+  Flox-packaged Remotion: Node 22, `npx create-video` ready,
+  and the Remotion best-practices skill auto-registered as a
+  Claude Code plugin. ffmpeg comes from Remotion itself.
+intro: >
+  flox/remotion sets up a Remotion-ready Node 22 sandbox and
+  composes flox/claude with claude-code-plugin-remotion so
+  the Remotion best-practices skill loads automatically
+  whenever Claude touches Remotion code. ffmpeg/ffprobe are
+  intentionally not in the closure — Remotion ships its own
+  via `npx remotion ffmpeg`, which is what the skill tells
+  the agent to use. Useful for building videos
+  programmatically with React (animations, audio, captions,
+  3D, transitions, charts). Combines well with env:claude
+  for the managed-config + isolated workflow, with
+  env:javascript-node for separately-pinned node tooling,
+  and with env:playwright if your video content needs to
+  capture browser screenshots.
+summary:
+  - "Node 22 ready for `npx create-video`, `remotion studio`, `remotion render`"
+  - "Remotion best-practices skill auto-loaded in Claude Code"
+  - "ffmpeg sourced from Remotion itself — no host install"
+  - "Composes cleanly with flox/claude"
+category: ai
+ai_role: tooling
+tags: [video, react, claude-code, plugin, programmatic-video]
+stack: [nodejs, typescript, react]
+featured: false
+combines_well_with:
+  - env:claude
+  - env:javascript-node
+  - env:playwright
+status: beta
+license: MIT
+upstream:
+  name: Remotion
+  url: https://remotion.dev
+  license: Remotion License
+maintainer: "@rok"
+install:
+  include: |
+    [include]
+    environments = [{ remote = "flox/remotion" }]
+  activate: |
+    flox activate -r flox/remotion
+  docker: |
+    docker run -it ghcr.io/flox/floxenvs/remotion-latest
+recipes:
+  - name: remotion-demo
+    title: Quick start
+    start_services: false
+    features:
+      - "Scaffolds a blank Remotion project"
+      - "Opens the Remotion studio against the demo"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/remotion
+  floxhub: https://hub.flox.dev/flox/remotion
+  docker: https://github.com/flox/floxenvs/pkgs/container/floxenvs/remotion-latest
+  issues: https://github.com/flox/floxenvs/issues?q=label%3Aremotion

--- a/serena/meta.yaml
+++ b/serena/meta.yaml
@@ -1,0 +1,69 @@
+kind: env
+name: serena
+title: Serena
+publisher: flox
+tagline: >
+  Semantic IDE-grade tools for coding agents — exposed via
+  MCP over SSE.
+seo_title: >
+  Serena dev environment — IDE-grade semantic MCP toolkit
+  for Claude Code, Cursor, ChatGPT
+seo_description: >
+  Flox-packaged Serena: language-server-backed find-symbol,
+  find-references, rename, and symbolic edit, served over
+  MCP/SSE on port 19121.
+intro: >
+  flox/serena packages Serena — Oraios's MCP toolkit that
+  gives coding agents real IDE semantics — with the
+  language-server runtime pre-wired and the MCP server
+  running as a Flox service on
+  http://127.0.0.1:19121/sse by default. Serena exposes
+  symbolic operations the model can't fake with grep:
+  find-symbol, find-references, rename, symbolic edit —
+  driven by an underlying language server. Includes
+  `serena-hooks` for project-side wiring and pulls in
+  Node 20 so the bundled Pyright LSP runs without host
+  setup. Pair with env:claude or any other MCP-capable
+  agent host. Useful for codebases where wrong-file-edits
+  are expensive (large monorepos, ambiguous symbol names).
+summary:
+  - "MCP/SSE server on 127.0.0.1:19121"
+  - "find-symbol, find-references, rename, symbolic edit"
+  - "Bundled Pyright + node runtime, no host LSP setup"
+  - "Boots as a Flox service"
+category: ai
+ai_role: tooling
+tags: [agent, mcp, lsp, refactor, ide]
+stack: [python, nodejs]
+featured: false
+combines_well_with:
+  - env:claude
+  - env:graphify
+  - env:python-uv
+status: beta
+license: MIT
+upstream:
+  name: Serena
+  url: https://github.com/oraios/serena
+  license: MIT
+maintainer: "@rok"
+install:
+  include: |
+    [include]
+    environments = [{ remote = "flox/serena" }]
+  activate: |
+    flox activate -r flox/serena --start-services
+  docker: |
+    docker run -it ghcr.io/flox/floxenvs/serena-latest
+recipes:
+  - name: serena-demo
+    title: Quick start
+    start_services: true
+    features:
+      - "Boots the Serena MCP server on :19121"
+      - "Demonstrates find-symbol from Claude Code"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/serena
+  floxhub: https://hub.flox.dev/flox/serena
+  docker: https://github.com/flox/floxenvs/pkgs/container/floxenvs/serena-latest
+  issues: https://github.com/flox/floxenvs/issues?q=label%3Aserena

--- a/worktrunk/meta.yaml
+++ b/worktrunk/meta.yaml
@@ -1,0 +1,67 @@
+kind: env
+name: worktrunk
+title: Worktrunk
+publisher: flox
+tagline: >
+  Git worktree management designed for running parallel
+  AI coding agents.
+seo_title: >
+  Worktrunk dev environment — parallel git worktrees for
+  Claude Code, Codex, Gemini CLI
+seo_description: >
+  Flox-packaged Worktrunk: `wt` and `git wt` for managing
+  many worktrees at once, designed for parallel AI coding
+  agent runs. git bundled, no host wiring.
+intro: >
+  flox/worktrunk packages the Worktrunk CLI — a git worktree
+  manager purpose-built for spinning up many AI coding
+  sessions in parallel without trampling each other's
+  branches. Exposes `wt` and the same binary as `git wt`,
+  with `git` always wrapped onto the PATH so it works
+  regardless of what the consumer env provides. Pair with
+  any coding agent env — flox/claude, pkg:codex,
+  pkg:gemini-cli, pkg:opencode — and run them side by side
+  in isolated worktrees. Useful when one repo needs many
+  concurrent agent sessions, or for branch-heavy workflows
+  (stacked PRs, large-scale refactors).
+summary:
+  - "`wt` and `git wt` — same binary, two entrypoints"
+  - "Designed for parallel AI coding agents"
+  - "Bundled git so wt's runtime works anywhere"
+  - "Per-env scratch dir under $FLOX_ENV_CACHE/worktrunk"
+category: tool
+tags: [git, worktree, agent, workflow]
+stack: [go]
+featured: false
+combines_well_with:
+  - env:claude
+  - pkg:codex
+  - pkg:gemini-cli
+  - pkg:opencode
+status: beta
+license: MIT
+upstream:
+  name: Worktrunk
+  url: https://worktrunk.dev
+  license: MIT
+maintainer: "@rok"
+install:
+  include: |
+    [include]
+    environments = [{ remote = "flox/worktrunk" }]
+  activate: |
+    flox activate -r flox/worktrunk
+  docker: |
+    docker run -it ghcr.io/flox/floxenvs/worktrunk-latest
+recipes:
+  - name: worktrunk-demo
+    title: Quick start
+    start_services: false
+    features:
+      - "Walks through `wt switch -c feat`"
+      - "Pairs worktrunk with a coding agent env"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/worktrunk
+  floxhub: https://hub.flox.dev/flox/worktrunk
+  docker: https://github.com/flox/floxenvs/pkgs/container/floxenvs/worktrunk-latest
+  issues: https://github.com/flox/floxenvs/issues?q=label%3Aworktrunk


### PR DESCRIPTION
## Summary
- Add `meta.yaml` for **11 envs** and **40 packages** that previously existed on disk but never surfaced on the website. Catalog grows from 34→45 envs and 34→74 pkgs.
- New `/envs/packages/` page renders every package every env installs, two ways: **by-env** (chips, catalog ones highlighted) and **by-package reverse lookup** (which envs share each `pkg-path`, sorted by reuse). Linked from the envs index and the homepage footer.
- Each env detail page gains a **"Packages installed"** section (new `PackagesInstalled.astro` component) that links each entry to the catalog detail page, FloxHub, or nixpkgs search depending on where the `pkg-path` resolves.
- `just website-*` recipes now run `npm ci` before the underlying npm command so a fresh checkout / stale `node_modules` no longer breaks `just website-dev`, `just website-build`, etc.

## What changed
- **Envs added**: agentmemory, basic-memory, caveman, codeburn, fnox, gstack, iloom, lmstudio, remotion, serena, worktrunk.
- **Pkgs added**: agent-browser, amp, basic-memory, ccstatusline, ccusage, six `claude-code-plugin-*` bundles (agentmemory, caveman, claude-ads, claude-obsidian, gstack, remotion), claude-code-router, claudebox, codeburn, coderabbit-cli, copilot-cli, cursor-agent, deepseek-tui, fnox, forgecode, gemini-cli, goose-cli, grok, herdr, iloom-cli, lmstudio, mcporter, mistral-vibe, ollama-cuda, openspec, qwen-code, sandbox-runtime, serena, skills-shipshit, skillspector, spec-kit, temporal, temporal-cli, workmux, worktrunk.

Every new `meta.yaml` follows the existing schema (`kind`, `name`, `title`, `tagline`, `category`, `tags`, `status`, `license`, `install`, `links`) with `subkind: plain|plugin|skill` where applicable and `combines_well_with` entries prefixed `env:`/`pkg:` so they pass `scripts/lint-meta.sh`.

## Test plan
- [x] `npm ci` → `npm run check` (0 errors, 4 pre-existing hints)
- [x] `npm run build` (334 pages built, sitemap regenerated, pagefind index OK)
- [x] `npm run test` (25/25 unit tests pass)
- [x] `bash scripts/discover-envs.sh --validate` (all 45 envs + 45 demo envs OK)
- [x] `bash scripts/list-items.sh` surfaces every new env and pkg
- [ ] Spot-check `/envs/packages/` and a couple of new detail pages once deployed