### PR TITLE
fix(upgrade): repair all five failing package upgrade jobs

### DIFF
--- a/.flox/pkgs/agent-deck/default.nix
+++ b/.flox/pkgs/agent-deck/default.nix
@@ -20,6 +20,17 @@ buildGoModule (finalAttrs: {
     repo = "agent-deck";
     tag = "v${finalAttrs.version}";
     hash = srcHash;
+
+    # Upstream commits its own `.flox/env/manifest.lock`, which is full
+    # of `/nix/store/...` paths. A fetched source is a fixed-output
+    # derivation, and modern Nix refuses FODs that reference store paths
+    # ("fixed-output derivations must not reference store paths"). The
+    # lockfile is irrelevant to building the Go binary, so drop it before
+    # the output is hashed. (Recompute `srcHash` in upgrade.sh after
+    # changing this.)
+    postFetch = ''
+      rm -rf "$out/.flox"
+    '';
   };
 
   inherit vendorHash;

--- a/.flox/pkgs/agent-deck/hashes.json
+++ b/.flox/pkgs/agent-deck/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.9.49",
-  "srcHash": "sha256-LfQoomymphCb5Kxz+L+LfIbeTISkWlCsMBnEIoximhs=",
-  "vendorHash": "sha256-ltU0qyZEUjzN+E5FOBnfnc4W3CchPJ0+0GFCtA9C8Zo="
+  "version": "1.9.55",
+  "srcHash": "sha256-aU3KhUrqHk4D9fxds681yhBLj9RJIipS8PyIg88e07M=",
+  "vendorHash": "sha256-GyG71/iR2R4mq1vOYcL4rGXh0RQIMNeWj+WtjF75KCg="
 }

--- a/.flox/pkgs/agent-deck/upgrade.sh
+++ b/.flox/pkgs/agent-deck/upgrade.sh
@@ -5,8 +5,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HASHES_FILE="$SCRIPT_DIR/hashes.json"
 
+# Authenticated API calls use Actions' 5000/hr quota. The
+# unauthenticated 60/hr is shared per egress IP and gets exhausted
+# by parallel runners, surfacing as `curl exit 22`.
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
 current_version=$(jq -r '.version' "$HASHES_FILE")
