### PR TITLE
fix(pkgs): repair upgrade scripts for ccusage, coderabbit-cli, goose-cli

### DIFF
--- a/.flox/pkgs/agent-browser/upgrade.sh
+++ b/.flox/pkgs/agent-browser/upgrade.sh
@@ -36,7 +36,7 @@ jq -n \
 echo "Building with dummy hashes to compute real ones..."
 # pnpm deps build first; capture both hashes from successive build runs.
 pnpm_hash=$(flox build agent-browser 2>&1 \
-  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep -A2 "hash mismatch in fixed-output derivation" \
   | grep "got:" | head -1 | awk '{print $NF}') || true
 
 if [ -z "$pnpm_hash" ]; then
@@ -53,7 +53,7 @@ jq -n \
   '{version: $v, srcHash: $s, cargoHash: $c, pnpmDepsHash: $p}' > "$HASHES_FILE"
 
 cargo_hash=$(flox build agent-browser 2>&1 \
-  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep -A2 "hash mismatch in fixed-output derivation" \
   | grep "got:" | head -1 | awk '{print $NF}') || true
 
 if [ -z "$cargo_hash" ]; then

--- a/.flox/pkgs/ccusage/upgrade.sh
+++ b/.flox/pkgs/ccusage/upgrade.sh
@@ -34,7 +34,7 @@ jq -n \
 
 echo "Building with dummy cargoHash to compute real one..."
 cargo_hash=$(flox build ccusage 2>&1 \
-  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep -A2 "hash mismatch in fixed-output derivation" \
   | grep "got:" | head -1 | awk '{print $NF}') || true
 
 if [ -z "$cargo_hash" ]; then

--- a/.flox/pkgs/coderabbit-cli/upgrade.sh
+++ b/.flox/pkgs/coderabbit-cli/upgrade.sh
@@ -6,13 +6,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HASHES_FILE="$SCRIPT_DIR/hashes.json"
 
 # CodeRabbit publishes the current CLI version at a stable endpoint.
-VERSION_URL="https://cli.coderabbit.ai/releases/latest"
+# The official install.sh fetches this same VERSION file to detect latest.
+VERSION_URL="https://cli.coderabbit.ai/releases/latest/VERSION"
 
 current_version=$(jq -r '.version' "$HASHES_FILE")
-# Follow redirect to /releases/<version> and extract the version path
-latest_version=$(curl -sILf "$VERSION_URL" \
-  | grep -i '^location:' | tail -1 \
-  | sed -E 's|.*/releases/([^/[:space:]]+).*|\1|' | tr -d '[:space:]')
+latest_version=$(curl -sfL "$VERSION_URL" | tr -d '[:space:]')
 
 echo "Current: $current_version, Latest: $latest_version"
 

--- a/.flox/pkgs/gemini-cli/upgrade.sh
+++ b/.flox/pkgs/gemini-cli/upgrade.sh
@@ -36,7 +36,7 @@ jq -n \
 
 echo "Building with dummy npmDepsHash to compute real one..."
 npm_hash=$(flox build gemini-cli 2>&1 \
-  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep -A2 "hash mismatch in fixed-output derivation" \
   | grep "got:" | head -1 | awk '{print $NF}') || true
 
 if [ -z "$npm_hash" ]; then

--- a/.flox/pkgs/goose-cli/default.nix
+++ b/.flox/pkgs/goose-cli/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchurl,
   rustPlatform,
+  cmake,
   pkg-config,
   openssl,
   libxcb,
