### PR TITLE
feat(skills-youtube-skills): package youtube-skills as a skill

### DIFF
--- a/.flox/pkgs/skills-youtube-skills/default.nix
+++ b/.flox/pkgs/skills-youtube-skills/default.nix
@@ -1,0 +1,68 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  curl,
+}:
+
+let
+  data = builtins.fromJSON (builtins.readFile ./hashes.json);
+
+  src = fetchFromGitHub {
+    owner = "ZeroPointRepo";
+    repo = "youtube-skills";
+    rev = data.rev;
+    hash = data.srcHash;
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "skills-youtube-skills";
+  version = data.version;
+  inherit src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # youtube-skills ships 12 directory skills under skills/ (the
+    # clawhub/ tree is an OpenClaw-specific variant we don't use here).
+    # Each skill is SKILL.md + references/ and must ship as a unit.
+    # The skill bodies invoke `curl` by bare name to call
+    # transcriptapi.com, so we drop a `curl` on PATH (see below) to make
+    # the package self-contained — no host curl assumption.
+    for share in \
+      "$out/share/claude-code/skills" \
+      "$out/share/opencode/skills"; do
+      mkdir -p "$share"
+      cp -r "$src/skills/." "$share/"
+      chmod -R u+w "$share"
+    done
+
+    # The only runtime dependency the skills reach for is `curl`. Bundle
+    # it on PATH so the bare `curl ...` invocations in every SKILL.md
+    # resolve once this package is installed into the consumer's flox
+    # env, with nix recording curl in the closure automatically.
+    mkdir -p "$out/bin"
+    ln -s "${curl}/bin/curl" "$out/bin/curl"
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "youtube-skills for Claude Code and OpenCode — 12 skills for "
+      + "YouTube transcripts, captions, search, channels, and playlists "
+      + "via the TranscriptAPI.com backend. The SKILL.md curl calls run "
+      + "against a bundled curl on PATH; set TRANSCRIPT_API_KEY to use.";
+    homepage = "https://github.com/ZeroPointRepo/youtube-skills";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/skills-youtube-skills/hashes.json
+++ b/.flox/pkgs/skills-youtube-skills/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "1.5.0+unstable-2026-05-20.d4b7a18",
+  "rev": "d4b7a18ffdbccaad0edc19b3563ff30f0a773708",
+  "srcHash": "sha256-gmWRQjpIKhvvu1XUMorGqzbMd+UaYwYUWzGwUm1jpQQ="
+}

--- a/.flox/pkgs/skills-youtube-skills/meta.yaml
+++ b/.flox/pkgs/skills-youtube-skills/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: skill
+name: skills-youtube-skills
+title: YouTube Skills
+skill_for: claude-code
+publisher: flox
+tagline: >
+  YouTube transcripts, search, channels, and playlists for
+  Claude Code — via the TranscriptAPI.com backend.
+category: ai
+ai_role: tooling
+tags: [claude-code, skill, youtube, transcripts, search]
+status: stable
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    skills-youtube-skills.pkg-path = "flox/skills-youtube-skills"
+    skills-youtube-skills.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/skills-youtube-skills
+  floxhub: https://hub.flox.dev/flox/skills-youtube-skills

--- a/.flox/pkgs/skills-youtube-skills/publish.json
+++ b/.flox/pkgs/skills-youtube-skills/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/skills-youtube-skills/upgrade.sh
+++ b/.flox/pkgs/skills-youtube-skills/upgrade.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="ZeroPointRepo"
+REPO="youtube-skills"
+BRANCH="main"
+
+current_version=$(jq -r '.version // ""' "$HASHES_FILE")
+
+# Resolve current HEAD on main to a full SHA.
+rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/heads/$BRANCH" | awk '{print $1}')
+
+if [ -z "$rev" ]; then
+  echo "Failed to resolve $BRANCH on $OWNER/$REPO" >&2
+  exit 1
+fi
+
+short_sha="${rev:0:7}"
+
+# Committer date (YYYY-MM-DD) via the GitHub commits API.
+commit_json=$(curl -sfL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
+commit_date=$(echo "$commit_json" \
+  | jq -r '.commit.committer.date' \
+  | cut -c1-10)
+
+# youtube-skills has no repo-level version, so anchor on the
+# youtube-full skill's frontmatter version (the flagship skill).
+skill_md=$(curl -sfL \
+  "https://raw.githubusercontent.com/$OWNER/$REPO/$rev/skills/youtube-full/SKILL.md")
+base_version=$(echo "$skill_md" \
+  | awk -F'"' '/^version:/ { print $2; exit }')
+
+if [ -z "$base_version" ]; then
+  echo "Failed to extract version from youtube-full SKILL.md" >&2
+  exit 1
+fi
+
+new_version="${base_version}+unstable-${commit_date}.${short_sha}"
+
+echo "Current: $current_version"
+echo "Latest:  $new_version"
+
+if [ "$current_version" = "$new_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating skills-youtube-skills to $new_version"
+
+# Prefetch the source tarball and compute SRI hash.
+sha256_base32=$(nix-prefetch-url --unpack \
+  "https://github.com/$OWNER/$REPO/archive/$rev.tar.gz")
+sri_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$sha256_base32")
+
+jq -n \
+  --arg v "$new_version" \
+  --arg r "$rev" \
+  --arg h "$sri_hash" \
+  '{version: $v, rev: $r, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Wrote $HASHES_FILE:"
+cat "$HASHES_FILE"


### PR DESCRIPTION
## What

Packages [ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) as a new custom package `skills-youtube-skills` under `.flox/pkgs/`.

## Details

- Ships the 12 directory skills from the repo's `skills/` tree (transcripts, captions, subtitles, search, channels, playlists, `yt`, `youtube-full`, etc.) into `share/claude-code/skills/` and `share/opencode/skills/`.
- The skill bodies are plain `curl` calls to transcriptapi.com — no standalone helper scripts. The only runtime dependency is `curl`, which is bundled on `$out/bin` so the bare `curl` invocations resolve in any flox env (nix records it in the closure).
- Requires `TRANSCRIPT_API_KEY` at runtime (free tier, 100 credits) — documented in each skill's frontmatter.
- No environment (minimal/demo) created, per request — package only.

## Package files

- `default.nix` — fetchFromGitHub + install + bundled curl
- `hashes.json` — rev `d4b7a18`, version `1.5.0+unstable-2026-05-20.d4b7a18`
- `upgrade.sh` — tracks `main`, anchors version on the `youtube-full` skill frontmatter
- `meta.yaml`, `publish.json` — catalog metadata, flox org, 4 systems

## Verification

`flox build skills-youtube-skills` succeeds on aarch64-darwin; output has all 12 skill dirs intact and a working `curl` on PATH.