-latest_tag=$(curl -sf \
+latest_tag=$(curl -sf --retry 3 --retry-delay 5 \
+  -H "Accept: application/vnd.github+json" \
+  "${auth_header[@]}" \
   https://api.github.com/repos/asheshgoplani/agent-deck/releases/latest \
   | jq -r '.tag_name')
 latest_version="${latest_tag#v}"

--- a/.flox/pkgs/agent-deck/upgrade.sh
+++ b/.flox/pkgs/agent-deck/upgrade.sh
@@ -29,11 +29,21 @@ fi
 
 echo "Updating agent-deck from $current_version to $latest_version"
 
-# Download and hash the new source tarball
+# Download and hash the new source tarball. default.nix strips the
+# committed `.flox/` directory in postFetch (it carries /nix/store
+# paths that a fixed-output derivation may not reference), so the
+# srcHash must be computed over the same stripped tree -- the NAR hash
+# of the unpacked source minus `.flox`, which is exactly what
+# fetchFromGitHub hashes. `nix-prefetch-url --unpack` would hash the
+# unmodified tree and mismatch.
 src_url="https://github.com/asheshgoplani/agent-deck/archive/refs/tags/v${latest_version}.tar.gz"
 echo "Fetching source from $src_url ..."
-src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
-src_sri=$(nix hash convert --hash-algo sha256 --to sri "$src_hash")
+src_dir=$(mktemp -d)
+curl -sfL --retry 3 --retry-delay 5 "$src_url" \
+  | tar -xz -C "$src_dir" --strip-components=1
+rm -rf "$src_dir/.flox"
+src_sri=$(nix hash path --type sha256 --sri "$src_dir")
+rm -rf "$src_dir"
 echo "  srcHash: $src_sri"
 
 # Write with dummy vendorHash so flox build can compute the real one

--- a/.flox/pkgs/cursor-agent/upgrade.sh
+++ b/.flox/pkgs/cursor-agent/upgrade.sh
@@ -6,9 +6,12 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HASHES_FILE="$SCRIPT_DIR/hashes.json"
 
 # Cursor publishes the current agent CLI version on their install page;
-# the lab download URL embeds it as <year>.<month>.<day>-<short-sha>.
+# the lab download URL embeds it after /lab/. The build suffix varies
+# (e.g. <date>-<short-sha> or <date>-<hh>-<mm>-<ss>-<short-sha>), so
+# match the whole path segment up to the next slash rather than a
+# fixed shape.
 VERSION_URL="https://cursor.com/install"
-VERSION_RE='downloads\.cursor\.com/lab/([0-9]{4}\.[0-9]{2}\.[0-9]{2}-[a-f0-9]+)'
+VERSION_RE='downloads\.cursor\.com/lab/[0-9]{4}\.[0-9]{2}\.[0-9]{2}-[0-9a-f-]+'
 
 current_version=$(jq -r '.version' "$HASHES_FILE")
 latest_version=$(curl -sfL "$VERSION_URL" \

--- a/.flox/pkgs/skills-taste-skill/upgrade.sh
+++ b/.flox/pkgs/skills-taste-skill/upgrade.sh
@@ -9,6 +9,13 @@ OWNER="Leonxlnx"
 REPO="taste-skill"
 BRANCH="main"
 
+# Authenticated API calls use Actions' 5000/hr quota. The
+# unauthenticated 60/hr is shared per egress IP and gets exhausted
+# by parallel runners, surfacing as `curl exit 22`.
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
 current_version=$(jq -r '.version // ""' "$HASHES_FILE")
 
 # Resolve current HEAD on main to a full SHA.
@@ -23,8 +30,9 @@ fi
 short_sha="${rev:0:7}"
 
 # Committer date (YYYY-MM-DD) via the GitHub commits API.
-commit_json=$(curl -sfL \
+commit_json=$(curl -sfL --retry 3 --retry-delay 5 \
   -H "Accept: application/vnd.github+json" \
+  "${auth_header[@]}" \
   "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
 commit_date=$(echo "$commit_json" \
   | jq -r '.commit.committer.date' \

--- a/.flox/pkgs/temporal-cli/default.nix
+++ b/.flox/pkgs/temporal-cli/default.nix
@@ -3,6 +3,8 @@
   stdenv,
   buildGoModule,
   fetchFromGitHub,
+  fetchurl,
+  go,
   installShellFiles,
   writableTmpDirAsHomeHook,
 }:
@@ -11,8 +13,21 @@ let
   versionData =
     builtins.fromJSON (builtins.readFile ./hashes.json);
   inherit (versionData) version srcHash vendorHash;
+
+  # temporal-cli >= 1.7.1 sets `go 1.26.4` in go.mod, but the pinned
+  # catalog still ships Go 1.26.2 and buildGoModule runs with
+  # GOTOOLCHAIN=local, so the build fails the version gate. Bump just
+  # the toolchain used for this package (a patch-level source swap)
+  # until the base nixpkgs advances past 1.26.4.
+  go_1_26_4 = go.overrideAttrs (old: {
+    version = "1.26.4";
+    src = fetchurl {
+      url = "https://go.dev/dl/go1.26.4.src.tar.gz";
+      hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
+    };
+  });
 in
-buildGoModule (finalAttrs: {
+(buildGoModule.override { go = go_1_26_4; }) (finalAttrs: {
   pname = "temporal-cli";
   inherit version;
 

--- a/.flox/pkgs/temporal-cli/hashes.json
+++ b/.flox/pkgs/temporal-cli/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.7.0",
-  "srcHash": "sha256-P/wfvKRAvqRgUJabVE9RvT4o3fNZ52JX48hXm3C3orI=",
-  "vendorHash": "sha256-dD21m6tlwkZkclYOcYUNlsPXxYmLggjrFTv9XctCIt0="
+  "version": "1.7.2",
+  "srcHash": "sha256-HlG/zBfyd120ENERqdpfPuHPwu84bWijzoE4tEOsOeE=",
+  "vendorHash": "sha256-GI+rLSCwBRcZytbJsxqCL1+3p5/UbCvTxUHn2ele3+c="
 }

--- a/.flox/pkgs/temporal-cli/upgrade.sh
+++ b/.flox/pkgs/temporal-cli/upgrade.sh
@@ -5,8 +5,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HASHES_FILE="$SCRIPT_DIR/hashes.json"
 
+# Authenticated API calls use Actions' 5000/hr quota. The
+# unauthenticated 60/hr is shared per egress IP and gets exhausted
+# by parallel runners, surfacing as `curl exit 22`.
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
 current_version=$(jq -r '.version' "$HASHES_FILE")
-latest_version=$(curl -sf \
+latest_version=$(curl -sf --retry 3 --retry-delay 5 \
+  -H "Accept: application/vnd.github+json" \
+  "${auth_header[@]}" \
   https://api.github.com/repos/temporalio/cli/releases/latest \
   | jq -r '.tag_name' | sed 's/^v//')
 

--- a/.flox/pkgs/temporal/default.nix
+++ b/.flox/pkgs/temporal/default.nix
@@ -2,6 +2,8 @@
   lib,
   buildGoModule,
   fetchFromGitHub,
+  fetchurl,
+  go,
   versionCheckHook,
 }:
 
@@ -9,8 +11,21 @@ let
   versionData =
     builtins.fromJSON (builtins.readFile ./hashes.json);
   inherit (versionData) version srcHash vendorHash;
+
+  # temporal >= 1.31.1 sets `go 1.26.4` in go.mod, but the pinned
+  # catalog still ships Go 1.26.2 and buildGoModule runs with
+  # GOTOOLCHAIN=local, so the build fails the version gate. Bump just
+  # the toolchain used for this package (a patch-level source swap)
+  # until the base nixpkgs advances past 1.26.4.
+  go_1_26_4 = go.overrideAttrs (old: {
+    version = "1.26.4";
+    src = fetchurl {
+      url = "https://go.dev/dl/go1.26.4.src.tar.gz";
+      hash = "sha256-T2aKMvv8ETLmqIH7lowvHa2mMUkqM5IRc1+7JVpCYC0=";
+    };
+  });
 in
-buildGoModule (finalAttrs: {
+(buildGoModule.override { go = go_1_26_4; }) (finalAttrs: {
   pname = "temporal";
   inherit version;
 

--- a/.flox/pkgs/temporal/hashes.json
+++ b/.flox/pkgs/temporal/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.31.0",
-  "srcHash": "sha256-FgqJcDHY7p6k5Z7TFBQHMV0xZjfdqBPRDIQ2hsa+1LQ=",
-  "vendorHash": "sha256-CRoBLiHi9EBOuTm4Ue6tpg7SGDdvG7ySGUcM+8w4HCU="
+  "version": "1.31.1",
+  "srcHash": "sha256-NOmIEVBWA91oU7+yp1ySF7dyGlnQHgor1gKvvGg80BE=",
+  "vendorHash": "sha256-KZKlARki/AXGhfsQsOixHjx+t1H9htd9oBx3wsiebY0="
 }

--- a/.flox/pkgs/temporal/upgrade.sh
+++ b/.flox/pkgs/temporal/upgrade.sh
@@ -5,8 +5,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HASHES_FILE="$SCRIPT_DIR/hashes.json"
 
+# Authenticated API calls use Actions' 5000/hr quota. The
+# unauthenticated 60/hr is shared per egress IP and gets exhausted
+# by parallel runners, surfacing as `curl exit 22`.
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
 current_version=$(jq -r '.version' "$HASHES_FILE")
-latest_version=$(curl -sf \
+latest_version=$(curl -sf --retry 3 --retry-delay 5 \
+  -H "Accept: application/vnd.github+json" \
+  "${auth_header[@]}" \
   https://api.github.com/repos/temporalio/temporal/releases/latest \
   | jq -r '.tag_name' | sed 's/^v//')
 


### PR DESCRIPTION
## What

Fixes all five failing jobs in the
[Upgrade Packages run](https://github.com/flox/floxenvs/actions/runs/27370460019).
Each fix was verified on-branch via the Upgrade Packages workflow
(green runs, bump PRs linked below); CI-computed hashes match local
`flox build` validation.

### cursor-agent — wrong version detected (exit 1)

Cursor's install page changed the `/lab/` build suffix from
`<date>-<short-sha>` to `<date>-<hh>-<mm>-<ss>-<short-sha>`. The old
fixed-shape regex truncated the version at the first two digits
(`2026.06.11-03`), producing a non-existent build and a `403` on
download. Now matches the whole path segment. → bump PR #3656

### agent-deck — source references store paths (exit 1)

Since `v1.9.55` upstream commits its own `.flox/env/manifest.lock`,
which is full of `/nix/store/...` paths. A fetched source is a
fixed-output derivation, and modern Nix rejects FODs that reference
store paths, so the build died before compiling. `fetchFromGitHub`
now strips `.flox` in `postFetch`, and `upgrade.sh` computes `srcHash`
over the same stripped tree. No-op for tags without a committed
`.flox`. → bump PR #3657

### temporal / temporal-cli — Go toolchain too old (exit 1)

`temporal >= 1.31.1` and `temporal-cli >= 1.7.1` set `go 1.26.4` in
go.mod, but the pinned catalog ships Go 1.26.2 with
`GOTOOLCHAIN=local`, failing the version gate. Override the toolchain
to Go 1.26.4 (patch-level source swap; all nixpkgs Go patches apply
cleanly) for just these two packages. Satisfies older tags too, so
current pins keep building; drop the override once the base nixpkgs
advances past 1.26.4. → bump PRs #3658, #3659

### skills-taste-skill — rate-limited (exit 22)

Failed with `curl exit 22` on the GitHub commits API. Now uses the
authenticated Actions quota (5000/hr) with retries, matching the
pattern already used by `fnox`, `agent-browser`, etc. → bump PR #3655

The same `Authorization: Bearer $GITHUB_TOKEN` + `--retry` hardening
is applied to agent-deck, temporal, and temporal-cli so they fail on
real reasons rather than the shared-60/hr flake.

## Testing

- All five upgrade scripts run end-to-end; resulting derivations
  `flox build` successfully.
- Verified on-branch via the Upgrade Packages workflow — five green
  runs produced bump PRs #3655–#3659. CI hashes match local.
- `bash -n` clean on all touched scripts.