### PR TITLE
feat(skills-last30days): package last30days research skill

### DIFF
--- a/.flox/pkgs/skills-last30days/default.nix
+++ b/.flox/pkgs/skills-last30days/default.nix
@@ -1,0 +1,137 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  python3,
+  nodejs_22,
+}:
+
+let
+  data = builtins.fromJSON (builtins.readFile ./hashes.json);
+
+  # The engine is pure-stdlib Python — pyproject declares no runtime
+  # dependencies, and every import across scripts/ resolves to the
+  # standard library — so it only needs a 3.12+ interpreter. The
+  # X/Twitter source (scripts/lib/bird_x.py) shells out to the vendored
+  # scripts/lib/vendor/bird-search/bird-search.mjs, which needs Node 22+
+  # (and has no npm dependencies of its own). Both runtimes are bundled
+  # so the skill runs with no host Python/Node and no surrounding flox
+  # environment.
+  py = "${python3}/bin/python3";
+  rtPath = lib.makeBinPath [
+    python3
+    nodejs_22
+  ];
+
+  src = fetchFromGitHub {
+    owner = "mvanhorn";
+    repo = "last30days-skill";
+    rev = data.rev;
+    hash = data.srcHash;
+  };
+in
+stdenvNoCC.mkDerivation {
+  pname = "skills-last30days";
+  version = data.version;
+  inherit src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    # last30days is a directory skill: SKILL.md drives the engine by a
+    # path relative to its own location (`"$SKILL_DIR/scripts/last30days.py"`),
+    # so the whole skills/last30days tree must ship together with SKILL.md
+    # at the root. Ship into every agent skills dir we support.
+    for share in \
+      "$out/share/claude-code/skills" \
+      "$out/share/opencode/skills"; do
+      mkdir -p "$share"
+      cp -r "$src/skills/last30days" "$share/last30days"
+      chmod -R u+w "$share/last30days"
+    done
+
+    runHook postInstall
+  '';
+
+  # Wire the engine to the bundled runtimes so it runs with no host
+  # Python/Node and no surrounding flox env:
+  #
+  #   1. Each entry-point helper's shebang -> the bundled interpreter.
+  #   2. A startup shim (injected right after the script's first import
+  #      anchor) prepends the bundled python3 + node bins to PATH, so the
+  #      `shutil.which("node")` gate and the `["node", bird-search.mjs,
+  #      ...]` subprocess in lib/bird_x.py resolve the bundled Node, and
+  #      re-execs the script under the bundled interpreter if it was
+  #      launched some other way.
+  #   3. SKILL.md's "Runtime Preflight" probes PATH for a python3.12+ and
+  #      keeps it in LAST30DAYS_PYTHON; pin that probe to the bundled
+  #      interpreter directly so the engine Bash call uses it with nothing
+  #      installed.
+  postInstall = ''
+    for skill in "$out"/share/*/skills/last30days; do
+      scripts="$skill/scripts"
+
+      # Only the top-level entry scripts are executed directly; the
+      # lib/ modules are imported into the same process, so the PATH the
+      # entry script sets up covers them too.
+      for f in "$scripts"/*.py; do
+        anchor='from __future__ import'
+        if ! grep -q "^$anchor" "$f"; then
+          # No __future__ import: anchor the shim right after the shebang.
+          anchor='__SHEBANG_ONLY__'
+        fi
+        # NB: awk var is BINS, not RT — RT is a gawk built-in (record
+        # terminator) and gawk clobbers any -v RT= with the matched
+        # newline on the first record read.
+        awk -v PY="${py}" -v BINS="${rtPath}" -v ANCHOR="$anchor" '
+          function emit() {
+            print "import os as _os, sys as _sys"
+            print "_os.environ[\"PATH\"] = \"" BINS "\" + _os.pathsep + _os.environ.get(\"PATH\", \"\")"
+            print "_PY = \"" PY "\""
+            print "if _os.path.realpath(_sys.executable) != _os.path.realpath(_PY) and _os.path.exists(_PY):"
+            print "    _os.execv(_PY, [_PY] + _sys.argv)"
+          }
+          NR == 1 {
+            print "#!" PY
+            if (ANCHOR == "__SHEBANG_ONLY__") { emit(); shim = 1 }
+            next
+          }
+          { print }
+          $0 ~ ("^" ANCHOR) && !shim { emit(); shim = 1 }
+        ' "$f" > "$f.wired"
+        mv "$f.wired" "$f"
+        chmod +x "$f"
+      done
+
+      # Pin the agent-facing interpreter probe to the bundled python so
+      # the engine runs with no python3 installed on the host. The loop's
+      # own `command -v` + version check still validate the path.
+      substituteInPlace "$skill/SKILL.md" \
+        --replace-fail \
+          'for py in python3.14 python3.13 python3.12 python3; do' \
+          'for py in "${py}"; do'
+    done
+  '';
+
+  meta = {
+    description =
+      "last30days skill for Claude Code and OpenCode — research "
+      + "what people actually said about any topic in the last 30 "
+      + "days across Reddit, X, YouTube, TikTok, Hacker News, "
+      + "Polymarket, GitHub, and the web, then synthesize a grounded, "
+      + "cited summary. The pure-stdlib Python engine ships wired to a "
+      + "bundled interpreter and the vendored bird-search X client runs "
+      + "on a bundled Node 22 — no host runtime required.";
+    homepage = "https://github.com/mvanhorn/last30days-skill";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/skills-last30days/hashes.json
+++ b/.flox/pkgs/skills-last30days/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "3.3.2+unstable-2026-06-06.1221584",
+  "rev": "122158415ae421da83e739f2668032f6bc78d39c",
+  "srcHash": "sha256-Z9IMwsQavs2cli8G9eFl5jd9OcAZaGbQpZy7gDrzGT4="
+}

--- a/.flox/pkgs/skills-last30days/meta.yaml
+++ b/.flox/pkgs/skills-last30days/meta.yaml
@@ -1,0 +1,24 @@
+kind: pkg
+subkind: skill
+name: skills-last30days
+title: Last30Days
+skill_for: claude-code
+publisher: flox
+tagline: >
+  Multi-source last-30-days research skill for Claude Code.
+category: ai
+ai_role: tooling
+tags: [claude-code, skill, research, social-media, news]
+status: beta
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    skills-last30days.pkg-path = "flox/skills-last30days"
+    skills-last30days.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/skills-last30days
+  floxhub: https://hub.flox.dev/flox/skills-last30days

--- a/.flox/pkgs/skills-last30days/publish.json
+++ b/.flox/pkgs/skills-last30days/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/skills-last30days/upgrade.sh
+++ b/.flox/pkgs/skills-last30days/upgrade.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="mvanhorn"
+REPO="last30days-skill"
+BRANCH="main"
+
+current_version=$(jq -r '.version // ""' "$HASHES_FILE")
+
+# Resolve current HEAD on main to a full SHA.
+rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/heads/$BRANCH" | awk '{print $1}')
+
+if [ -z "$rev" ]; then
+  echo "Failed to resolve $BRANCH on $OWNER/$REPO" >&2
+  exit 1
+fi
+
+short_sha="${rev:0:7}"
+
+# Committer date (YYYY-MM-DD) via the GitHub commits API.
+commit_json=$(curl -sfL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
+commit_date=$(echo "$commit_json" \
+  | jq -r '.commit.committer.date' \
+  | cut -c1-10)
+
+# Anchor the base version on the skill's own frontmatter version
+# (skills/last30days/SKILL.md), which is the number the engine
+# stamps into its output badge.
+skill_md=$(curl -sfL \
+  "https://raw.githubusercontent.com/$OWNER/$REPO/$rev/skills/last30days/SKILL.md")
+# Match only the first `version:` line, but keep reading to EOF (no awk
+# `exit`) so the upstream `echo` never gets SIGPIPE on this large file —
+# under `set -o pipefail` that early close would abort the script (141).
+base_version=$(printf '%s\n' "$skill_md" \
+  | awk '/^version:/ && !seen { gsub(/"/, "", $2); print $2; seen = 1 }')
+
+if [ -z "$base_version" ]; then
+  echo "Failed to extract version from SKILL.md" >&2
+  exit 1
+fi
+
+new_version="${base_version}+unstable-${commit_date}.${short_sha}"
+
+echo "Current: $current_version"
+echo "Latest:  $new_version"
+
+if [ "$current_version" = "$new_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating skills-last30days to $new_version"
+
+# Prefetch the source tarball and compute SRI hash.
+sha256_base32=$(nix-prefetch-url --unpack \
+  "https://github.com/$OWNER/$REPO/archive/$rev.tar.gz")
+sri_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$sha256_base32")
+
+jq -n \
+  --arg v "$new_version" \
+  --arg r "$rev" \
+  --arg h "$sri_hash" \
+  '{version: $v, rev: $r, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Wrote $HASHES_FILE:"
+cat "$HASHES_FILE"


### PR DESCRIPTION
## What

Packages [mvanhorn/last30days-skill](https://github.com/mvanhorn/last30days-skill) as the `skills-last30days` flox skill pkg under `.flox/pkgs/`. Multi-source last-30-days research skill across Reddit, X, YouTube, TikTok, Hacker News, Polymarket, GitHub, and the web.

No environment / `-demo` layer — a self-contained skill pkg (`kind: pkg`, `subkind: skill`), same shape as `skills-video-use` / `skills-graphify`.

## Runtime wiring (scripts wrapped, deps bundled)

The engine is **pure-stdlib Python** (pyproject declares zero deps); `lib/bird_x.py` shells out to a vendored `bird-search.mjs` needing **Node 22+**. `default.nix`:

1. Rewrites each entry script's **shebang** → bundled `python3`.
2. Injects a startup **PATH + re-exec shim** after the first import line, so `shutil.which("node")` and the `["node", bird-search.mjs, …]` subprocess resolve the bundled Node, and the script re-execs under the bundled interpreter if launched another way.
3. Pins SKILL.md's `LAST30DAYS_PYTHON` interpreter probe to the bundled python.

Result: runs with **no host Python/Node and no surrounding flox env**.

## Verification

- `nix-build` succeeds (Linux + Darwin platforms declared)
- Under an **empty PATH**: `--help` runs, `shutil.which("node")` → bundled Node 22, `bird_x.is_bird_installed()` → `True`
- `lint-meta` 100/100; `lint-conventions` 77 (parity with all existing `skills-*` pkgs — only the non-applicable env-schema check misses)
- `upgrade.sh` idempotent (tracks `main`, anchors version on SKILL.md frontmatter)

## Files

`default.nix`, `hashes.json`, `meta.yaml`, `publish.json`, `upgrade.sh`