### PR TITLE
feat(pkgs): add skills-temporal-developer

### DIFF
--- a/.flox/pkgs/skills-temporal-developer/default.nix
+++ b/.flox/pkgs/skills-temporal-developer/default.nix
@@ -1,0 +1,69 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+let
+  data = builtins.fromJSON (builtins.readFile ./hashes.json);
+
+  src = fetchFromGitHub {
+    owner = "temporalio";
+    repo = "skill-temporal-developer";
+    rev = data.rev;
+    hash = data.srcHash;
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "skills-temporal-developer";
+  version = data.version;
+  inherit src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Upstream ships a single skill: SKILL.md at the repo root
+    # plus a references/ tree it links into (references/core/*.md
+    # and per-language go/, python/, java/, dotnet/, typescript/,
+    # ruby/). SKILL.md's links are relative, so the references/
+    # tree must travel with it or every reference breaks. Install
+    # the whole thing under skills/temporal-developer/ for both
+    # Claude Code and OpenCode, where claude-managed (pulled in via
+    # flox/claude) auto-discovers it on activate.
+    if [ ! -f "$src/SKILL.md" ]; then
+      echo "error: SKILL.md not found in skill-temporal-developer" >&2
+      exit 1
+    fi
+
+    for dest in \
+      "$out/share/claude-code/skills/temporal-developer" \
+      "$out/share/opencode/skills/temporal-developer"; do
+      mkdir -p "$dest"
+      cp "$src/SKILL.md" "$dest/SKILL.md"
+      if [ -d "$src/references" ]; then
+        cp -r "$src/references" "$dest/references"
+      fi
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Temporal Developer skill for Claude Code and OpenCode "
+      + "— build, debug, and manage Temporal workflows, "
+      + "activities, and workers across Python, TypeScript, Go, "
+      + "Java, .NET, and Ruby.";
+    homepage = "https://github.com/temporalio/skill-temporal-developer";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/skills-temporal-developer/hashes.json
+++ b/.flox/pkgs/skills-temporal-developer/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.5.0",
+  "rev": "16bc5715a1a9fd0daa7cd58e538c265c3310ada2",
+  "srcHash": "sha256-rDuPGJDyUQdiMH/ObDmlrrXmWkngy5dflw1Ju7bCZgo="
+}

--- a/.flox/pkgs/skills-temporal-developer/meta.yaml
+++ b/.flox/pkgs/skills-temporal-developer/meta.yaml
@@ -1,0 +1,24 @@
+kind: pkg
+subkind: skill
+name: skills-temporal-developer
+title: Temporal Developer
+skill_for: claude-code
+publisher: flox
+tagline: >
+  Temporal Developer skill for Claude Code and OpenCode.
+category: ai
+ai_role: tooling
+tags: [claude-code, skill, temporal, workflow, durable-execution]
+status: beta
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    skills-temporal-developer.pkg-path = "flox/skills-temporal-developer"
+    skills-temporal-developer.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/skills-temporal-developer
+  floxhub: https://hub.flox.dev/flox/skills-temporal-developer

--- a/.flox/pkgs/skills-temporal-developer/publish.json
+++ b/.flox/pkgs/skills-temporal-developer/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/skills-temporal-developer/upgrade.sh
+++ b/.flox/pkgs/skills-temporal-developer/upgrade.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="temporalio"
+REPO="skill-temporal-developer"
+
+current_version=$(jq -r '.version // ""' "$HASHES_FILE")
+
+# Upstream ships real tagged releases with a matching `version`
+# field in SKILL.md frontmatter, so pin to the latest release tag
+# rather than chasing the default branch.
+release_json=$(curl -sfL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$OWNER/$REPO/releases/latest")
+tag=$(echo "$release_json" | jq -r '.tag_name')
+
+if [ -z "$tag" ] || [ "$tag" = "null" ]; then
+  echo "Failed to resolve latest release for $OWNER/$REPO" >&2
+  exit 1
+fi
+
+new_version="${tag#v}"
+
+# Resolve the tag to a full commit SHA. Prefer the dereferenced
+# (^{}) object so annotated tags resolve to their commit.
+rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/tags/$tag^{}" | awk '{print $1}')
+if [ -z "$rev" ]; then
+  rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+    "refs/tags/$tag" | awk '{print $1}')
+fi
+
+if [ -z "$rev" ]; then
+  echo "Failed to resolve tag $tag to a commit" >&2
+  exit 1
+fi
+
+echo "Current: $current_version"
+echo "Latest:  $new_version ($tag)"
+
+if [ "$current_version" = "$new_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating skills-temporal-developer to $new_version"
+
+# Prefetch the source tarball and compute SRI hash.
+sha256_base32=$(nix-prefetch-url --unpack \
+  "https://github.com/$OWNER/$REPO/archive/$rev.tar.gz")
+sri_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$sha256_base32")
+
+jq -n \
+  --arg v "$new_version" \
+  --arg r "$rev" \
+  --arg h "$sri_hash" \
+  '{version: $v, rev: $r, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Wrote $HASHES_FILE:"
+cat "$HASHES_FILE"


### PR DESCRIPTION
## What

Packages the [Temporal Developer skill](https://github.com/temporalio/skill-temporal-developer)
(pinned to release `v0.5.0`) as a custom flox package for Claude Code and
OpenCode.

Follows the established `skills-shipshit` GitHub-sourced pattern:

- `default.nix` — `fetchFromGitHub`, copies `SKILL.md` **and** its
  `references/` tree into `share/{claude-code,opencode}/skills/temporal-developer/`,
  where `claude-managed` auto-discovers it on activate. The references tree
  must travel with `SKILL.md` because its links are relative.
- `hashes.json` — pinned `version` / `rev` / `srcHash` (release `v0.5.0`).
- `upgrade.sh` — tracks the latest GitHub **release tag** (upstream ships
  real releases with a matching `version` in frontmatter).
- `meta.yaml` / `publish.json` — catalog metadata, 4 systems.

Frontmatter is already agentskills.io-compliant (`name` / `description` /
`version`), so no frontmatter fixup is needed.

## Notes

- The `temporal-demo` env wiring lands in a **follow-up PR** once this package
  is published to the catalog for all systems.
- `aarch64-darwin` and `x86_64-darwin` were published manually during testing;
  `ci_pkgs.yml` publishes the `*-linux` artifacts on merge to `main`.

## Verification

- `nix-build` succeeds; output has `SKILL.md` + 88 reference files under both
  `claude-code` and `opencode` skill dirs.
- `upgrade.sh` correctly reports "Already up to date" at `v0.5.0`.

Refs AI-137

🤖 Generated with [Claude Code](https://claude.com/claude-code)