### PR TITLE
fix: repair failing package upgrade jobs

### DIFF
--- a/.flox/pkgs/agent-browser/default.nix
+++ b/.flox/pkgs/agent-browser/default.nix
@@ -8,7 +8,7 @@
   makeBinaryWrapper,
   nodejs-slim,
   pnpmConfigHook,
-  pnpm_10,
+  pnpm_11,
   rustPlatform,
 }:
 
@@ -47,14 +47,14 @@ let
 
     nativeBuildInputs = [
       nodejs-slim
-      pnpm_10
+      pnpm_11
       pnpmConfigHook
     ];
 
     pnpmDeps = fetchPnpmDeps {
       pname = "agent-browser-dashboard";
       inherit version src;
-      pnpm = pnpm_10;
+      pnpm = pnpm_11;
       hash = pnpmDepsHash;
       fetcherVersion = 3;
     };

--- a/.flox/pkgs/agent-browser/hashes.json
+++ b/.flox/pkgs/agent-browser/hashes.json
@@ -1,6 +1,6 @@
 {
-  "version": "0.27.0",
-  "srcHash": "sha256-c+AJAXMX88t+zzFsEAtFJDjDY5EbhmEyMRGFL4t63nE=",
-  "cargoHash": "sha256-2u7yokHCxIVq16370Mg+n5kf03yUDYJmctFxN1fnaAA=",
-  "pnpmDepsHash": "sha256-xNxNFvaw5sdX0ZaBIUf449wIHQNifMPK3I+qi+yp+UU="
+  "version": "0.27.1",
+  "srcHash": "sha256-eLtN4ErLaSetEDb/6RMqILDnVua8QnEN6r1VgbwTQBw=",
+  "cargoHash": "sha256-tZtnCKhPFW9lpyj6JIEwYcEV1ZEXSCYlyxMkYi24Hqw=",
+  "pnpmDepsHash": "sha256-hSmlZvGlnvSWpCki1eImUNEe1myfbC3eDVcX07k0Bm4="
 }

--- a/.flox/pkgs/agent-browser/upgrade.sh
+++ b/.flox/pkgs/agent-browser/upgrade.sh
@@ -5,8 +5,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HASHES_FILE="$SCRIPT_DIR/hashes.json"
 
+auth_header=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
+
 current_version=$(jq -r '.version' "$HASHES_FILE")
