### PR TITLE
fix(website): stop rev-parse corrupting audit cache key (~100 failing audit jobs)

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -96,9 +96,13 @@ jobs:
       - name: "Content hash"
         id: hash
         run: |
-          MAIN_H=$(git rev-parse "HEAD:${{ steps.dir.outputs.dir }}" 2>/dev/null || echo none)
-          DEMO_H=$(git rev-parse "HEAD:${{ matrix.name }}-demo" 2>/dev/null || echo none)
-          CONF_H=$(git rev-parse "HEAD:.gitleaks.toml" 2>/dev/null || echo none)
+          # --verify --quiet prints nothing and fails cleanly when the
+          # path is absent. Without it, `git rev-parse "HEAD:missing"`
+          # echoes the literal arg to stdout, embedding a newline in the
+          # cache key that corrupts $GITHUB_OUTPUT ("Invalid format").
+          MAIN_H=$(git rev-parse --verify --quiet "HEAD:${{ steps.dir.outputs.dir }}" || echo none)
+          DEMO_H=$(git rev-parse --verify --quiet "HEAD:${{ matrix.name }}-demo" || echo none)
+          CONF_H=$(git rev-parse --verify --quiet "HEAD:.gitleaks.toml" || echo none)
           KEY="audit-v1-${{ matrix.kind }}-${{ matrix.name }}-${MAIN_H}-${DEMO_H}-${CONF_H}"
           echo "key=$KEY" >> "$GITHUB_OUTPUT"
       - name: "Restore cache"


### PR DESCRIPTION
## Problem

On the post-merge `main` run, ~100 of the `Website / Audit …` matrix
jobs fail at the `Content hash` step with:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format 'none-3d943735548b7f530f2abb2d98fc3853812f71e8'
```

Run: https://github.com/flox/floxenvs/actions/runs/26834696861

## Cause

Same `git rev-parse` footgun as the `resolve_base` deploy-tag bug. The
step ran:

```bash
DEMO_H=$(git rev-parse "HEAD:${{ matrix.name }}-demo" 2>/dev/null || echo none)
```

`git rev-parse "HEAD:<missing>"` (no `--verify`) **echoes the literal
argument to stdout** and exits non-zero. `2>/dev/null` only hides
stderr, so the captured value became e.g. `HEAD:claude-code-demo\nnone`
— with an embedded newline. That newline split the `key=…` line written
to `$GITHUB_OUTPUT`, leaving a bare `none-<sha>` line the runner
rejects.

Every item without a `-demo` (or pkg) path — all packages and demoless
envs — hit this, which is the bulk of the failures.

## Fix

```bash
MAIN_H=$(git rev-parse --verify --quiet "HEAD:${{ steps.dir.outputs.dir }}" || echo none)
```

`--verify --quiet` prints nothing and fails cleanly, so the fallback to
`none` works and the key stays a single clean line. Verified locally:
the key for `pkg:claude-code` now has zero embedded newlines.

## Not covered by this PR (separate bugs, reported for follow-up)

A handful of envs that get *past* the hash step fail inside the audit
itself, from different causes — flagging so they're not forgotten:

- `env:claude`, `env:langchain` → `jq: Unknown option -o=json`. The
  audit installs python-`yq` via apt, but `run-flox-evals.sh` uses
  mikefarah's `yq -o=json`. **Caveat:** `lint-meta.sh` uses python-`yq`
  syntax (`yq -r`), so the repo's yq usage is inconsistent — a binary
  swap needs care.
- `env:caveman` → `jq: Cannot iterate over null` in `run-audit.sh`
  (a scanner returning null). Needs its own look.