### PR TITLE
feat(pkgs): add sfw (Socket Firewall Free) [AI-206]

### DIFF
--- a/.flox/pkgs/sfw/default.nix
+++ b/.flox/pkgs/sfw/default.nix
@@ -1,0 +1,97 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  autoPatchelfHook,
+  gcc-unwrapped,
+  versionCheckHook,
+  writableTmpDirAsHomeHook,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version hashes;
+
+  platformMap = {
+    aarch64-darwin = "sfw-free-macos-arm64";
+    x86_64-darwin = "sfw-free-macos-x86_64";
+    aarch64-linux = "sfw-free-linux-arm64";
+    x86_64-linux = "sfw-free-linux-x86_64";
+  };
+
+  platform = stdenv.hostPlatform.system;
+  asset = platformMap.${platform} or (throw "Unsupported system: ${platform}");
+in
+stdenv.mkDerivation {
+  pname = "sfw";
+  inherit version;
+
+  src = fetchurl {
+    url =
+      "https://github.com/SocketDev/sfw-free/releases/download/"
+      + "v${version}/${asset}";
+    hash = hashes.${platform};
+  };
+
+  shims = ./shims;
+
+  dontUnpack = true;
+  # The release binary bundles a JS runtime; stripping can break it.
+  dontStrip = true;
+
+  nativeBuildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    autoPatchelfHook
+  ];
+
+  buildInputs = lib.optionals stdenv.hostPlatform.isLinux [
+    gcc-unwrapped.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 $src $out/bin/sfw
+
+    # Per-ecosystem PATH shims. Consumers opt in by prepending
+    # $FLOX_ENV/libexec/sfw-shims to their PATH (e.g. in [hook]
+    # on-activate), which transparently routes each package-manager
+    # call through `sfw` in interactive shells, scripts, sub-processes,
+    # and CI alike.
+    install -Dm755 $shims/sfw-shim $out/libexec/sfw-shims/sfw-shim
+    for cmd in npm yarn pnpm pip uv cargo; do
+      ln -s sfw-shim "$out/libexec/sfw-shims/$cmd"
+    done
+
+    # Sourceable helpers for [profile.bash] / [profile.zsh] that keep the
+    # shim dir at the front of PATH even after a third-party activate
+    # script (e.g. a Python venv) prepends its own bin.
+    install -Dm644 $shims/activate.bash $out/libexec/sfw-shims/activate.bash
+    install -Dm644 $shims/activate.zsh $out/libexec/sfw-shims/activate.zsh
+
+    runHook postInstall
+  '';
+
+  doInstallCheck = true;
+  nativeInstallCheckInputs = [
+    versionCheckHook
+    writableTmpDirAsHomeHook
+  ];
+  versionCheckKeepEnvironment = [ "HOME" ];
+
+  meta = {
+    description = "Socket Firewall Free - wraps your package manager to prevent installation of malicious packages";
+    homepage = "https://github.com/SocketDev/sfw-free";
+    changelog = "https://github.com/SocketDev/sfw-free/releases/tag/v${version}";
+    license = lib.licenses.unfree;
+    sourceProvenance = with lib.sourceTypes; [
+      binaryNativeCode
+    ];
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+    mainProgram = "sfw";
+  };
+}

--- a/.flox/pkgs/sfw/hashes.json
+++ b/.flox/pkgs/sfw/hashes.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.12.0",
+  "hashes": {
+    "aarch64-darwin": "sha256-MZrrqT1eV8LbaNZwnloEqhIuMmstlaJ8EHTQqExWcDE=",
+    "aarch64-linux": "sha256-WYyNGcgIMu9cp/2wqfw1wEWEf9AoiRJqcRXANFpHjaM=",
+    "x86_64-darwin": "sha256-sF/KJci6E/rQGhbwW5nSG4Zlkca0b5xmL2i6MSC1obM=",
+    "x86_64-linux": "sha256-UYJPAqJC+JLGHEIiPgW36Cu2JHYjN/Amr8KsIp/8rec="
+  }
+}

