### PR TITLE
fix(pkgs/goose-cli): unblock 1.34.1 build

### DIFF
--- a/.flox/pkgs/goose-cli/default.nix
+++ b/.flox/pkgs/goose-cli/default.nix
@@ -4,6 +4,7 @@
   fetchFromGitHub,
   fetchurl,
   rustPlatform,
+  cacert,
   cmake,
   pkg-config,
   openssl,
@@ -44,6 +45,7 @@ rustPlatform.buildRustPackage {
   nativeBuildInputs = [
     cmake
     pkg-config
+    rustPlatform.bindgenHook
   ];
 
   # cmake's nix hook sets CMAKE_BUILD_TYPE=Release which the
@@ -65,7 +67,12 @@ rustPlatform.buildRustPackage {
   ];
 
   # Tests need writable XDG dirs and run only goose-cli's test target.
+  # cacert provides the CA bundle for reqwest's TLS init (otherwise
+  # tests that build an HTTP client panic with "No CA certificates
+  # were loaded from the system" on Linux, where there's no system
+  # trust store in the Nix sandbox).
   doCheck = true;
+  nativeCheckInputs = [ cacert ];
   checkPhase = ''
     runHook preCheck
 
@@ -78,7 +85,12 @@ rustPlatform.buildRustPackage {
       $XDG_CONFIG_HOME $XDG_DATA_HOME \
       $XDG_STATE_HOME $XDG_CACHE_HOME
 
-    cargo test --package goose-cli --release
+    # Skip tests that require live network access (sigstore.dev for
+    # SLSA provenance verification, langfuse for tracing). These
+    # can't run in the Nix sandbox.
+    cargo test --package goose-cli --release -- \
+      --skip commands::update::tests::test_verify_provenance_warns_on_missing_attestation \
+      --skip logging::tests::test_langfuse_layer_creation
 
     runHook postCheck
   '';


### PR DESCRIPTION
The auto-upgrade PR #1914 (goose-cli 1.24.0 → 1.34.1) keeps failing
because the bot force-pushes new bot commits over any in-place fix.
This lands the build fix on `main` so the next upgrade run sees a
working derivation.

## What was broken at 1.34.1

`llama-cpp-sys-2` (pulled in via `llama-cpp-2`) does two things the
current derivation can't support on Linux:

1. **bindgen against llama.cpp headers** — needs libclang. The Nix
   sandbox on Linux has none, so the build panicked with `Unable to
   find libclang`. Darwin happens to find libclang via the SDK, which
   is why local macOS builds passed.
2. **reqwest HTTP clients in tests** — two tests in goose-cli's lib
   (`commands::update::tests::test_verify_provenance_warns_on_missing_attestation`
   and `logging::tests::test_langfuse_layer_creation`) build a
   reqwest client and then call live services (sigstore.dev,
   Langfuse). On Linux the client builder panics with `No CA
   certificates were loaded from the system`. On Darwin reqwest
   uses the system keychain.

## The fix

- Add `rustPlatform.bindgenHook` to `nativeBuildInputs` so bindgen
  has libclang on every system (this is what nixpkgs upstream's
  goose-cli does).
- Add `cacert` to `nativeCheckInputs` so reqwest can build a client
  at all in the sandbox.
- Pass `--skip` for the two network-bound tests so the remaining
  ~188 unit tests still gate the build.

## Verification

Verified locally on `aarch64-darwin`: full build succeeds, doc tests
pass, version-check phase passes. The same changes were applied to
PR #1914's branch and made CI green there until the upgrade bot
force-pushed over them — landing this on `main` makes the fix
durable.