-latest_tag=$(curl -sfL \
+latest_tag=$(curl -sfL "${auth_header[@]}" \
   https://api.github.com/repos/vercel-labs/agent-browser/releases/latest \
   | jq -r '.tag_name')
 latest_version="${latest_tag#v}"
@@ -26,47 +31,78 @@ src_sri=$(nix hash convert --hash-algo sha256 --to sri "$src_hash")
 echo "  srcHash: $src_sri"
 
 dummy="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
-jq -n \
-  --arg v "$latest_version" \
-  --arg s "$src_sri" \
-  --arg c "$dummy" \
-  --arg p "$dummy" \
-  '{version: $v, srcHash: $s, cargoHash: $c, pnpmDepsHash: $p}' > "$HASHES_FILE"
+
+write_hashes() {
+  jq -n \
+    --arg v "$latest_version" \
+    --arg s "$src_sri" \
+    --arg c "$cargo_hash" \
+    --arg p "$pnpm_hash" \
+    '{version: $v, srcHash: $s, cargoHash: $c, pnpmDepsHash: $p}' \
+    > "$HASHES_FILE"
+}
+
+# Extract the `got:` hash from the mismatch block whose fixed-output
+# derivation name contains the given substring. Keying on the drv name
+# (not log position) is required because the pnpm-deps and cargo
+# vendor-staging FODs build in parallel and either can surface first.
+extract_got() {
+  awk -v pat="$1" '
+    /hash mismatch in fixed-output derivation/ { cur = ($0 ~ pat) ? 1 : 0; next }
+    cur && /got:/ { print $NF; cur = 0 }
+  ' "$2"
+}
+
+backup=$(mktemp)
+cp "$HASHES_FILE" "$backup"
+build_log=$(mktemp)
+cleanup() { rm -f "$backup" "$build_log"; }
+trap cleanup EXIT
+
+# The dashboard's pnpm deps (`*-pnpm-deps`) and the Rust crate's cargo
+# vendor (`*-vendor-staging`) are independent fixed-output derivations.
+# Nix stops at the first one that fails, so a single build may reveal
+# only one real hash. Loop: feed back each hash we learn until a build
+# completes with no remaining mismatch.
+pnpm_hash="$dummy"
+cargo_hash="$dummy"
 
 echo "Building with dummy hashes to compute real ones..."
-# pnpm deps build first; capture both hashes from successive build runs.
-pnpm_hash=$(flox build agent-browser 2>&1 \
-  | grep -A2 "hash mismatch in fixed-output derivation" \
-  | grep "got:" | head -1 | awk '{print $NF}') || true
+for attempt in 1 2 3 4; do
+  write_hashes
+  if flox build agent-browser > "$build_log" 2>&1; then
+    echo "Build succeeded with resolved hashes"
+    break
+  fi
 
-if [ -z "$pnpm_hash" ]; then
-  echo "ERROR: could not extract pnpmDepsHash from build output" >&2
+  changed=0
+  new_pnpm=$(extract_got 'pnpm-deps' "$build_log")
+  new_cargo=$(extract_got 'vendor-staging' "$build_log")
+  if [ -n "$new_pnpm" ] && [ "$new_pnpm" != "$pnpm_hash" ]; then
+    pnpm_hash="$new_pnpm"
+    echo "  pnpmDepsHash: $pnpm_hash"
+    changed=1
+  fi
+  if [ -n "$new_cargo" ] && [ "$new_cargo" != "$cargo_hash" ]; then
+    cargo_hash="$new_cargo"
+    echo "  cargoHash: $cargo_hash"
+    changed=1
+  fi
+
+  if [ "$changed" -eq 0 ]; then
+    echo "ERROR: build failed without a resolvable hash mismatch." >&2
+    tail -30 "$build_log" >&2
+    cp "$backup" "$HASHES_FILE"
+    exit 1
+  fi
+done
+
+if [ "$pnpm_hash" = "$dummy" ] || [ "$cargo_hash" = "$dummy" ]; then
+  echo "ERROR: failed to resolve both hashes after retries." >&2
+  tail -30 "$build_log" >&2
+  cp "$backup" "$HASHES_FILE"
   exit 1
 fi
-echo "  pnpmDepsHash: $pnpm_hash"
 
-jq -n \
-  --arg v "$latest_version" \
-  --arg s "$src_sri" \
-  --arg c "$dummy" \
-  --arg p "$pnpm_hash" \
-  '{version: $v, srcHash: $s, cargoHash: $c, pnpmDepsHash: $p}' > "$HASHES_FILE"
-
-cargo_hash=$(flox build agent-browser 2>&1 \
-  | grep -A2 "hash mismatch in fixed-output derivation" \
-  | grep "got:" | head -1 | awk '{print $NF}') || true
-
-if [ -z "$cargo_hash" ]; then
-  echo "ERROR: could not extract cargoHash from build output" >&2
-  exit 1
-fi
-echo "  cargoHash: $cargo_hash"
-
-jq -n \
-  --arg v "$latest_version" \
-  --arg s "$src_sri" \
-  --arg c "$cargo_hash" \
-  --arg p "$pnpm_hash" \
-  '{version: $v, srcHash: $s, cargoHash: $c, pnpmDepsHash: $p}' > "$HASHES_FILE"
-
+write_hashes
 echo "Updated to $latest_version"

--- a/.flox/pkgs/claude-code-plugin-impeccable/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-impeccable/upgrade.sh
@@ -7,11 +7,22 @@ HASHES_FILE="$SCRIPT_DIR/hashes.json"
 
 current_version=$(jq -r '.version' "$HASHES_FILE")
 
-# Upstream tags releases as `skill-vX.Y.Z`. Pull the latest such tag.
-latest_tag=$(curl -sf \
-  https://api.github.com/repos/pbakaus/impeccable/releases/latest \
-  | jq -r '.tag_name')
-latest_version="${latest_tag#skill-v}"
+# Upstream publishes multiple tag tracks (skill-v*, ext-v*, cli-v*), and
+# `releases/latest` may point at a non-skill track. List tags and pick the
+# highest `skill-v*` semver explicitly.
+auth_header=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
+latest_version=$(curl -sf "${auth_header[@]}" \
+  https://api.github.com/repos/pbakaus/impeccable/tags \
+  | jq -r '.[].name | select(startswith("skill-v")) | ltrimstr("skill-v")' \
+  | sort -V | tail -1)
+
+if [ -z "$latest_version" ]; then
+  echo "ERROR: no skill-v* tags found" >&2
+  exit 1
+fi
 
 echo "Current: $current_version, Latest: $latest_version"
 

--- a/.flox/pkgs/claude-code-plugin-official-kotlin-lsp/upgrade.sh
+++ b/.flox/pkgs/claude-code-plugin-official-kotlin-lsp/upgrade.sh
@@ -9,7 +9,13 @@ current_version=$(jq -r '.version // ""' "$HASHES_FILE")
 rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" "refs/heads/$BRANCH" | awk '{print $1}')
 if [ -z "$rev" ]; then echo "Failed to resolve $BRANCH on $OWNER/$REPO" >&2; exit 1; fi
 short_sha="${rev:0:7}"
-commit_json=$(curl -sfL -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
+# Authenticate the API call so it isn't throttled by the shared
+# unauthenticated rate limit when many upgrade jobs run in parallel.
+auth_header=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+fi
+commit_json=$(curl -sfL "${auth_header[@]}" -H "Accept: application/vnd.github+json" "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
 commit_date=$(echo "$commit_json" | jq -r '.commit.committer.date' | cut -c1-10)
 new_version="unstable-${commit_date}.${short_sha}"
 echo "Current: $current_version"

--- a/.flox/pkgs/gemini-cli/default.nix
+++ b/.flox/pkgs/gemini-cli/default.nix
@@ -91,10 +91,15 @@ buildNpmPackage (finalAttrs: {
   '';
 
   postPatch = ''
-    # Hardcode ripgrep path so ensureRgPath() returns our Nix-provided binary
-    # instead of downloading or finding a dynamically-linked one.
+    # Force ripgrep resolution to our Nix-provided binary. Upstream's
+    # resolveRipgrepPath() probes bundled vendor/ paths then the system
+    # PATH; prepend the store path as the first candidate so fileExists()
+    # always finds it, avoiding any vendored download.
     substituteInPlace packages/core/src/tools/ripGrep.ts \
-      --replace-fail "await ensureRgPath();" "'${lib.getExe ripgrep}';"
+      --replace-fail \
+        'const candidatePaths = [' \
+        'const candidatePaths = [
+      "${lib.getExe ripgrep}",'
 
     # Disable auto-update and the update nag - Nix manages updates.
     sed -i "/enableAutoUpdate: {/,/}/ s/default: true/default: false/" \

--- a/.flox/pkgs/gemini-cli/hashes.json
+++ b/.flox/pkgs/gemini-cli/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.43.0",
-  "srcHash": "sha256-UFz+CQLGbzFlpa5Mhf/frnQJWttF35URvua1QTfoaZ0=",
-  "npmDepsHash": "sha256-kz3S+EYAKYJtRAaHYsYHgsfAMxf4PZzDi4A6256FDLc="
+  "version": "0.45.1",
+  "srcHash": "sha256-XZGqZMylKQi7Cc74qvvz50UY4EIJ19bjOYOwD39L2yo=",
+  "npmDepsHash": "sha256-qlY/apF3dtRa1GeypouwT6hl7MiQpmPMBHagI4yH5bk="
 }


### PR DESCRIPTION
Fixes the 5 failing jobs in the scheduled **Upgrade Packages** run
([run 27001736190](https://github.com/flox/floxenvs/actions/runs/27001736190)).
Each had a distinct root cause; all fixes reproduced and build-verified locally.

## Fixes

### `impeccable` — wrong release track
`releases/latest` started returning the `cli-v*` track (`cli-v2.3.2`), so the
script built a bogus `skill-vcli-v2.3.2.tar.gz` URL and 404'd. Now lists
`/tags`, filters `skill-v*`, and picks the highest semver. `skill-v3.5.0` is
already installed → correctly a no-op.

### `kotlin-lsp` — unauthenticated rate limit (exit 22)
The commits API curl sent no `Authorization` header. With ~100 parallel jobs
hammering `api.github.com` it hit the shared unauthenticated rate limit and
exited 22. Now passes `GITHUB_TOKEN` (already in the job env) when present.

### `gemini-cli` 0.43.0 → 0.45.1 — stale ripgrep patch
0.45.1 replaced `ensureRgPath()` with `resolveRipgrepPath()` (probes bundled
`vendor/` paths then `PATH`). The old `--replace-fail` target was gone, so
`postPatch` aborted — surfaced misleadingly as "could not extract npmDepsHash".
Patch now prepends the Nix ripgrep store path as the first candidate so it
always resolves. Full build verified.

### `agent-browser` 0.27.0 → 0.27.1 — pnpm 11 + flaky hash extraction
- 0.27.1 bumped `engines.pnpm` to `>=11.0.0`: `pnpm_10` → `pnpm_11`.
- `upgrade.sh` rewrite: the `pnpm-deps` and cargo `vendor-staging` FODs build
  in parallel, so the old `grep "got:" | head -1` was nondeterministic and
  wrote cargo's hash into **both** slots. Extraction now keys each `got:` to
  its derivation name and loops, feeding back learned hashes until a clean
  build. The final build doubles as verification; on failure the previous
  hashes are restored. Verified by a full from-0.27.0 run (hashes matched
  byte-for-byte).

## Not addressed
`temporal-cli` 1.7.0 → 1.7.1 is blocked upstream: its `go.mod` requires
Go ≥ 1.26.3 but the flox build base ships 1.26.2 (`flox build` uses the base
nixpkgs, not this repo's flake input). Nothing to fix in-repo until the base
bumps Go.