### PR TITLE
feat(skills-video-use): package video-use skill for Claude Code

### DIFF
--- a/.flox/pkgs/skills-video-use/default.nix
+++ b/.flox/pkgs/skills-video-use/default.nix
@@ -1,0 +1,147 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  python3,
+  ffmpeg,
+}:
+
+let
+  data = builtins.fromJSON (builtins.readFile ./hashes.json);
+
+  # Everything the helpers import. timeline_view deliberately avoids
+  # librosa (wave + ffmpeg fallback), so requests/numpy/pillow is the
+  # complete set at this pin.
+  pythonEnv = python3.withPackages (ps: [
+    ps.requests
+    ps.numpy
+    ps.pillow
+  ]);
+  py = "${pythonEnv}/bin/python3";
+
+  src = fetchFromGitHub {
+    owner = "browser-use";
+    repo = "video-use";
+    rev = data.rev;
+    hash = data.srcHash;
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "skills-video-use";
+  version = data.version;
+  inherit src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # video-use is a directory skill: SKILL.md references its helpers
+    # by bare name (`transcribe.py <video>`), so the whole repo tree
+    # must ship together with SKILL.md at the root. The optional Manim
+    # engine lives at skills/manim-video; expose it as a first-class
+    # sibling skill too. Ship into every agent skills dir we support.
+    for share in \
+      "$out/share/claude-code/skills" \
+      "$out/share/opencode/skills"; do
+      mkdir -p "$share/video-use"
+      cp -r "$src"/. "$share/video-use/"
+      chmod -R u+w "$share/video-use"
+
+      mkdir -p "$share/manim-video"
+      cp -r "$src/skills/manim-video"/. "$share/manim-video/"
+      chmod -R u+w "$share/manim-video"
+    done
+
+    runHook postInstall
+  '';
+
+  # Make the Python helpers self-contained so they run correctly no
+  # matter how the agent launches them, with no host PATH assumptions:
+  #
+  #   1. Shebang -> the bundled interpreter (which carries requests,
+  #      numpy, pillow). A shebang is a comment, so it is legal even
+  #      ahead of the helpers' `from __future__` imports.
+  #   2. A re-exec shim right after `from __future__` re-launches the
+  #      script under the bundled interpreter when it was started as
+  #      `python helpers/x.py` with some other Python — before any
+  #      third-party import can fail.
+  #   3. The bare "ffmpeg"/"ffprobe" subprocess literals are rewritten
+  #      to absolute store paths, so they resolve without PATH and nix
+  #      records ffmpeg in the package closure automatically.
+  #
+  # The SKILL.md / install.md prose is patched to drop the now-stale
+  # "install ffmpeg / uv sync" steps and tell the agent the helpers are
+  # executable and self-contained.
+  postInstall = ''
+    for skill in "$out"/share/*/skills/video-use; do
+      helpers="$skill/helpers"
+
+      for f in "$helpers"/*.py; do
+        substituteInPlace "$f" \
+          --replace-quiet '"ffmpeg"'  '"${ffmpeg}/bin/ffmpeg"' \
+          --replace-quiet '"ffprobe"' '"${ffmpeg}/bin/ffprobe"'
+
+        awk -v py="${py}" '
+          NR == 1 { print "#!" py }
+          { print }
+          /^from __future__ import/ && !shim {
+            print "import os as _os, sys as _sys"
+            print "_PY = \"" py "\""
+            print "if _os.path.realpath(_sys.executable) != _os.path.realpath(_PY) and _os.path.exists(_PY):"
+            print "    _os.execv(_PY, [_PY] + _sys.argv)"
+            shim = 1
+          }
+        ' "$f" > "$f.wired"
+        mv "$f.wired" "$f"
+        chmod +x "$f"
+      done
+
+      # Reflect the packaged reality in the prose the agent reads.
+      substituteInPlace "$skill/SKILL.md" \
+        --replace-quiet \
+          '- `ffmpeg` + `ffprobe` on PATH.' \
+          '- `ffmpeg` + `ffprobe` are bundled with this package (the helpers call them by absolute path) — nothing to install.' \
+        --replace-quiet \
+          '- Python deps installed (`uv sync` or `pip install -e .` inside the repo).' \
+          '- Python deps (requests, numpy, pillow) are bundled — the helpers are executable and self-contained. Run them directly (e.g. `"$SKILL_DIR"/helpers/transcribe.py <video>`), not via `python`.'
+
+      # install.md describes a manual clone/brew/pip flow that does not
+      # apply to the flox package. Prepend a note so the agent skips it.
+      note="$skill/.install-note.md"
+      cat > "$note" <<'MD'
+> **Packaged via flox (`flox/skills-video-use`).** The clone, `uv sync`,
+> `pip install`, and `brew install ffmpeg` steps below are NOT needed:
+> ffmpeg/ffprobe and the Python deps (requests, numpy, pillow) are bundled
+> and the helpers are self-contained executables. You still need an
+> `ELEVENLABS_API_KEY` for transcription. Optional, install on first use
+> only: `yt-dlp` (URL downloads), Node.js + `npx` (HyperFrames / Remotion
+> slots), Manim + LaTeX (manim-video slots). Subtitle burn-in uses libass;
+> on a headless host install a font (e.g. DejaVu) or pass an available
+> `FontName` if Helvetica is missing.
+
+MD
+      cat "$skill/install.md" >> "$note"
+      mv "$note" "$skill/install.md"
+    done
+  '';
+
+  meta = {
+    description =
+      "video-use skill for Claude Code — edit raw footage into a "
+      + "finished cut by conversation: transcribe, cut on word "
+      + "boundaries, color grade, fade, burn subtitles, and generate "
+      + "overlay animations. Python helpers ship wired to a bundled "
+      + "interpreter (requests/numpy/pillow) and ffmpeg. Includes the "
+      + "manim-video engine sub-skill.";
+    homepage = "https://github.com/browser-use/video-use";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/skills-video-use/default.nix
+++ b/.flox/pkgs/skills-video-use/default.nix
@@ -2,8 +2,11 @@
   lib,
   stdenvNoCC,
   fetchFromGitHub,
+  makeWrapper,
   python3,
   ffmpeg,
+  manim,
+  texliveMedium,
 }:
 
 let
@@ -19,6 +22,19 @@ let
   ]);
   py = "${pythonEnv}/bin/python3";
 
+  # The manim-video sub-skill drives the Manim CE engine. Bundle a TeX
+  # distribution carrying the packages Manim's MathTex/Tex templates and
+  # the dvisvgm step need, so equation rendering works headless. The
+  # skill is consumed by installing this package into a flox env, so the
+  # `manim` wrapper we drop in $out/bin lands on PATH — which is exactly
+  # how the sub-skill invokes it (`manim -ql script.py Scene`).
+  texEnv = texliveMedium.withPackages (ps: [
+    ps.standalone
+    ps.preview
+    ps.doublestroke
+    ps.dvisvgm
+  ]);
+
   src = fetchFromGitHub {
     owner = "browser-use";
     repo = "video-use";
@@ -31,11 +47,21 @@ stdenvNoCC.mkDerivation {
   version = data.version;
   inherit src;
 
+  nativeBuildInputs = [ makeWrapper ];
+
   dontConfigure = true;
   dontBuild = true;
 
   installPhase = ''
     runHook preInstall
+
+    # Bundle the Manim engine on PATH for the manim-video sub-skill:
+    # the real manim plus a TeX distro and ffmpeg for MathTex + dvisvgm
+    # + scene stitching. Lands in $out/bin, which is on PATH once the
+    # package is installed into the consumer's flox env.
+    mkdir -p "$out/bin"
+    makeWrapper "${manim}/bin/manim" "$out/bin/manim" \
+      --prefix PATH : "${lib.makeBinPath [ texEnv ffmpeg ]}"
 
     # video-use is a directory skill: SKILL.md references its helpers
     # by bare name (`transcribe.py <video>`), so the whole repo tree
@@ -124,6 +150,17 @@ stdenvNoCC.mkDerivation {
 MD
       cat "$skill/install.md" >> "$note"
       mv "$note" "$skill/install.md"
+    done
+
+    # The Manim engine is bundled on PATH; reflect that in every copy of
+    # the manim-video prereqs (it ships both as a top-level sibling skill
+    # and nested under video-use/skills/manim-video).
+    for md in "$out"/share/*/skills/manim-video/SKILL.md \
+              "$out"/share/*/skills/video-use/skills/manim-video/SKILL.md; do
+      substituteInPlace "$md" \
+        --replace-quiet \
+          'Run `scripts/setup.sh` to verify all dependencies. Requires: Python 3.10+, Manim Community Edition v0.20+ (`pip install manim`), LaTeX (`texlive-full` on Linux, `mactex` on macOS), and ffmpeg. Reference docs tested against Manim CE v0.20.1.' \
+          'Manim CE v0.20.1, a bundled TeX distribution (for `MathTex`/`Tex` via dvisvgm), and ffmpeg are bundled with this package — the `manim` command is on PATH, nothing to install. `scripts/setup.sh` still works as a sanity check.'
     done
   '';
 

--- a/.flox/pkgs/skills-video-use/default.nix
+++ b/.flox/pkgs/skills-video-use/default.nix
@@ -35,6 +35,22 @@ let
     ps.dvisvgm
   ]);
 
+  # Bundle the Manim binary only on Linux. Manim drags
+  # moderngl-window -> pyglet -> ffmpeg-full, and in the flox catalog
+  # base set ffmpeg-full enables the HEVC encoder kvazaar, whose check
+  # phase fails to run in the macOS build sandbox (the same
+  # invalid-signature / SIGKILL issue nixpkgs hits with Darwin ffmpeg).
+  # Catalog artifacts are prebuilt, so the dep cannot be reliably patched
+  # out via an override. On Linux the whole closure builds cleanly, so we
+  # ship `manim` on PATH there; on Darwin the skill still ships and the
+  # prose tells the agent to install manim per slot.
+  bundleManim = stdenvNoCC.hostPlatform.isLinux;
+  manimNote =
+    if bundleManim then
+      "Manim CE v0.20.1, a bundled TeX distribution (for `MathTex`/`Tex` via dvisvgm), and ffmpeg are bundled with this package — the `manim` command is on PATH, nothing to install. `scripts/setup.sh` still works as a sanity check."
+    else
+      "On macOS the Manim engine is not bundled (the upstream HEVC-encoder dependency fails to build in the flox sandbox on Darwin). Install it per slot when needed: `pip install manim` plus a LaTeX distribution (`brew install --cask mactex-no-gui`). ffmpeg ships with this package. `scripts/setup.sh` verifies the slot.";
+
   src = fetchFromGitHub {
     owner = "browser-use";
     repo = "video-use";
@@ -55,13 +71,16 @@ stdenvNoCC.mkDerivation {
   installPhase = ''
     runHook preInstall
 
-    # Bundle the Manim engine on PATH for the manim-video sub-skill:
-    # the real manim plus a TeX distro and ffmpeg for MathTex + dvisvgm
-    # + scene stitching. Lands in $out/bin, which is on PATH once the
-    # package is installed into the consumer's flox env.
-    mkdir -p "$out/bin"
-    makeWrapper "${manim}/bin/manim" "$out/bin/manim" \
-      --prefix PATH : "${lib.makeBinPath [ texEnv ffmpeg ]}"
+    # Bundle the Manim engine on PATH for the manim-video sub-skill (Linux
+    # only — see bundleManim above): the real manim plus a TeX distro and
+    # ffmpeg for MathTex + dvisvgm + scene stitching. Lands in $out/bin,
+    # which is on PATH once the package is installed into the consumer's
+    # flox env.
+    ${lib.optionalString bundleManim ''
+      mkdir -p "$out/bin"
+      makeWrapper "${manim}/bin/manim" "$out/bin/manim" \
+        --prefix PATH : "${lib.makeBinPath [ texEnv ffmpeg ]}"
+    ''}
 
     # video-use is a directory skill: SKILL.md references its helpers
     # by bare name (`transcribe.py <video>`), so the whole repo tree
@@ -160,7 +179,7 @@ MD
       substituteInPlace "$md" \
         --replace-quiet \
           'Run `scripts/setup.sh` to verify all dependencies. Requires: Python 3.10+, Manim Community Edition v0.20+ (`pip install manim`), LaTeX (`texlive-full` on Linux, `mactex` on macOS), and ffmpeg. Reference docs tested against Manim CE v0.20.1.' \
-          'Manim CE v0.20.1, a bundled TeX distribution (for `MathTex`/`Tex` via dvisvgm), and ffmpeg are bundled with this package — the `manim` command is on PATH, nothing to install. `scripts/setup.sh` still works as a sanity check.'
+          ${lib.escapeShellArg manimNote}
     done
   '';
 

--- a/.flox/pkgs/skills-video-use/hashes.json
+++ b/.flox/pkgs/skills-video-use/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.1.0+unstable-2026-05-15.cf12ac3",
+  "rev": "cf12ac35143caa48db76efa35b1cb439582333bb",
+  "srcHash": "sha256-uZZCN85xLDruFMpmryyLGtHzLXV8MLm8fjrJuGobrto="
+}

--- a/.flox/pkgs/skills-video-use/meta.yaml
+++ b/.flox/pkgs/skills-video-use/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: skill
+name: skills-video-use
+title: Video Use
+skill_for: claude-code
+publisher: flox
+tagline: >
+  Conversational video editor skill for Claude Code —
+  footage in, final.mp4 out.
+category: ai
+ai_role: tooling
+tags: [claude-code, skill, video, ffmpeg, subtitles]
+status: beta
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    skills-video-use.pkg-path = "flox/skills-video-use"
+    skills-video-use.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/skills-video-use
+  floxhub: https://hub.flox.dev/flox/skills-video-use

--- a/.flox/pkgs/skills-video-use/publish.json
+++ b/.flox/pkgs/skills-video-use/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/skills-video-use/upgrade.sh
+++ b/.flox/pkgs/skills-video-use/upgrade.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="browser-use"
+REPO="video-use"
+BRANCH="main"
+
+current_version=$(jq -r '.version // ""' "$HASHES_FILE")
+
+# Resolve current HEAD on main to a full SHA.
+rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/heads/$BRANCH" | awk '{print $1}')
+
+if [ -z "$rev" ]; then
+  echo "Failed to resolve $BRANCH on $OWNER/$REPO" >&2
+  exit 1
+fi
+
+short_sha="${rev:0:7}"
+
+# Committer date (YYYY-MM-DD) via the GitHub commits API.
+commit_json=$(curl -sfL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
+commit_date=$(echo "$commit_json" \
+  | jq -r '.commit.committer.date' \
+  | cut -c1-10)
+
+# video-use ships no frontmatter version, so anchor on the
+# pyproject.toml project version at this rev.
+pyproject=$(curl -sfL \
+  "https://raw.githubusercontent.com/$OWNER/$REPO/$rev/pyproject.toml")
+base_version=$(echo "$pyproject" \
+  | awk -F'"' '/^version[[:space:]]*=/ { print $2; exit }')
+
+if [ -z "$base_version" ]; then
+  echo "Failed to extract version from pyproject.toml" >&2
+  exit 1
+fi
+
+new_version="${base_version}+unstable-${commit_date}.${short_sha}"
+
+echo "Current: $current_version"
+echo "Latest:  $new_version"
+
+if [ "$current_version" = "$new_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating skills-video-use to $new_version"
+
+# Prefetch the source tarball and compute SRI hash.
+sha256_base32=$(nix-prefetch-url --unpack \
+  "https://github.com/$OWNER/$REPO/archive/$rev.tar.gz")
+sri_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$sha256_base32")
+
+jq -n \
+  --arg v "$new_version" \
+  --arg r "$rev" \
+  --arg h "$sri_hash" \
+  '{version: $v, rev: $r, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Wrote $HASHES_FILE:"
+cat "$HASHES_FILE"


### PR DESCRIPTION
## What

Packages [browser-use/video-use](https://github.com/browser-use/video-use) as a flox skill package: `.flox/pkgs/skills-video-use/`.

video-use is a conversation-driven video editor skill for Claude Code — drop raw footage in a folder, chat, get `final.mp4` back. Cuts filler/dead space, color grades, fades audio at cuts, burns subtitles, generates overlay animations.

## Packaging notes

- **Directory skill** — SKILL.md references its helpers by bare name (`python helpers/transcribe.py`), so the whole repo tree ships together with SKILL.md at the root.
- Ships into both `share/claude-code/skills/` and `share/opencode/skills/` as the `video-use` skill, plus the optional Manim engine as a first-class `manim-video` sibling skill.
- Pinned to upstream `main` at `cf12ac3` (no release tags); version anchors on the `pyproject.toml` project version, `upgrade.sh` rolls it forward.
- Runtime deps (`ffmpeg`, `python`, `yt-dlp`, ElevenLabs API key) are the consumer's concern — the package only delivers skill files.

## Verification

- `nix-build` succeeds on the package
- Output layout verified: `video-use/SKILL.md` + `helpers/` siblings present, `manim-video` sibling skill present
- `scripts/lint-meta.sh pkg` scores 100