### PR TITLE
fix(website): resolve diff base safely when deploy tag is missing

### DIFF
--- a/scripts/changed-items.sh
+++ b/scripts/changed-items.sh
@@ -25,11 +25,16 @@ resolve_base() {
   local b
   b=$(
     cd "$ROOT" || exit 1
-    if git rev-parse site-last-deployed 2>/dev/null; then
-      :
+    # --verify --quiet prints nothing and fails cleanly when the tag is
+    # missing (e.g. before the first successful deploy); without it,
+    # `git rev-parse` echoes the literal ref to stdout, which would then
+    # be used as a bogus diff base.
+    if sha=$(git rev-parse --verify --quiet \
+               "refs/tags/site-last-deployed^{commit}"); then
+      echo "$sha"
     else
-      git rev-list --max-parents=0 HEAD
-    fi | head -1
+      git rev-list --max-parents=0 HEAD | head -1
+    fi
   )
   echo "$b"
 }


### PR DESCRIPTION
Follow-up to #2807 and #2810. With the trigger and setup bugs fixed, the
post-merge `main` run got into `changed-items.sh` and hit the next layer:

```
TRIGGER: workflow_call
fatal: ambiguous argument 'site-last-deployed': unknown revision or path not in the working tree
##[error]Process completed with exit code 128
```

Failing run:
https://github.com/flox/floxenvs/actions/runs/26822765775/job/79081700564

## Cause

Two compounding problems:

1. The `site-last-deployed` tag has **never existed** — it is only
   created after the first *successful* deploy, which has never
   happened. So every run takes the fallback path.

2. `resolve_base()` took that fallback incorrectly:

   ```bash
   if git rev-parse site-last-deployed 2>/dev/null; then :
   else git rev-list --max-parents=0 HEAD
   fi | head -1
   ```

   `git rev-parse <missing-ref>` (no `--verify`) **echoes the literal
   ref name to stdout** and exits non-zero. Because the whole `if/else`
   is piped to `head -1`, that literal `site-last-deployed` string
   became the diff base — so `git diff site-last-deployed <sha>` failed
   with `fatal: ambiguous argument` (exit 128).

## Fix

```bash
if sha=$(git rev-parse --verify --quiet \
           "refs/tags/site-last-deployed^{commit}"); then
  echo "$sha"
else
  git rev-list --max-parents=0 HEAD | head -1
fi
```

`--verify --quiet` prints nothing and fails cleanly on a missing ref, so
the fallback to the root commit works. `^{commit}` also dereferences an
annotated tag once the tag does exist.

### Verified locally

```
$ REPO_ROOT=$PWD TRIGGER=workflow_call SHA=HEAD bash scripts/changed-items.sh
exit=0, 153 items (full catalog — correct for the first deploy)
```

On the first successful run the deploy job creates `site-last-deployed`,
and subsequent runs diff incrementally from it.