### PR TITLE
fix(website): pass a TRIGGER value changed-items.sh understands

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -55,7 +55,7 @@ jobs:
       - name: "Compute matrix"
         id: matrix
         env:
-          TRIGGER: ${{ github.event_name }}
+          TRIGGER: ${{ github.event_name == 'workflow_dispatch' && 'workflow_dispatch' || 'workflow_call' }}
           SHA: ${{ inputs.sha || github.sha }}
           INPUT_ITEMS: ${{ inputs.items || 'changed' }}
         run: |


### PR DESCRIPTION
Follow-up to #2807. With the workflow no longer failing at setup and now
running for package-only pushes, the post-merge run surfaced the next
bug in the same pipeline:

```
TRIGGER: push
unknown TRIGGER: push
##[error]Process completed with exit code 2.
```

Failing run:
https://github.com/flox/floxenvs/actions/runs/26822340199/job/79080142884

## Cause

`scripts/changed-items.sh` only accepts two trigger values:

```bash
case "$TRIGGER" in
  workflow_call)     ... ;;
  workflow_dispatch) ... ;;
  *) echo "unknown TRIGGER: $TRIGGER" >&2; exit 2 ;;
esac
```

But `website.yml` passed `github.event_name` raw:

```yaml
TRIGGER: ${{ github.event_name }}
```

When CI invokes the website via `workflow_call`, `github.event_name` is
the **parent's** event — `push` — not `workflow_call`. So the script hit
its default case and exited 2. The CI path never actually worked; the
earlier setup failures (unpinned actions) masked it.

## Fix

Map the event to the value the script's contract expects:

```yaml
TRIGGER: ${{ github.event_name == 'workflow_dispatch' && 'workflow_dispatch' || 'workflow_call' }}
```

- Manual `workflow_dispatch` → `workflow_dispatch` (reads `items` input)
- CI push (via `workflow_call`) → `workflow_call` (diffs from
  `site-last-deployed` → current SHA)