### PR TITLE
fix(ci): rewrite all local includes to remote before FloxHub push

### DIFF
--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -422,6 +422,26 @@ jobs:
           fi
           popd
 
+      - name: "Rewrite include to use remote environments"
+        env:
+          FLOX_REMOTE_OWNER: "${{ steps.org.outputs.owner }}"
+        run: |
+          ENV="${{ inputs.environment }}"
+          MANIFEST="$ENV/.flox/env/manifest.toml"
+          # A non-demo env can still include local siblings (e.g.
+          # understand-anything includes ../claude). FloxHub rejects
+          # pushes whose manifest includes local environments, so rewrite
+          # any `{ dir = "../X" }` to its published `{ remote = "OWNER/X" }`
+          # form and re-lock. No-op for envs without local includes.
+          if grep -q '{ dir = "\.\./' "$MANIFEST"; then
+            sed -E "s#\{ dir = \"\.\./([A-Za-z0-9_.-]+)\" \}#{ remote = \"$FLOX_REMOTE_OWNER/\1\" }#g" "$MANIFEST" > "$MANIFEST.new"
+            mv "$MANIFEST.new" "$MANIFEST"
+            cat "$MANIFEST"
+            pushd "$ENV"
+            flox include upgrade
+            popd
+          fi
+
       - name: "Sync to remote environment"
         env:
           FLOX_REMOTE_OWNER: "${{ steps.org.outputs.owner }}"
@@ -488,7 +508,12 @@ jobs:
           # sed -i is non-portable between GNU (Linux) and BSD (macOS) sed;
           # write through a temp file so the same step works on both runners.
           MANIFEST="$DEMO_DIR/.flox/env/manifest.toml"
-          sed "s|{ dir = \"../$ENV\" }|{ remote = \"$FLOX_REMOTE_OWNER/$ENV\" }|g" "$MANIFEST" > "$MANIFEST.new"
+          # Rewrite every local `{ dir = "../X" }` include to its
+          # published `{ remote = "OWNER/X" }` form; FloxHub rejects
+          # pushes whose manifest includes local environments. The demo
+          # can include siblings beyond its own parent (e.g. ../claude),
+          # so match any sibling rather than only ../$ENV.
+          sed -E "s#\{ dir = \"\.\./([A-Za-z0-9_.-]+)\" \}#{ remote = \"$FLOX_REMOTE_OWNER/\1\" }#g" "$MANIFEST" > "$MANIFEST.new"
           mv "$MANIFEST.new" "$MANIFEST"
           cat "$DEMO_DIR/.flox/env/manifest.toml"
 


### PR DESCRIPTION
## Problem

Two environments fail their `Push … to FloxHub` job with:

```
✘ ERROR: cannot push environment that includes local environments
```

FloxHub refuses to push an environment whose manifest has a local
(`dir`-based) `include`. The CI is meant to rewrite local includes to
their published `remote` form first, but the rewrite was incomplete.

Failing jobs:
- `basic-memory-demo` —
  https://github.com/flox/floxenvs/actions/runs/26824010113/job/79086883067
- `understand-anything` —
  https://github.com/flox/floxenvs/actions/runs/26824008474/job/79086541524

## Cause

1. **`push-demo` job** rewrote only the self-include:

   ```bash
   sed "s|{ dir = \"../$ENV\" }|{ remote = \"$FLOX_REMOTE_OWNER/$ENV\" }|g"
   ```

   `basic-memory-demo` includes `[{ dir = "../basic-memory" }, { dir = "../claude" }]`.
   `../basic-memory` was rewritten, but `../claude` stayed local → push rejected.

2. **`push` job** had **no rewrite step at all**. `understand-anything`
   is a non-demo env that includes `../claude`, so its push failed too.

## Fix

- Generalize the demo rewrite to convert **every** `{ dir = "../X" }`
  into `{ remote = "OWNER/X" }`:

  ```bash
  sed -E "s#\{ dir = \"\.\./([A-Za-z0-9_.-]+)\" \}#{ remote = \"$FLOX_REMOTE_OWNER/\1\" }#g"
  ```

- Add the same rewrite (plus `flox include upgrade`) to the `push` job,
  **guarded** by a `grep` so it is a no-op for the ~45 envs without local
  includes.

Fixes `basic-memory-demo` and `understand-anything`; also covers the
latently broken `caveman` (non-demo, includes `../claude`).
`claude-demo` was already fine (its `../claude` is the self-include).

## Verification

Sed transform checked against the real manifests:

| Env | Before | After |
| --- | ------ | ----- |
| `basic-memory-demo` | `{ dir = "../basic-memory" }, { dir = "../claude" }` | `{ remote = "flox/basic-memory" }, { remote = "flox/claude" }` |
| `understand-anything` | `{ dir = "../claude" }` | `{ remote = "flox/claude" }` |

Guard matches `understand-anything`/`caveman`, skips `mysql`/`redis`.
YAML validated.

Note: the rewrite assumes included siblings share the pushing env's
owner (`$FLOX_REMOTE_OWNER`) — true for the all-`flox` set today, same
assumption the original self-include rewrite already made.