### PR TITLE
fix: repair website CI and trigger it for package-only updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -630,9 +630,11 @@ jobs:
     name: "Website"
     needs: ["result", "containerize"]
     if: |
-      github.ref == 'refs/heads/main'
+      always()
+      && github.ref == 'refs/heads/main'
       && github.event_name == 'push'
       && needs.result.result == 'success'
+      && needs.containerize.result != 'failure'
     permissions:
       contents: "write"
       pages: "write"

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -45,7 +45,7 @@ jobs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       count: ${{ steps.matrix.outputs.count }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
         with:
           fetch-depth: 0
       - name: "Install yq, jq, gh"
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJson(needs.detect-changed.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
         with:
           fetch-depth: 0
       - name: "Install tools"
@@ -103,7 +103,7 @@ jobs:
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
       - name: "Restore cache"
         id: cache
-        uses: actions/cache@v5
+        uses: "actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae" # v5
         with:
           path: "audit/${{ matrix.kind }}/${{ matrix.name }}/metrics.json"
           key: ${{ steps.hash.outputs.key }}
@@ -118,7 +118,7 @@ jobs:
           bash scripts/run-audit.sh \
             "${{ matrix.kind }}" "${{ matrix.name }}"
       - name: "Upload metrics.json artifact"
-        uses: actions/upload-artifact@v7
+        uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7
         with:
           name: "metrics-${{ matrix.kind }}-${{ matrix.name }}"
           path: "audit/${{ matrix.kind }}/${{ matrix.name }}/metrics.json"
@@ -130,14 +130,14 @@ jobs:
     if: always() && needs.detect-changed.result == 'success'
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v6
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
       - name: "Install jq"
         run: sudo apt-get install -y -qq jq
       - name: "Stage directory"
         run: mkdir -p .website/src/content/metrics/env \
                        .website/src/content/metrics/pkg
       - name: "Download changed-item artifacts"
-        uses: actions/download-artifact@v8
+        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8
         with:
           pattern: "metrics-*"
           path: "_metrics_in"
@@ -176,7 +176,7 @@ jobs:
             fi
           done
       - name: "Upload staged metrics"
-        uses: actions/upload-artifact@v7
+        uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7
         with:
           name: "site-metrics-staged"
           path: ".website/src/content/metrics"
@@ -186,14 +186,14 @@ jobs:
     needs: ["collect-metrics"]
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
+      - uses: "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e" # v6
         with:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: ".website/package-lock.json"
       - name: "Download staged metrics"
-        uses: actions/download-artifact@v8
+        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8
         with:
           name: "site-metrics-staged"
           path: ".website/src/content/metrics"
@@ -224,7 +224,7 @@ jobs:
           BASE_PATH: ${{ vars.BASE_PATH || '/' }}
         run: "npm run build"
       - name: "Upload dist artifact for the deploy job"
-        uses: actions/upload-artifact@v7
+        uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7
         with:
           name: "website-dist"
           path: ".website/dist"
@@ -237,16 +237,16 @@ jobs:
     permissions:
       contents: "write"
     steps:
-      - uses: actions/checkout@v6
+      - uses: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" # v6
         with:
           fetch-depth: 0
       - name: "Download built site"
-        uses: actions/download-artifact@v8
+        uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8
         with:
           name: "website-dist"
           path: ".website/dist"
       - name: "Publish to gh-pages branch"
-        uses: peaceiris/actions-gh-pages@v4
+        uses: "peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453" # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ".website/dist"


### PR DESCRIPTION
This PR fixes two separate bugs that were keeping the website from
building and deploying.

## Bug 1 — Website workflow failed at setup (unpinned actions)

The Website CI failed at the `Detect changed items` job during *setup*,
before any step ran:

```
Error: The action actions/checkout@v6 is not allowed in flox/floxenvs
because all actions must be pinned to a full-length commit SHA.
```

Because that job failed at setup, the entire Website pipeline (Build
site, Deploy) was skipped — so the site never built or published.

Failing run:
https://github.com/flox/floxenvs/actions/runs/26820728975/job/79076166810

### Fix

Pinned all 14 `uses:` references in `.github/workflows/website.yml` to
their full commit SHAs, keeping the `# vX` comment convention used by
the rest of the repo:

| Action | SHA |
| ------ | --- |
| `actions/checkout` | `de0fac2…` # v6 |
| `actions/cache` | `27d5ce7…` # v5 |
| `actions/upload-artifact` | `043fb46…` # v7 |
| `actions/download-artifact` | `3e5f45b…` # v8 |
| `actions/setup-node` | `48b55a0…` # v6 |
| `peaceiris/actions-gh-pages` | `84c30a8…` # v4 |

The `actions/checkout` SHA matches the one already used in `ci.yml`.

## Bug 2 — Website never rebuilt for package-only updates

`trigger-website` in `ci.yml` listed `containerize` in `needs` but its
`if:` did not use `always()`. In GitHub Actions, a skipped needed job
skips the dependent job regardless of its `if:`.

`containerize` only runs when an environment changed
(`successful_envs != '[]'`). So a package-only push to `main`
(`.flox/pkgs/*` with no env change) skipped `containerize`, which in
turn skipped `trigger-website` — the website never rebuilt for package
updates.

### Fix

Guard `trigger-website` with `always()` and tolerate a skipped
`containerize`, only bailing when `result` fails or `containerize`
actually failed:

```yaml
needs: ["result", "containerize"]
if: |
  always()
  && github.ref == 'refs/heads/main'
  && github.event_name == 'push'
  && needs.result.result == 'success'
  && needs.containerize.result != 'failure'
```

The diff base (`site-last-deployed` tag) already determines what
actually changed, so once the job runs for package updates,
`changed-items.sh` picks up the package diff and rebuilds correctly.