### PR TITLE
feat(skills-cybersecurity): package Anthropic Cybersecurity Skills

### DIFF
--- a/.flox/pkgs/skills-cybersecurity/default.nix
+++ b/.flox/pkgs/skills-cybersecurity/default.nix
@@ -1,0 +1,149 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  python3,
+}:
+
+let
+  data = builtins.fromJSON (builtins.readFile ./hashes.json);
+
+  # The 754 skills ship ~1030 Python helpers (scripts/agent.py,
+  # scripts/process.py, …) that import 90+ distinct third-party libs.
+  # Most of that long tail is exotic or unpackaged (impacket, frida,
+  # ghidra, yara, pwntools, …) and several fail to build on Darwin, so
+  # bundling all of it would make the package un-buildable across the
+  # four catalog systems. Instead we bundle a curated core: the
+  # highest-frequency imports that build cleanly everywhere. Every
+  # helper is wired to this interpreter regardless (see postInstall);
+  # a skill that needs something outside the core pip-installs it per
+  # slot, which the install note spells out.
+  pythonEnv = python3.withPackages (ps: [
+    ps.requests
+    ps.urllib3
+    ps.cryptography
+    ps.pyyaml
+    ps.rich
+    ps.pandas
+    ps.numpy
+    ps.lxml
+    ps.dnspython
+    ps.boto3
+    ps.botocore
+    ps.paramiko
+    ps.scapy
+    ps.ldap3
+    ps.jinja2
+    ps.defusedxml
+    ps.psutil
+    ps.beautifulsoup4
+    ps.pyjwt
+    ps.jsonschema
+  ]);
+  py = "${pythonEnv}/bin/python3";
+
+  src = fetchFromGitHub {
+    owner = "mukul975";
+    repo = "Anthropic-Cybersecurity-Skills";
+    rev = data.rev;
+    hash = data.srcHash;
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "skills-cybersecurity";
+  version = data.version;
+  inherit src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # Each upstream skills/<name>/ is a self-contained directory skill
+    # (SKILL.md plus optional scripts/, references/, assets/). Ship the
+    # whole set, one directory per skill, into every agent skills dir we
+    # support — exactly how flox/claude-code discovers them on PATH.
+    for share in \
+      "$out/share/claude-code/skills" \
+      "$out/share/opencode/skills"; do
+      mkdir -p "$share"
+      cp -r "$src/skills"/. "$share/"
+      chmod -R u+w "$share"
+    done
+
+    runHook postInstall
+  '';
+
+  # Two fix-ups so the packaged skills work without host assumptions:
+  #
+  #   1. Wire every Python helper to the bundled interpreter. The
+  #      shebang is rewritten to ${py} (carries the curated core), and a
+  #      re-exec shim is inserted as the first statement so that even
+  #      when the agent launches a helper as `python scripts/agent.py`
+  #      with some other Python, it re-launches under ${py} before any
+  #      third-party import can fail. Helpers are made executable.
+  #
+  #   2. Upstream SKILL.md frontmatter puts `version:` at the top level,
+  #      which the agentskills.io loader flags as an unknown key on every
+  #      session start. With 754 skills that is a lot of warning noise,
+  #      so nest it under `metadata:` (same fix as flox/skills-humanizer).
+  postInstall = ''
+    for share in \
+      "$out/share/claude-code/skills" \
+      "$out/share/opencode/skills"; do
+
+      # 1. Self-contain the Python helpers.
+      find "$share" -name '*.py' -type f | while read -r f; do
+        awk -v py="${py}" '
+          NR == 1 {
+            has_sb = ($0 ~ /^#!/)
+            print "#!" py
+            print "import os as _os, sys as _sys"
+            print "_PY = \"" py "\""
+            print "if _os.path.realpath(_sys.executable) != _os.path.realpath(_PY) and _os.path.exists(_PY):"
+            print "    _os.execv(_PY, [_PY] + _sys.argv)"
+            if (!has_sb) print $0
+            next
+          }
+          { print }
+        ' "$f" > "$f.wired"
+        mv "$f.wired" "$f"
+        chmod +x "$f"
+      done
+
+      # 2. Nest the stray top-level `version:` frontmatter key.
+      find "$share" -name 'SKILL*.md' -type f | while read -r md; do
+        awk '
+          BEGIN { fm = 0 }
+          /^---[[:space:]]*$/ { fm++; print; next }
+          fm == 1 && /^version:[[:space:]]/ {
+            print "metadata:"
+            print "  " $0
+            next
+          }
+          { print }
+        ' "$md" > "$md.new"
+        mv "$md.new" "$md"
+      done
+    done
+  '';
+
+  meta = {
+    description =
+      "754 cybersecurity skills for Claude Code and OpenCode — web "
+      + "security, pentesting, DFIR, threat intelligence, cloud "
+      + "security, and malware analysis, mapped to MITRE ATT&CK, NIST "
+      + "CSF 2.0, ATLAS, D3FEND, and NIST AI RMF. Python helpers ship "
+      + "wired to a bundled interpreter carrying a curated core of "
+      + "common libs (requests, cryptography, boto3, scapy, …).";
+    homepage = "https://github.com/mukul975/Anthropic-Cybersecurity-Skills";
+    license = lib.licenses.asl20;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/skills-cybersecurity/hashes.json
+++ b/.flox/pkgs/skills-cybersecurity/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.2.0+unstable-2026-06-01.0445030",
+  "rev": "04450304b12645cb2b974ab96d28c0664758a88d",
+  "srcHash": "sha256-BF1lZIjDOhOVXhGWD7rS5SlwOT6enwoZuRgoEmQIqNQ="
+}

--- a/.flox/pkgs/skills-cybersecurity/meta.yaml
+++ b/.flox/pkgs/skills-cybersecurity/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: skill
+name: skills-cybersecurity
+title: Cybersecurity Skills
+skill_for: claude-code
+publisher: flox
+tagline: >
+  754 cybersecurity skills for Claude Code — pentesting,
+  DFIR, threat intel, cloud security, and malware analysis.
+category: ai
+ai_role: tooling
+tags: [claude-code, skill, security, pentesting, forensics, dfir]
+status: beta
+license: Apache-2.0
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    skills-cybersecurity.pkg-path = "flox/skills-cybersecurity"
+    skills-cybersecurity.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/skills-cybersecurity
+  floxhub: https://hub.flox.dev/flox/skills-cybersecurity

--- a/.flox/pkgs/skills-cybersecurity/publish.json
+++ b/.flox/pkgs/skills-cybersecurity/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/skills-cybersecurity/upgrade.sh
+++ b/.flox/pkgs/skills-cybersecurity/upgrade.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="mukul975"
+REPO="Anthropic-Cybersecurity-Skills"
+BRANCH="main"
+
+current_version=$(jq -r '.version // ""' "$HASHES_FILE")
+
+# Resolve current HEAD on main to a full SHA.
+rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/heads/$BRANCH" | awk '{print $1}')
+
+if [ -z "$rev" ]; then
+  echo "Failed to resolve $BRANCH on $OWNER/$REPO" >&2
+  exit 1
+fi
+
+short_sha="${rev:0:7}"
+
+# Committer date (YYYY-MM-DD) via the GitHub commits API.
+commit_json=$(curl -sfL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
+commit_date=$(echo "$commit_json" \
+  | jq -r '.commit.committer.date' \
+  | cut -c1-10)
+
+# The skills carry per-skill frontmatter versions, so anchor the package
+# version on the marketplace metadata version at this rev.
+marketplace=$(curl -sfL \
+  "https://raw.githubusercontent.com/$OWNER/$REPO/$rev/.claude-plugin/marketplace.json")
+base_version=$(echo "$marketplace" \
+  | jq -r '.metadata.version // ""')
+
+if [ -z "$base_version" ]; then
+  echo "Failed to extract version from marketplace.json" >&2
+  exit 1
+fi
+
+new_version="${base_version}+unstable-${commit_date}.${short_sha}"
+
+echo "Current: $current_version"
+echo "Latest:  $new_version"
+
+if [ "$current_version" = "$new_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating skills-cybersecurity to $new_version"
+
+# Prefetch the source tarball and compute SRI hash.
+sha256_base32=$(nix-prefetch-url --unpack \
+  "https://github.com/$OWNER/$REPO/archive/$rev.tar.gz")
+sri_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$sha256_base32")
+
+jq -n \
+  --arg v "$new_version" \
+  --arg r "$rev" \
+  --arg h "$sri_hash" \
+  '{version: $v, rev: $r, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Wrote $HASHES_FILE:"
+cat "$HASHES_FILE"


### PR DESCRIPTION
## What

Packages [mukul975/Anthropic-Cybersecurity-Skills](https://github.com/mukul975/Anthropic-Cybersecurity-Skills) (754 skills, pinned rev `0445030`) as a flox catalog skill package `skills-cybersecurity`. Pkg only — no environment.

## How

- **Ships all 754 skills** to `share/claude-code/skills` and `share/opencode/skills`, one directory per skill (SKILL.md + optional `scripts/`, `references/`, `assets/`).
- **Wraps all ~1030 Python helpers** (`scripts/agent.py`, `scripts/process.py`, …): shebang rewritten to a bundled interpreter, plus a re-exec shim inserted as the first statement so helpers run correctly even when launched as `python scripts/agent.py` with a different host Python — it re-execs into the bundled interpreter before any third-party import can fail. Helpers made executable.
- **Bundles a curated core of runtime deps** — the highest-frequency imports that build cleanly on all four catalog systems: requests, urllib3, cryptography, pyyaml, rich, pandas, numpy, lxml, dnspython, boto3, botocore, paramiko, scapy, ldap3, jinja2, defusedxml, psutil, beautifulsoup4, pyjwt, jsonschema. The exotic long tail (impacket, frida, yara, …) installs per-slot.
- **Nests the stray top-level `version:`** frontmatter key under `metadata:` to silence loader warnings across all 754 skills (same fix as `skills-humanizer`).

## Verification

- `nix build` succeeds; output has 754 skill dirs in both share trees.
- Helpers wired to the bundled interpreter + executable; the 5 docstring-first files also get a shebang.
- Re-exec shim proven: ran a `requests`-importing helper through `/usr/bin/python3` (no requests) → re-execed into the bundled interpreter, `--help` worked.
- `list-items.sh` discovers it as both `pkg` and `skill`; `meta.yaml` lints identically to the reference `skills-video-use`.

License: Apache-2.0 (upstream), `asl20` in nix.