### PR TITLE
feat(website): add "memory" ai_role

### DIFF
--- a/.website/src/components/AiRoleFilter.tsx
+++ b/.website/src/components/AiRoleFilter.tsx
@@ -6,6 +6,7 @@ const LABELS: Record<AiRole | "all", string> = {
   agent: "Agent",
   "llm-runtime": "LLM runtime",
   rag: "RAG",
+  memory: "Memory",
   orchestrator: "Orchestrator",
   tooling: "Tooling",
   ide: "IDE",

--- a/.website/src/content.config.ts
+++ b/.website/src/content.config.ts
@@ -43,7 +43,7 @@ const baseFields = {
   summary: z.array(z.string()).default([]),
   category: z.enum(["ai","language","database","service","tool","runtime"]),
   ai_role: z
-    .enum(["agent","llm-runtime","rag","orchestrator","tooling","ide"])
+    .enum(["agent","llm-runtime","rag","memory","orchestrator","tooling","ide"])
     .optional(),
   tags: z.array(z.string()).default([]),
   stack: z.array(z.string()).default([]),

--- a/.website/src/lib/kindNames.ts
+++ b/.website/src/lib/kindNames.ts
@@ -8,6 +8,7 @@ export const AI_ROLES = [
   "agent",
   "llm-runtime",
   "rag",
+  "memory",
   "orchestrator",
   "tooling",
   "ide",


### PR DESCRIPTION
## What

Adds a distinct `memory` value to the `ai_role` enum used by the
website content collection.

## Why

The `honcho` package (merged in #2990) sets `ai_role: memory` — it's
memory infrastructure for agents, semantically distinct from `rag`.
The website schema only allowed `agent | llm-runtime | rag |
orchestrator | tooling | ide`, so the post-merge **Website / Build
site** job failed:

```
[InvalidContentEntryDataError] packages → honcho data does not match collection schema.
ai_role: Invalid enum value. Expected '...', received 'memory'
```

The package PR didn't catch this because the website job only runs on
push to `main`.

## Changes

- `content.config.ts` — extend the zod `ai_role` enum.
- `kindNames.ts` — extend `AI_ROLES` (drives the filter list + the
  `AiRole` type).
- `AiRoleFilter.tsx` — add the `Memory` display label.