@@ -40,7 +41,15 @@ rustPlatform.buildRustPackage {
 
   inherit cargoHash;
 
-  nativeBuildInputs = [ pkg-config ];
+  nativeBuildInputs = [
+    cmake
+    pkg-config
+  ];
+
+  # cmake's nix hook sets CMAKE_BUILD_TYPE=Release which the
+  # llama-cpp-sys-2 crate's build script overrides. Disable the hook so
+  # the crate stays in control of its own cmake invocation.
+  dontUseCmakeConfigure = true;
 
   buildInputs = [
     openssl

--- a/.flox/pkgs/goose-cli/upgrade.sh
+++ b/.flox/pkgs/goose-cli/upgrade.sh
@@ -41,7 +41,7 @@ mv "$HASHES_FILE.tmp" "$HASHES_FILE"
 
 echo "Building with dummy cargoHash to compute real one..."
 cargo_hash=$(flox build goose-cli 2>&1 \
-  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep -A2 "hash mismatch in fixed-output derivation" \
   | grep "got:" | head -1 | awk '{print $NF}') || true
 
 if [ -z "$cargo_hash" ]; then

--- a/.flox/pkgs/mcporter/upgrade.sh
+++ b/.flox/pkgs/mcporter/upgrade.sh
@@ -34,7 +34,7 @@ jq -n \
 
 echo "Building with dummy pnpmDepsHash to compute real one..."
 pnpm_hash=$(flox build mcporter 2>&1 \
-  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep -A2 "hash mismatch in fixed-output derivation" \
   | grep "got:" | head -1 | awk '{print $NF}') || true
 
 if [ -z "$pnpm_hash" ]; then

--- a/.flox/pkgs/openspec/upgrade.sh
+++ b/.flox/pkgs/openspec/upgrade.sh
@@ -42,7 +42,7 @@ jq -n \
 
 echo "Building with dummy npmDepsHash to compute real one..."
 npm_hash=$(flox build openspec 2>&1 \
-  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep -A2 "hash mismatch in fixed-output derivation" \
   | grep "got:" | head -1 | awk '{print $NF}') || true
 
 if [ -z "$npm_hash" ]; then

--- a/.flox/pkgs/qwen-code/upgrade.sh
+++ b/.flox/pkgs/qwen-code/upgrade.sh
@@ -34,7 +34,7 @@ jq -n \
 
 echo "Building with dummy npmDepsHash to compute real one..."
 npm_hash=$(flox build qwen-code 2>&1 \
-  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep -A2 "hash mismatch in fixed-output derivation" \
   | grep "got:" | head -1 | awk '{print $NF}') || true
 
 if [ -z "$npm_hash" ]; then

--- a/.flox/pkgs/sandbox-runtime/upgrade.sh
+++ b/.flox/pkgs/sandbox-runtime/upgrade.sh
@@ -49,7 +49,7 @@ jq -n \
 
 echo "Building with dummy npmDepsHash to compute real one..."
 npm_hash=$(flox build sandbox-runtime 2>&1 \
-  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep -A2 "hash mismatch in fixed-output derivation" \
   | grep "got:" | head -1 | awk '{print $NF}') || true
 
 if [ -z "$npm_hash" ]; then

--- a/.flox/pkgs/workmux/upgrade.sh
+++ b/.flox/pkgs/workmux/upgrade.sh
@@ -34,7 +34,7 @@ jq -n \
 
 echo "Building with dummy cargoHash to compute real one..."
 cargo_hash=$(flox build workmux 2>&1 \
-  | grep -A1 "hash mismatch in fixed-output derivation" \
+  | grep -A2 "hash mismatch in fixed-output derivation" \
   | grep "got:" | head -1 | awk '{print $NF}') || true
 
 if [ -z "$cargo_hash" ]; then


### PR DESCRIPTION
## Summary

Three jobs in the Upgrade Packages workflow have been failing
(run [26182960188](https://github.com/flox/floxenvs/actions/runs/26182960188)).
Two unrelated root causes — plus a third issue uncovered while
verifying the goose-cli fix:

### `ccusage` and `goose-cli` — `grep -A1` misses the `got:` line

Nix prints hash mismatches across three lines:

```
error: hash mismatch in fixed-output derivation '...'
         specified: sha256-AAA...
            got:    sha256-...
```

`grep -A1` only captured lines 1–2, so the follow-up `grep "got:"`
returned nothing and `cargo_hash` stayed empty — the scripts then
exited with `ERROR: could not extract cargoHash from build output`.
Changed to `-A2`.

Same latent bug fixed in 7 other scripts that didn't fail this run
only because their packages were already up to date:
`agent-browser` (2 instances), `gemini-cli`, `mcporter`, `openspec`,
`qwen-code`, `sandbox-runtime`, `workmux`.

### `coderabbit-cli` — `/releases/latest` endpoint retired

`https://cli.coderabbit.ai/releases/latest` now returns 404 (no
redirect), so `curl -sILf` failed under `set -e` and the script
exited silently before printing `Current:`. CodeRabbit's official
`install.sh` reads the current version from
`/releases/latest/VERSION` (plain text). Switched to that.

### `goose-cli` — needs `cmake` for `llama-cpp-sys-2`

goose 1.34.1 pulled in `llama-cpp-sys-2` (via `llama-cpp-2`), whose
build script invokes cmake to compile the bundled llama.cpp library.
Added `cmake` to `nativeBuildInputs` and set
`dontUseCmakeConfigure = true` so nixpkgs's cmake hook doesn't try
to drive the top-level source — the crate's build script drives
cmake itself with its own arguments.

## Test plan

- [x] Locally ran `flox activate -- bash .flox/pkgs/ccusage/upgrade.sh`
      → bumps to 20.0.1, `flox build ccusage` passes
- [x] Locally ran `flox activate -- bash .flox/pkgs/coderabbit-cli/upgrade.sh`
      → bumps to 0.5.1, `flox build coderabbit-cli` passes
- [x] Locally ran `flox activate -- bash .flox/pkgs/goose-cli/upgrade.sh`
      → bumps to 1.34.1, `flox build goose-cli` passes (~15 min build,
      checkPhase 1/1 test passes)
- [ ] CI confirms upgrade workflow jobs no longer fail on next schedule