### PR TITLE
feat(skills-avoid-ai-writing): package conorbronsdon/avoid-ai-writing

### DIFF
--- a/.flox/pkgs/skills-avoid-ai-writing/default.nix
+++ b/.flox/pkgs/skills-avoid-ai-writing/default.nix
@@ -1,0 +1,61 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+let
+  data = builtins.fromJSON (builtins.readFile ./hashes.json);
+
+  src = fetchFromGitHub {
+    owner = "conorbronsdon";
+    repo = "avoid-ai-writing";
+    rev = data.rev;
+    hash = data.srcHash;
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "skills-avoid-ai-writing";
+  version = data.version;
+  inherit src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # The skill is a single self-contained SKILL.md. Upstream keeps the
+    # canonical copy at the repo root (the same bytes it syncs into its
+    # Claude Code plugin at plugins/avoid-ai-writing/skills/avoid-ai-writing/).
+    # The repo root is NOT a bare skill folder — it also carries the JS
+    # detector, a Cursor port, docs, and build scripts — so copy only
+    # SKILL.md rather than the whole tree. The skill needs no supporting
+    # files: it references the detector's thresholds in prose but never
+    # invokes it, so SKILL.md alone is the complete agent capability.
+    for dest in \
+      "$out/share/claude-code/skills/avoid-ai-writing" \
+      "$out/share/opencode/skills/avoid-ai-writing"; do
+      mkdir -p "$dest"
+      cp "$src/SKILL.md" "$dest/SKILL.md"
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Avoid AI Writing skill for Claude Code and OpenCode — audits and "
+      + "rewrites content to remove AI writing patterns (\"AI-isms\"), with "
+      + "detect-only and edit-in-place modes, voice profiles, and "
+      + "iterate-to-convergence.";
+    homepage = "https://github.com/conorbronsdon/avoid-ai-writing";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/skills-avoid-ai-writing/hashes.json
+++ b/.flox/pkgs/skills-avoid-ai-writing/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "3.10.0+unstable-2026-06-12.0878950",
+  "rev": "0878950dd5165b7e7a85423fcd279c9ff3609549",
+  "srcHash": "sha256-uxWNoPNJ4JiN3gnzkQuYQabaJ2RXvv2VlG3BkvIWvfQ="
+}

--- a/.flox/pkgs/skills-avoid-ai-writing/meta.yaml
+++ b/.flox/pkgs/skills-avoid-ai-writing/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: skill
+name: skills-avoid-ai-writing
+title: Avoid AI Writing
+skill_for: claude-code
+publisher: flox
+tagline: >
+  Audit and rewrite content to strip AI writing patterns
+  ("AI-isms") — detect-only, edit-in-place, and voice profiles.
+category: ai
+ai_role: tooling
+tags: [claude-code, skill, writing, editing, humanize]
+status: beta
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    skills-avoid-ai-writing.pkg-path = "flox/skills-avoid-ai-writing"
+    skills-avoid-ai-writing.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/skills-avoid-ai-writing
+  floxhub: https://hub.flox.dev/flox/skills-avoid-ai-writing

--- a/.flox/pkgs/skills-avoid-ai-writing/publish.json
+++ b/.flox/pkgs/skills-avoid-ai-writing/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/skills-avoid-ai-writing/upgrade.sh
+++ b/.flox/pkgs/skills-avoid-ai-writing/upgrade.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="conorbronsdon"
+REPO="avoid-ai-writing"
+BRANCH="main"
+
+current_version=$(jq -r '.version // ""' "$HASHES_FILE")
+
+# Resolve current HEAD on main to a full SHA. Upstream publishes no
+# git tags, so main HEAD is the canonical "latest".
+rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/heads/$BRANCH" | awk '{print $1}')
+
+if [ -z "$rev" ]; then
+  echo "Failed to resolve $BRANCH on $OWNER/$REPO" >&2
+  exit 1
+fi
+
+short_sha="${rev:0:7}"
+
+# Committer date (YYYY-MM-DD) via the GitHub commits API.
+commit_json=$(curl -sfL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
+commit_date=$(echo "$commit_json" \
+  | jq -r '.commit.committer.date' \
+  | cut -c1-10)
+
+# Frontmatter `version:` from raw SKILL.md at this rev.
+skill_md=$(curl -sfL \
+  "https://raw.githubusercontent.com/$OWNER/$REPO/$rev/SKILL.md")
+frontmatter_version=$(echo "$skill_md" \
+  | awk '
+      BEGIN { in_fm = 0 }
+      /^---[[:space:]]*$/ {
+        if (in_fm == 0) { in_fm = 1; next }
+        else { exit }
+      }
+      in_fm == 1 && /^version:[[:space:]]*/ {
+        sub(/^version:[[:space:]]*/, "")
+        gsub(/^["'\'']|["'\''][[:space:]]*$/, "")
+        print
+        exit
+      }
+    ')
+
+if [ -z "$frontmatter_version" ]; then
+  echo "Failed to extract frontmatter version from SKILL.md" >&2
+  exit 1
+fi
+
+new_version="${frontmatter_version}+unstable-${commit_date}.${short_sha}"
+
+echo "Current: $current_version"
+echo "Latest:  $new_version"
+
+if [ "$current_version" = "$new_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating skills-avoid-ai-writing to $new_version"
+
+# Prefetch the source tarball and compute SRI hash.
+sha256_base32=$(nix-prefetch-url --unpack \
+  "https://github.com/$OWNER/$REPO/archive/$rev.tar.gz")
+sri_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$sha256_base32")
+
+jq -n \
+  --arg v "$new_version" \
+  --arg r "$rev" \
+  --arg h "$sri_hash" \
+  '{version: $v, rev: $r, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Wrote $HASHES_FILE:"
+cat "$HASHES_FILE"


### PR DESCRIPTION
Package the [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) skill as a flox package, following the `skills-*` family convention (matching `skills-humanizer`).

## What

`skills-avoid-ai-writing` — `subkind: skill`, installs `SKILL.md` to both `share/claude-code/skills/avoid-ai-writing/` and `share/opencode/skills/avoid-ai-writing/` (multi-harness, since the upstream skill is agentskills.io-spec).

The skill audits and rewrites content to remove AI writing patterns ("AI-isms") — detect-only, edit-in-place, voice profiles, iterate-to-convergence.

## Notes

- **Skill only.** Copies just `SKILL.md`. The repo also ships a JS detector (`detector/patterns.js`), a Cursor port, and docs — left out. The skill is self-contained: it references the detector's thresholds in prose but never invokes it, so `SKILL.md` alone is the complete agent capability.
- **No git tags upstream.** `upgrade.sh` tracks `main` HEAD; version = SKILL.md frontmatter version + `unstable-<date>.<sha>` (same scheme as `skills-humanizer`). Pinned to `0878950` (frontmatter `3.10.0`).
- **Frontmatter copied verbatim** — unlike `skills-humanizer`, `version:` is left at top level because upstream already has a `metadata:` block and declares `agentskills_spec: "1.0"`; nesting would inject a duplicate `metadata:` key.

## Verification

- `nix-build` clean; `SKILL.md` lands in both harness skill dirs
- `lint-meta` score 100; `yamllint` clean; `bash -n upgrade.sh` ok

`ci_pkgs.yml` auto-discovers `.flox/pkgs/*/` — no flake.nix or workflow changes needed.