--- a/.flox/pkgs/sfw/meta.yaml
+++ b/.flox/pkgs/sfw/meta.yaml
@@ -1,0 +1,31 @@
+kind: pkg
+subkind: plain
+name: sfw
+title: Socket Firewall
+publisher: flox
+tagline: >
+  Socket Firewall Free — wraps your package manager to block
+  installation of malicious packages.
+category: tool
+tags: [security, supply-chain, npm, pip, cargo, firewall]
+stack: [typescript]
+featured: false
+combines_well_with:
+  - pkg:claude-code
+  - env:python-uv
+  - env:javascript-node
+status: stable
+license: Unfree
+upstream:
+  name: Socket Firewall Free
+  url: https://github.com/SocketDev/sfw-free
+  license: Unfree
+maintainer: "@rok"
+install:
+  pkg: |
+    [install]
+    sfw.pkg-path = "flox/sfw"
+    sfw.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/sfw
+  floxhub: https://hub.flox.dev/flox/sfw

--- a/.flox/pkgs/sfw/publish.json
+++ b/.flox/pkgs/sfw/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/sfw/shims/activate.bash
+++ b/.flox/pkgs/sfw/shims/activate.bash
@@ -1,0 +1,20 @@
+# Source from your env's [profile.bash]:
+#   source "$FLOX_ENV/libexec/sfw-shims/activate.bash"
+_sfw_shim_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+case ":$PATH:" in
+  *":$_sfw_shim_dir:"*) ;;
+  *) export PATH="$_sfw_shim_dir:$PATH" ;;
+esac
+_sfw_ensure_shim_path() {
+  case ":$PATH:" in
+    "$_sfw_shim_dir:"*) return ;;
+  esac
+  local cleaned=":$PATH:"
+  cleaned="${cleaned//:$_sfw_shim_dir:/:}"
+  cleaned="${cleaned#:}"; cleaned="${cleaned%:}"
+  export PATH="$_sfw_shim_dir:$cleaned"
+}
+case ";${PROMPT_COMMAND:-};" in
+  *";_sfw_ensure_shim_path;"*) ;;
+  *) PROMPT_COMMAND="_sfw_ensure_shim_path;${PROMPT_COMMAND:-}" ;;
+esac

--- a/.flox/pkgs/sfw/shims/activate.zsh
+++ b/.flox/pkgs/sfw/shims/activate.zsh
@@ -1,0 +1,22 @@
+# Source from your env's [profile.zsh]:
+#   source "$FLOX_ENV/libexec/sfw-shims/activate.zsh"
+# Use logical path (no :A symlink resolution) so this matches the
+# $FLOX_ENV/libexec/... form a consumer's PATH actually has.
+_sfw_shim_dir="$(cd "${${(%):-%N}:h}" && pwd)"
+case ":$PATH:" in
+  *":$_sfw_shim_dir:"*) ;;
+  *) export PATH="$_sfw_shim_dir:$PATH" ;;
+esac
+_sfw_ensure_shim_path() {
+  case ":$PATH:" in
+    "$_sfw_shim_dir:"*) return ;;
+  esac
+  local cleaned=":$PATH:"
+  cleaned="${cleaned//:$_sfw_shim_dir:/:}"
+  cleaned="${cleaned#:}"; cleaned="${cleaned%:}"
+  export PATH="$_sfw_shim_dir:$cleaned"
+}
+autoload -Uz add-zsh-hook 2>/dev/null
+if (( $+functions[add-zsh-hook] )); then
+  add-zsh-hook precmd _sfw_ensure_shim_path
+fi

--- a/.flox/pkgs/sfw/shims/sfw-shim
+++ b/.flox/pkgs/sfw/shims/sfw-shim
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Routes calls through `sfw` for Socket Firewall protection. Multiple
+# package-manager names are symlinked to this single script; basename
+# is used to dispatch to the right real binary.
+shim_dir="$(cd "$(dirname "$0")" && pwd)"
+cmd_name="$(basename "$0")"
+real=""
+IFS=:; for d in $PATH; do
+  [ "$d" = "$shim_dir" ] && continue
+  if [ -x "$d/$cmd_name" ]; then real="$d/$cmd_name"; break; fi
+done
+if [ -z "$real" ]; then
+  echo "sfw-shim: real $cmd_name not found on PATH" >&2
+  exit 127
+fi
+# Recursion guard: if sfw re-execs us via PATH, just run the real binary.
+if [ -n "${_SFW_WRAPPING:-}" ]; then
+  exec "$real" "$@"
+fi
+export _SFW_WRAPPING=1
+exec sfw "$real" "$@"

