### PR TITLE
fix(skills-humanizer): nest version under metadata

### DIFF
--- a/.flox/pkgs/skills-humanizer/default.nix
+++ b/.flox/pkgs/skills-humanizer/default.nix
@@ -35,10 +35,30 @@ stdenvNoCC.mkDerivation {
     runHook postInstall
   '';
 
+  # Upstream SKILL.md puts `version:` at the top level of the YAML
+  # frontmatter, which agentskills.io flags as an unknown key. Nest it
+  # under `metadata:` so the loader stops warning on every session start.
+  postInstall = ''
+    for skill_md in \
+      "$out/share/claude-code/skills/humanizer/SKILL.md" \
+      "$out/share/opencode/skills/humanizer/SKILL.md"; do
+      awk '
+        BEGIN { fm = 0 }
+        /^---[[:space:]]*$/ { fm++; print; next }
+        fm == 1 && /^version:[[:space:]]/ {
+          print "metadata:"
+          print "  " $0
+          next
+        }
+        { print }
+      ' "$skill_md" > "$skill_md.new"
+      mv "$skill_md.new" "$skill_md"
+    done
+  '';
+
   meta = {
     description =
-      "Humanizer skill for Claude Code and OpenCode "
-      + "— removes signs of AI-generated writing.";
+      "Humanizer skill for Claude Code and OpenCode " + "— removes signs of AI-generated writing.";
     homepage = "https://github.com/blader/humanizer";
     license = lib.licenses.mit;
     platforms = [

--- a/.flox/pkgs/skills-humanizer/hashes.json
+++ b/.flox/pkgs/skills-humanizer/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.5.1+unstable-2026-04-01.8b3a178",
+  "version": "2.5.1+unstable-2026-04-01.8b3a178.fixmeta1",
   "rev": "8b3a17889fbf12bedae20974a3c9f9de746ed754",
   "srcHash": "sha256-3yO13MKUK/zF36Sq+CACMM401BhtmYz5cZmC5FX4VQw="
 }


### PR DESCRIPTION
## Summary

- Upstream `blader/humanizer` SKILL.md has `version: 2.5.1` at the top
  level of the YAML frontmatter. agentskills.io flags this as an
  unknown key, producing a `WARN` on every Claude Code session start.
- Adds a `postInstall` step that uses `awk` to rewrite the SKILL.md
  frontmatter in both `claude-code` and `opencode` install destinations,
  nesting `version:` under `metadata:`. Version-agnostic, so future
  `upgrade.sh` runs don't break it.
- Bumps the local version to `...8b3a178.fixmeta1` so the catalog
  serves the rebuilt artifact for all 4 systems instead of the
  pre-patch entry cached under the same identifier.

## Test plan

- [x] Local `flox build skills-humanizer` produces a SKILL.md with
      `metadata:\n  version: 2.5.1` in the frontmatter.
- [ ] CI builds for all 4 systems.
- [ ] After merge + CI publish, `flox upgrade skills-humanizer` in a
      consuming env picks up `.fixmeta1` and the session-start warning
      disappears.

## Notes

A proper upstream fix would be a PR to `blader/humanizer` itself.
This patch is a local workaround until that lands.