### PR TITLE
fix(website): unblock Collect metrics + Build/Deploy (mkdir + OG font)

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -150,8 +150,9 @@ jobs:
       - name: "Install jq"
         run: sudo apt-get install -y -qq jq
       - name: "Stage directory"
-        run: mkdir -p .website/src/content/metrics/env \
-                       .website/src/content/metrics/pkg
+        run: |
+          mkdir -p .website/src/content/metrics/env
+          mkdir -p .website/src/content/metrics/pkg
       - name: "Download changed-item artifacts"
         uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8
         with:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -234,6 +234,17 @@ jobs:
       - name: "Install"
         working-directory: ".website"
         run: "npm ci"
+      - name: "Provide a font for OG image rendering"
+        run: |
+          # The OG image route (src/pages/og/[kind]/[name].png.ts) needs
+          # a TTF and reads OG_FONT_PATH first. Install Inter when
+          # available; fc-match always resolves to some installed font,
+          # so the build never hard-fails on a missing font.
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq fontconfig
+          sudo apt-get install -y -qq fonts-inter \
+            || echo "fonts-inter unavailable; falling back to default font"
+          echo "OG_FONT_PATH=$(fc-match -f '%{file}' Inter)" >> "$GITHUB_ENV"
       - name: "Build"
         working-directory: ".website"
         env:


### PR DESCRIPTION
Two sequential blockers that surfaced once the audit matrix went green
(after #2849/#2854/#2857). Both are needed to actually reach `Deploy`.

## Bug 1 — `Collect metrics`: broken `mkdir`

```
cp: cannot create '.website/src/content/metrics/pkg/agent-browser.json':
  No such file or directory
```

The `Stage directory` step used a backslash line-continuation inside a
YAML **plain scalar**. YAML folds the newline to a space, producing
`mkdir -p .../env \ .../pkg`; bash reads `\ ` as an escaped space, so
both paths collapse into one bogus dir name and neither `env/` nor
`pkg/` is created.

Fix: block scalar with one `mkdir` per line.

## Bug 2 — `Build site`: no font for OG images

```
No usable font found for OG image rendering. Set OG_FONT_PATH or install Inter.
```

The OG preview-image route (`src/pages/og/[kind]/[name].png.ts`) renders
PNGs via satori, which needs a TTF. The build-site job ran plain npm on
ubuntu with no font installed.

Fix: install Inter (tolerant if the package is unavailable) and set
`OG_FONT_PATH` via `fc-match`, which always resolves to an installed
font. The route already honors `OG_FONT_PATH`.

## Verification

Dispatched the workflow from this branch (audit cache warm):
- Bug 1 fix confirmed: **`Collect metrics` → success** (was the prior
  failure).
- Bug 2 fix being verified in a follow-up dispatch.

With both, `Collect metrics → Build site → Deploy` should complete and
publish the site.