--- a/.flox/pkgs/sfw/upgrade.sh
+++ b/.flox/pkgs/sfw/upgrade.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+current_version=$(jq -r '.version' "$HASHES_FILE")
+latest_tag=$(curl -sfL \
+  https://api.github.com/repos/SocketDev/sfw-free/releases/latest \
+  | jq -r '.tag_name')
+latest_version="${latest_tag#v}"
+
+echo "Current: $current_version, Latest: $latest_version"
+
+if [ "$current_version" = "$latest_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating sfw from $current_version to $latest_version"
+
+declare -A PLATFORMS=(
+  ["aarch64-darwin"]="sfw-free-macos-arm64"
+  ["aarch64-linux"]="sfw-free-linux-arm64"
+  ["x86_64-darwin"]="sfw-free-macos-x86_64"
+  ["x86_64-linux"]="sfw-free-linux-x86_64"
+)
+
+hashes_json="{}"
+for system in "${!PLATFORMS[@]}"; do
+  asset="${PLATFORMS[$system]}"
+  url="https://github.com/SocketDev/sfw-free/releases/download/v$latest_version/$asset"
+  echo "  fetching $system"
+  hash=$(nix-prefetch-url "$url" 2>/dev/null)
+  sri=$(nix hash convert --hash-algo sha256 --to sri "$hash")
+  echo "    $system: $sri"
+  hashes_json=$(echo "$hashes_json" \
+    | jq --arg p "$system" --arg h "$sri" '.[$p] = $h')
+done
+
+jq -n \
+  --arg v "$latest_version" \
+  --argjson h "$hashes_json" \
+  '{version: $v, hashes: ($h | to_entries | sort_by(.key) | from_entries)}' \
+  > "$HASHES_FILE"
+
+echo "Updated to $latest_version"


### PR DESCRIPTION
## Summary

Packages SocketDev's [Socket Firewall Free](https://github.com/SocketDev/sfw-free) as a custom package publishable to **`flox/sfw`**.

Restructures the upstream [`jbayer/flox-sfw`](https://github.com/jbayer/flox-sfw) **manifest build** into a **NEF (nix expression) build** under `.flox/pkgs/sfw/`, matching this repo's custom-package convention.

This PR is **package only** — the demo environments will follow in a separate PR.

## What it does

- `default.nix` — fetches the prebuilt `sfw` binary per-platform via `fetchurl`; `autoPatchelfHook` + `gcc-unwrapped.lib` on Linux (binary needs `libstdc++`/`libgcc_s`), `dontStrip` (bundled JS runtime), `versionCheckHook` for an install-time smoke test.
- `shims/` — the transparent PATH shims (`npm`, `yarn`, `pnpm`, `pip`, `uv`, `cargo`) plus `activate.{bash,zsh}` helpers, ported verbatim from the upstream packaging. Consumers opt in by prepending `$FLOX_ENV/libexec/sfw-shims` to `PATH`.
- `upgrade.sh` — GitHub-releases auto-bump (modeled on `forgecode`).
- `publish.json` — `{"org": "flox"}`, all four systems.
- `meta.yaml` — website/catalog registration.

## Changes vs. upstream

- Bumped **1.11.0 → 1.12.0** (latest).
- Added **`x86_64-darwin`** — SocketDev now ships a `macos-x86_64` asset, so all four systems are covered (upstream had three).
- Publishes under the `flox` org (`flox/sfw`) instead of `jbayer/sfw`.

## Verification

- `flox build sfw` on aarch64-darwin builds clean; `versionCheckHook` passes (`Socket Firewall Free, version 1.12.0`).
- Output contains `bin/sfw`, the six shim symlinks, and the activate helpers.
- Shim basename dispatch tested — resolves and execs the real binary.
- `upgrade.sh` runs and reports up-to-date.

Linux builds run in CI via remote builders (same path `amp`/`forgecode` already take).