### PR TITLE
fix(website): standardize on mikefarah yq for audits

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -51,7 +51,13 @@ jobs:
       - name: "Install yq, jq, gh"
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq jq yq
+          sudo apt-get install -y -qq jq
+          # mikefarah/yq (Go). Ubuntu's apt `yq` is the python jq-wrapper,
+          # which is incompatible with the mikefarah syntax the audit
+          # scripts use (e.g. `yq -o=json`).
+          sudo curl -sSL -o /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.6/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
       - name: "Compute matrix"
         id: matrix
         env:
@@ -82,7 +88,13 @@ jobs:
       - name: "Install tools"
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq jq yq shellcheck
+          sudo apt-get install -y -qq jq shellcheck
+          # mikefarah/yq (Go). Ubuntu's apt `yq` is the python jq-wrapper,
+          # which is incompatible with the mikefarah syntax the audit
+          # scripts use (e.g. `yq -o=json`).
+          sudo curl -sSL -o /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/download/v4.44.6/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
           curl -sSL -o /tmp/gitleaks.tgz \
             https://github.com/gitleaks/gitleaks/releases/download/v8.18.4/gitleaks_8.18.4_linux_x64.tar.gz
           sudo tar -xzf /tmp/gitleaks.tgz -C /usr/local/bin gitleaks

--- a/scripts/lint-meta.sh
+++ b/scripts/lint-meta.sh
@@ -95,9 +95,7 @@ required_pkg=(install)
         (.combines_well_with | length > 0)' \
        "$meta" >/dev/null 2>&1; then
     if yq -e '
-      .combines_well_with | all(
-        test("^env:") or test("^pkg:")
-      )
+      .combines_well_with | all_c(test("^(env|pkg):"))
     ' "$meta" >/dev/null 2>&1; then
       sh_check_json "meta-yaml-cww-prefixed" true 5
     else


### PR DESCRIPTION
## Problem

Audits for envs with an `evals.yaml` (`claude`, `langchain`) fail with:

```
jq: Unknown option -o=json
##[error]Process completed with exit code 2
```

Run: https://github.com/flox/floxenvs/actions/runs/26834696861

## Cause

The audit job installs `yq` via `apt`, which on Ubuntu is **python-yq**
(a `jq` wrapper). But `scripts/run-flox-evals.sh` uses **mikefarah**
syntax — `yq -o=json '.cases'`. python-yq passes `-o=json` straight to
`jq` → "Unknown option".

The repo's yq usage was inconsistent: `run-flox-evals.sh` is mikefarah,
while `lint-meta.sh` was written for python-yq.

## Fix — mikefarah everywhere

- Install **mikefarah/yq** (pinned `v4.44.6`) in both `website.yml`
  install steps, replacing the apt `yq`.
- Convert the one python-yq-only expression in `lint-meta.sh`:

  ```diff
  - .combines_well_with | all(test("^env:") or test("^pkg:"))
  + .combines_well_with | all_c(test("^(env|pkg):"))
  ```

Every other yq call already works under mikefarah — verified `-r`
(`--unwrapScalar`), `-e`, `//`, `has`, `length`, `-o=json` against real
files with yq `v4.44.6`.

## Verification (local, yq v4.44.6)

- `scripts/test/lint-meta.test.sh` → **4 passed, 0 failed**
- `lint-meta env:lmstudio` (has `combines_well_with`) →
  `meta-yaml-cww-prefixed: pass: true`
- `yq -o=json '.cases' claude/evals.yaml` → valid JSON
- A deliberately-bad `combines_well_with` entry → `all_c(...)` exits
  non-zero (check correctly fails)

## Notes

- This makes mikefarah yq the required `yq` for the audit scripts and
  their tests. The only non-website consumer is `scripts/test/*`, which
  now also expects mikefarah.
- Independent of #2849 (the audit cache-key fix); they touch different
  parts of `website.yml` and merge cleanly. Both are needed for the
  audit matrix to go green.