### PR TITLE
feat(hyperframes): add claude-code-plugin-hyperframes package

### DIFF
--- a/.flox/pkgs/claude-code-plugin-hyperframes/default.nix
+++ b/.flox/pkgs/claude-code-plugin-hyperframes/default.nix
@@ -1,0 +1,78 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  ffmpeg-headless,
+  perl,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version commit srcHash;
+in
+stdenv.mkDerivation {
+  pname = "claude-code-plugin-hyperframes";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "heygen-com";
+    repo = "hyperframes";
+    rev = commit;
+    hash = srcHash;
+  };
+
+  nativeBuildInputs = [ perl ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    PLUGIN_DIR="$out/share/claude-code/plugins/hyperframes"
+    mkdir -p "$PLUGIN_DIR"
+
+    # Upstream ships 15 skill folders under skills/ and a complete
+    # .claude-plugin/{plugin.json,marketplace.json} pair. Copy both
+    # verbatim — no manifest synthesis needed (unlike
+    # claude-code-plugin-remotion). Claude Code reads
+    # .claude-plugin/plugin.json to discover the plugin and recurses
+    # into skills/ to advertise each as a slash command.
+    cp -r "$src/skills" "$PLUGIN_DIR/skills"
+    cp -r "$src/.claude-plugin" "$PLUGIN_DIR/.claude-plugin"
+    chmod -R u+w "$PLUGIN_DIR"
+
+    # Nix-lock command-context references to ffmpeg / ffprobe so the
+    # skill content points the agent at the exact ffmpeg-headless build
+    # pulled into this derivation's closure, not whichever `ffmpeg`
+    # happens to be on PATH. The lookahead `(?=[\s",)])` restricts
+    # the substitution to executable positions (followed by space,
+    # closing quote, comma, or close-paren) — so we don't mangle
+    # filename uses like `$OUTDIR/ffmpeg.stderr`, the `ffmpeg/ffprobe`
+    # error-message slug, or possessives like `ffmpeg's filter`.
+    find "$PLUGIN_DIR" -type f \
+        \( -name '*.md' -o -name '*.sh' -o -name '*.py' \) -print0 \
+      | xargs -0 perl -i -pe '
+          s{\bffmpeg(?=[\s",)])}{${ffmpeg-headless}/bin/ffmpeg}g;
+          s{\bffprobe(?=[\s",)])}{${ffmpeg-headless}/bin/ffprobe}g;
+        '
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "HyperFrames skill bundle for Claude Code — 15 skills covering "
+      + "HTML compositions, GSAP/Anime.js/CSS/Lottie/Three.js/WAAPI "
+      + "animation adapters, Tailwind, captions, TTS, transcription, "
+      + "website-to-video, and Remotion-to-HyperFrames translation.";
+    homepage = "https://github.com/heygen-com/hyperframes";
+    license = lib.licenses.asl20;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/claude-code-plugin-hyperframes/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-hyperframes/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "2026.05.22",
+  "commit": "e9c515dedd3ac2cc883c3ae358c1e4f336491e5f",
+  "srcHash": "sha256-FXUfOcrobNGMvV5Lbtv2jcEQScyEMXdzCxcsls08ca4="
+}

--- a/.flox/pkgs/claude-code-plugin-hyperframes/hashes.json
+++ b/.flox/pkgs/claude-code-plugin-hyperframes/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "2026.05.22",
-  "commit": "e9c515dedd3ac2cc883c3ae358c1e4f336491e5f",
-  "srcHash": "sha256-FXUfOcrobNGMvV5Lbtv2jcEQScyEMXdzCxcsls08ca4="
+  "version": "2026.05.25",
+  "commit": "60cb9552e475f19dbe494ce22c7fc15da2f46cd1",
+  "srcHash": "sha256-7QWrQx/3a5lmP367Y69xOo1srSuhOMR0JKu14UPwZ30="
 }

--- a/.flox/pkgs/claude-code-plugin-hyperframes/meta.yaml
+++ b/.flox/pkgs/claude-code-plugin-hyperframes/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: plugin
+name: claude-code-plugin-hyperframes
+title: HyperFrames Skills
+plugin_for: claude-code
+publisher: flox
+tagline: >
+  HyperFrames skill bundle for Claude Code — 15 skills for
+  HTML-based programmatic video.
+category: ai
+ai_role: tooling
+tags: [claude-code, plugin, hyperframes, video, html, gsap]
+status: beta
+license: Apache-2.0
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    claude-code-plugin-hyperframes.pkg-path = "flox/claude-code-plugin-hyperframes"
+    claude-code-plugin-hyperframes.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/claude-code-plugin-hyperframes
+  floxhub: https://hub.flox.dev/flox/claude-code-plugin-hyperframes

--- a/.flox/pkgs/claude-code-plugin-hyperframes/publish.json
+++ b/.flox/pkgs/claude-code-plugin-hyperframes/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/claude-code-plugin-hyperframes/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-hyperframes/upgrade.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="heygen-com"
+REPO="hyperframes"
+
+current_commit=$(jq -r '.commit' "$HASHES_FILE")
+
+# heygen-com/hyperframes tags many npm packages (the CLI, @hyperframes/*)
+# but does not maintain a single "skills bundle" tag, so HEAD of `main`
+# is the canonical source — exactly like remotion-dev/skills. Pin to
+# the committer date so the floxhub version field stays monotonic.
+latest_commit=$(curl -sf \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/main" \
+  | jq -r '.sha')
+latest_date=$(curl -sf \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/$latest_commit" \
+  | jq -r '.commit.committer.date')
+latest_version=$(echo "$latest_date" | cut -dT -f1 | tr - .)
+
+echo "Current commit: $current_commit"
+echo "Latest commit:  $latest_commit ($latest_version)"
+
+if [ "$current_commit" = "$latest_commit" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating claude-code-plugin-hyperframes to $latest_version ($latest_commit)"
+
+src_url="https://github.com/$OWNER/$REPO/archive/${latest_commit}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg c "$latest_commit" \
+  --arg s "$src_sri" \
+  '{version: $v, commit: $c, srcHash: $s}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"


### PR DESCRIPTION
## Summary

- New Nix package `claude-code-plugin-hyperframes` bundling the
  heygen-com/hyperframes Claude Code skill set, installed under
  `share/claude-code/plugins/hyperframes/` with the upstream
  `.claude-plugin/{plugin.json,marketplace.json}` and all 15 skill
  folders verbatim
- Command-context `ffmpeg`/`ffprobe` references inside skill `.md`,
  `.sh`, and `.py` files are rewritten to the exact `ffmpeg-headless`
  build pulled into the derivation's closure; a perl lookahead
  preserves filename uses (e.g. `\$OUTDIR/ffmpeg.stderr`) and
  possessives (e.g. `ffmpeg's filter`)
- `upgrade.sh` tracks HEAD of `main` (heygen-com/hyperframes has no
  bundle tag) and pins floxhub version to the committer date; current
  pin is `60cb9552` (2026.05.25)

## Test plan

- [x] `nix-build -E '(import <nixpkgs> {}).callPackage ./.flox/pkgs/claude-code-plugin-hyperframes/default.nix {}'` succeeds on `aarch64-darwin`
- [x] Built tree contains `.claude-plugin/plugin.json` plus the 15
  upstream skill folders (animejs, contribute-catalog, css-animations,
  gsap, hyperframes, hyperframes-cli, hyperframes-media,
  hyperframes-registry, lottie, remotion-to-hyperframes, tailwind,
  three, typegpu, waapi, website-to-hyperframes)
- [x] ffmpeg/ffprobe rewrites land on the nix-locked
  `ffmpeg-headless-*/bin/ffmpeg` path, with no mangled filenames or
  possessives in the diff
- [ ] Load the plugin via `claude` and confirm all 15 skills register