### PR TITLE
fix(website): tolerate items without a CI workflow in reliability audit

### DIFF
--- a/scripts/compute-reliability.sh
+++ b/scripts/compute-reliability.sh
@@ -53,6 +53,11 @@ if command -v gh >/dev/null 2>&1 \
         "repos/${REPO}/actions/workflows/${workflow_file}/runs?branch=main&per_page=30" \
         2>/dev/null); then
     note="gh api failed; using defaults"
+    # On failure (e.g. 404 for an item without a ci_<name>.yml, like an
+    # env that has no dedicated workflow) gh still writes the error JSON
+    # body to stdout. Clear it so the non-empty guard below skips the
+    # parsing that would otherwise hit `.workflow_runs[]` on null.
+    runs_json=""
   fi
 else
   note="no GITHUB_TOKEN; reliability defaults to neutral"
@@ -66,18 +71,18 @@ score=80
 if [ -n "$runs_json" ]; then
   # Count consecutive successful main runs from newest.
   streak=$(echo "$runs_json" | jq '
-    [.workflow_runs[]
+    [(.workflow_runs // [])[]
      | select(.head_branch == "main")
      | .conclusion]
     | (. + ["FAIL"])
     | (index("failure") // index("FAIL"))
   ')
   last_at=$(echo "$runs_json" | jq -r '
-    [.workflow_runs[] | select(.head_branch == "main")][0]
+    [(.workflow_runs // [])[] | select(.head_branch == "main")][0]
     .created_at // ""
   ' | cut -d T -f1)
   avg_s=$(echo "$runs_json" | jq '
-    [.workflow_runs[]
+    [(.workflow_runs // [])[]
      | select(.head_branch == "main")
      | (((.updated_at | fromdateiso8601))
         - ((.created_at | fromdateiso8601)))]


### PR DESCRIPTION
## Problem

`env:caveman`'s audit fails (exit 5) with:

```
6:53PM INF no leaks found
jq: error (at <stdin>:1): Cannot iterate over null (null)
##[error]Process completed with exit code 5
```

Run: https://github.com/flox/floxenvs/actions/runs/26834696861

## Cause

`compute-reliability.sh` queries a per-item workflow's runs —
`ci_<name>.yml` for envs. **caveman has no `ci_caveman.yml`** (it's the
only env without a dedicated workflow), so the query 404s.

```bash
if ! runs_json=$(gh api .../workflows/${workflow_file}/runs ... 2>/dev/null); then
  note="gh api failed; using defaults"
fi
...
if [ -n "$runs_json" ]; then
  streak=$(echo "$runs_json" | jq '[.workflow_runs[] | ...]')   # 💥
```

On a 404, `gh` still writes the error body
(`{"message":"Not Found",...}`) to **stdout**, which `runs_json`
captures. The `if !` notes the failure but doesn't clear `runs_json`, so
the `[ -n "$runs_json" ]` guard passes and `jq '.workflow_runs[]'` runs
on a body with no `workflow_runs` → iterates over `null` → exit 5,
failing the whole audit.

## Fix

- Clear `runs_json=""` in the gh-failure branch so the parse is skipped
  (root cause).
- Harden the three iterations with `(.workflow_runs // [])[]` as defense
  against any unexpected-shape response.

## Verification (local)

- The 404 body `{"message":"Not Found"}` through the hardened jq →
  returns cleanly (exit 0) instead of crashing.
- `compute-reliability env:caveman` → clean default JSON.
- `scripts/test/compute-reliability.test.sh` → **17 passed, 0 failed**.

Part of the website-audit fix series (#2849 cache key, #2854 yq). With
all three, the audit matrix should finally run clean end-to-end.