### PR TITLE
refactor(flox-ai): cut gstack/graphify consumers over to flox-ai (Phase 3)

### DIFF
--- a/firecrawl/README.md
+++ b/firecrawl/README.md
@@ -67,7 +67,7 @@ Override either in your own manifest before
 
 This env includes `flox/claude`, so the bundled skills
 under `$FLOX_ENV/share/claude-code/skills/` are
-discovered by `claude-managed` and surfaced to Claude
+discovered by `flox-ai` and surfaced to Claude
 Code automatically. The same files are installed for
 OpenCode under
 `$FLOX_ENV/share/opencode/skills/`. The bundle covers

--- a/graphify-demo/.flox/env/manifest.lock
+++ b/graphify-demo/.flox/env/manifest.lock
@@ -20,14 +20,14 @@
         "pkg-path": "flox/claude-code",
         "pkg-group": "claude-code"
       },
-      "claude-managed": {
-        "pkg-path": "flox/claude-managed",
-        "pkg-group": "claude-managed",
-        "version": "^0.4.1"
-      },
       "curl": {
         "pkg-path": "curl",
         "pkg-group": "graphify-tools"
+      },
+      "flox-ai": {
+        "pkg-path": "flox/flox-ai",
+        "pkg-group": "flox-ai",
+        "version": "^0.5.0"
       },
       "gcc-unwrapped": {
         "pkg-path": "gcc-unwrapped",
@@ -69,12 +69,12 @@
       "VIRTUAL_ENV_DISABLE_PROMPT": "1"
     },
     "hook": {
-      "on-activate": "export PYTHON_DIR=\"$FLOX_ENV_CACHE/python\"\n\nCURRENT_INTERP=\"$(realpath \"$(which python3)\")\"\nCACHED_INTERP=\"$(cat \"$PYTHON_DIR/.interpreter\" \\\n  2>/dev/null || echo none)\"\n\nif [ ! -d \"$PYTHON_DIR\" ] \\\n    || [ \"$CURRENT_INTERP\" != \"$CACHED_INTERP\" ]; then\n  python3 -m venv --upgrade-deps \"$PYTHON_DIR\"\n  echo \"$CURRENT_INTERP\" > \"$PYTHON_DIR/.interpreter\"\nfi\n\nunset VIRTUAL_ENV\nsource \"$PYTHON_DIR/bin/activate\"\n\nHASH=$(echo \"$GRAPHIFY_INSTALL_PACKAGE\" | md5sum 2>/dev/null \\\n  || echo \"$GRAPHIFY_INSTALL_PACKAGE\" | md5 -q)\nHASH=$(echo \"$HASH\" | cut -d\" \" -f1)\nLAST=$(cat \"$PYTHON_DIR/.deps_hash\" 2>/dev/null)\nif [ \"$HASH\" != \"$LAST\" ]; then\n  pip install -q \"$GRAPHIFY_INSTALL_PACKAGE\"\n  echo \"$HASH\" > \"$PYTHON_DIR/.deps_hash\"\nfi\n\neval \"$(claude-managed setup-hook)\"\n\nif [[ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]]; then\n  gum style --border double --margin '1 2' \\\n    --padding '1 4' \\\n    'graphify — knowledge graphs for Claude Code' '' \\\n    'The /graphify skill is pre-installed via' \\\n    'flox/skill-graphify and discovered by' \\\n    'claude-managed. Just open Claude Code:' \\\n    '  /graphify .' '' \\\n    'Or use the CLI directly:' \\\n    '  graphify .' \\\n    '  graphify ./raw --mode deep' \\\n    '  graphify ./raw --update' '' \\\n    'Query the graph:' \\\n    '  graphify query \"what connects X to Y?\"' \\\n    '  graphify path \"Module\" \"Database\"' \\\n    '  graphify explain \"Concept\"'\nfi\n"
+      "on-activate": "export PYTHON_DIR=\"$FLOX_ENV_CACHE/python\"\n\nCURRENT_INTERP=\"$(realpath \"$(which python3)\")\"\nCACHED_INTERP=\"$(cat \"$PYTHON_DIR/.interpreter\" \\\n  2>/dev/null || echo none)\"\n\nif [ ! -d \"$PYTHON_DIR\" ] \\\n    || [ \"$CURRENT_INTERP\" != \"$CACHED_INTERP\" ]; then\n  python3 -m venv --upgrade-deps \"$PYTHON_DIR\"\n  echo \"$CURRENT_INTERP\" > \"$PYTHON_DIR/.interpreter\"\nfi\n\nunset VIRTUAL_ENV\nsource \"$PYTHON_DIR/bin/activate\"\n\nHASH=$(echo \"$GRAPHIFY_INSTALL_PACKAGE\" | md5sum 2>/dev/null \\\n  || echo \"$GRAPHIFY_INSTALL_PACKAGE\" | md5 -q)\nHASH=$(echo \"$HASH\" | cut -d\" \" -f1)\nLAST=$(cat \"$PYTHON_DIR/.deps_hash\" 2>/dev/null)\nif [ \"$HASH\" != \"$LAST\" ]; then\n  pip install -q \"$GRAPHIFY_INSTALL_PACKAGE\"\n  echo \"$HASH\" > \"$PYTHON_DIR/.deps_hash\"\nfi\n\neval \"$(flox-ai setup-hook)\"\n\nif [[ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]]; then\n  gum style --border double --margin '1 2' \\\n    --padding '1 4' \\\n    'graphify — knowledge graphs for Claude Code' '' \\\n    'The /graphify skill is pre-installed via' \\\n    'flox/skill-graphify and discovered by' \\\n    'flox-ai. Just open Claude Code:' \\\n    '  /graphify .' '' \\\n    'Or use the CLI directly:' \\\n    '  graphify .' \\\n    '  graphify ./raw --mode deep' \\\n    '  graphify ./raw --update' '' \\\n    'Query the graph:' \\\n    '  graphify query \"what connects X to Y?\"' \\\n    '  graphify path \"Module\" \"Database\"' \\\n    '  graphify explain \"Concept\"'\nfi\n"
     },
     "profile": {
-      "bash": "source \"$PYTHON_DIR/bin/activate\"\n\neval \"$(claude-managed setup-profile-bash)\"\n",
-      "zsh": "source \"$PYTHON_DIR/bin/activate\"\n\neval \"$(claude-managed setup-profile-zsh)\"\n",
-      "fish": "source \"$PYTHON_DIR/bin/activate.fish\"\n\nclaude-managed setup-profile-fish | source\n",
+      "bash": "source \"$PYTHON_DIR/bin/activate\"\n\neval \"$(flox-ai setup-profile-bash)\"\n",
+      "zsh": "source \"$PYTHON_DIR/bin/activate\"\n\neval \"$(flox-ai setup-profile-zsh)\"\n",
+      "fish": "source \"$PYTHON_DIR/bin/activate.fish\"\n\nflox-ai setup-profile-fish | source\n",
       "tcsh": "source \"$PYTHON_DIR/bin/activate.csh\"\n"
     },
     "options": {},
@@ -209,126 +209,6 @@
       "priority": 5
     },
     {
-      "attr_path": "claude-managed",
-      "broken": false,
-      "derivation": "/nix/store/jrvmawn988xs2da7mg9dzfg3h3jf5gm3-claude-managed-0.4.1.drv",
-      "description": "Flox-native config management for Claude Code CLI",
-      "install_id": "claude-managed",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "name": "claude-managed-0.4.1",
-      "pname": "claude-managed",
-      "rev": "ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "rev_count": 3677,
-      "rev_date": "2026-05-20T12:30:23Z",
-      "scrape_date": "2026-06-15T02:16:32.550373161Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.4.1",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/c4caj5rhq2l7p7j5p569a1f08pz5s41v-claude-managed-0.4.1"
-      },
-      "system": "aarch64-darwin",
-      "group": "claude-managed",
-      "priority": 5
-    },
-    {
-      "attr_path": "claude-managed",
-      "broken": false,
-      "derivation": "/nix/store/b0iga9ysmq5jga9xmnqf5884qhl7idjp-claude-managed-0.4.1.drv",
-      "description": "Flox-native config management for Claude Code CLI",
-      "install_id": "claude-managed",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "name": "claude-managed-0.4.1",
-      "pname": "claude-managed",
-      "rev": "ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "rev_count": 3677,
-      "rev_date": "2026-05-20T12:30:23Z",
-      "scrape_date": "2026-06-15T02:16:32.550374924Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.4.1",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/ikmmb7a0zfdwsyzcgczv7sam426n7y82-claude-managed-0.4.1"
-      },
-      "system": "aarch64-linux",
-      "group": "claude-managed",
-      "priority": 5
-    },
-    {
-      "attr_path": "claude-managed",
-      "broken": false,
-      "derivation": "/nix/store/nv6viy7wixxv9f92jh5pbzss4ipkmsaz-claude-managed-0.4.1.drv",
-      "description": "Flox-native config management for Claude Code CLI",
-      "install_id": "claude-managed",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "name": "claude-managed-0.4.1",
-      "pname": "claude-managed",
-      "rev": "ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "rev_count": 3677,
-      "rev_date": "2026-05-20T12:30:23Z",
-      "scrape_date": "2026-06-15T02:16:32.550375485Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.4.1",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/6mavy5l8gbcq21qxnlxip78dqdr960lm-claude-managed-0.4.1"
-      },
-      "system": "x86_64-darwin",
-      "group": "claude-managed",
-      "priority": 5
-    },
-    {
-      "attr_path": "claude-managed",
-      "broken": false,
-      "derivation": "/nix/store/xql8a4pin3z899a09rs9hbc5axcnbi93-claude-managed-0.4.1.drv",
-      "description": "Flox-native config management for Claude Code CLI",
-      "install_id": "claude-managed",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "name": "claude-managed-0.4.1",
-      "pname": "claude-managed",
-      "rev": "ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "rev_count": 3677,
-      "rev_date": "2026-05-20T12:30:23Z",
-      "scrape_date": "2026-06-15T02:16:32.550375896Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.4.1",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/ak71ws4lbp04ik1cvqws4drjbiaw5cin-claude-managed-0.4.1"
-      },
-      "system": "x86_64-linux",
-      "group": "claude-managed",
-      "priority": 5
-    },
-    {
       "attr_path": "gum",
       "broken": false,
       "derivation": "/nix/store/jsk66asqq2wnckkllv9sm1y94mxl0asm-gum-0.17.0.drv",
@@ -446,6 +326,126 @@
       },
       "system": "x86_64-linux",
       "group": "demo-tools",
+      "priority": 5
+    },
+    {
+      "attr_path": "flox-ai",
+      "broken": false,
+      "derivation": "/nix/store/3c69hqd40j8kpxjhc6qcz7ij502c9l10-flox-ai-0.5.0.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "flox-ai",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=b70958050f38ef6f333914e083379ad6b2c201f0",
+      "name": "flox-ai-0.5.0",
+      "pname": "flox-ai",
+      "rev": "b70958050f38ef6f333914e083379ad6b2c201f0",
+      "rev_count": 7638,
+      "rev_date": "2026-06-13T13:06:59Z",
+      "scrape_date": "2026-06-15T16:50:32.942640Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.5.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/yjn7g3y8a1zhrjzih6ycd00pban7bijm-flox-ai-0.5.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "flox-ai",
+      "priority": 5
+    },
+    {
+      "attr_path": "flox-ai",
+      "broken": false,
+      "derivation": "/nix/store/8ck474yn2l0dic0srxvml5l6szmlv0xf-flox-ai-0.5.0.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "flox-ai",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=b70958050f38ef6f333914e083379ad6b2c201f0",
+      "name": "flox-ai-0.5.0",
+      "pname": "flox-ai",
+      "rev": "b70958050f38ef6f333914e083379ad6b2c201f0",
+      "rev_count": 7638,
+      "rev_date": "2026-06-13T13:06:59Z",
+      "scrape_date": "2026-06-15T16:50:32.942643Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.5.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/l1wxijmjnmx66i7f15qkplpr5j2jsd2y-flox-ai-0.5.0"
+      },
+      "system": "aarch64-linux",
+      "group": "flox-ai",
+      "priority": 5
+    },
+    {
+      "attr_path": "flox-ai",
+      "broken": false,
+      "derivation": "/nix/store/pzgvpxjipsxjmqbdjjsyvmb3v14h178a-flox-ai-0.5.0.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "flox-ai",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=b70958050f38ef6f333914e083379ad6b2c201f0",
+      "name": "flox-ai-0.5.0",
+      "pname": "flox-ai",
+      "rev": "b70958050f38ef6f333914e083379ad6b2c201f0",
+      "rev_count": 7638,
+      "rev_date": "2026-06-13T13:06:59Z",
+      "scrape_date": "2026-06-15T16:50:32.942644Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.5.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/minnw6ndg1g8bi4s1khyi2r9a1p2ggp5-flox-ai-0.5.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "flox-ai",
+      "priority": 5
+    },
+    {
+      "attr_path": "flox-ai",
+      "broken": false,
+      "derivation": "/nix/store/rqx8dk2f34057zvlxp4518hh5jz390yz-flox-ai-0.5.0.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "flox-ai",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=b70958050f38ef6f333914e083379ad6b2c201f0",
+      "name": "flox-ai-0.5.0",
+      "pname": "flox-ai",
+      "rev": "b70958050f38ef6f333914e083379ad6b2c201f0",
+      "rev_count": 7638,
+      "rev_date": "2026-06-13T13:06:59Z",
+      "scrape_date": "2026-06-15T16:50:32.942645Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.5.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/hwnzrnlas0knhcjxd3imscx71dygj0cg-flox-ai-0.5.0"
+      },
+      "system": "x86_64-linux",
+      "group": "flox-ai",
       "priority": 5
     },
     {
@@ -1559,7 +1559,7 @@
         }
       },
       "hook": {
-        "on-activate": "if [[ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]]; then\n  gum style --border double --margin '1 2' \\\n    --padding '1 4' \\\n    'graphify — knowledge graphs for Claude Code' '' \\\n    'The /graphify skill is pre-installed via' \\\n    'flox/skill-graphify and discovered by' \\\n    'claude-managed. Just open Claude Code:' \\\n    '  /graphify .' '' \\\n    'Or use the CLI directly:' \\\n    '  graphify .' \\\n    '  graphify ./raw --mode deep' \\\n    '  graphify ./raw --update' '' \\\n    'Query the graph:' \\\n    '  graphify query \"what connects X to Y?\"' \\\n    '  graphify path \"Module\" \"Database\"' \\\n    '  graphify explain \"Concept\"'\nfi\n"
+        "on-activate": "if [[ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]]; then\n  gum style --border double --margin '1 2' \\\n    --padding '1 4' \\\n    'graphify — knowledge graphs for Claude Code' '' \\\n    'The /graphify skill is pre-installed via' \\\n    'flox/skill-graphify and discovered by' \\\n    'flox-ai. Just open Claude Code:' \\\n    '  /graphify .' '' \\\n    'Or use the CLI directly:' \\\n    '  graphify .' \\\n    '  graphify ./raw --mode deep' \\\n    '  graphify ./raw --update' '' \\\n    'Query the graph:' \\\n    '  graphify query \"what connects X to Y?\"' \\\n    '  graphify path \"Module\" \"Database\"' \\\n    '  graphify explain \"Concept\"'\nfi\n"
       },
       "options": {},
       "include": {
@@ -1662,19 +1662,19 @@
               "pkg-path": "flox/claude-code",
               "pkg-group": "claude-code"
             },
-            "claude-managed": {
-              "pkg-path": "flox/claude-managed",
-              "pkg-group": "claude-managed",
-              "version": "^0.4.1"
+            "flox-ai": {
+              "pkg-path": "flox/flox-ai",
+              "pkg-group": "flox-ai",
+              "version": "^0.5.0"
             }
           },
           "hook": {
-            "on-activate": "eval \"$(claude-managed setup-hook)\"\n"
+            "on-activate": "eval \"$(flox-ai setup-hook)\"\n"
           },
           "profile": {
-            "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
-            "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
-            "fish": "claude-managed setup-profile-fish | source\n"
+            "bash": "eval \"$(flox-ai setup-profile-bash)\"\n",
+            "zsh": "eval \"$(flox-ai setup-profile-zsh)\"\n",
+            "fish": "flox-ai setup-profile-fish | source\n"
           },
           "options": {}
         },

--- a/graphify-demo/.flox/env/manifest.toml
+++ b/graphify-demo/.flox/env/manifest.toml
@@ -9,7 +9,7 @@ environments = [
 # gum is a demo-only tool for styled terminal output.
 # skills-graphify ships the /graphify SKILL.md into
 # $FLOX_ENV/share/claude-code/skills/graphify/ where
-# claude-managed (pulled in via flox/claude) auto-discovers
+# flox-ai (pulled in via flox/claude) auto-discovers
 # it on activate — no `graphify install` step needed.
 
 [install]
@@ -26,7 +26,7 @@ if [[ "${FLOX_ENVS_TESTING:-}" != "1" ]]; then
     'graphify — knowledge graphs for Claude Code' '' \
     'The /graphify skill is pre-installed via' \
     'flox/skill-graphify and discovered by' \
-    'claude-managed. Just open Claude Code:' \
+    'flox-ai. Just open Claude Code:' \
     '  /graphify .' '' \
     'Or use the CLI directly:' \
     '  graphify .' \

--- a/graphify-demo/README.md
+++ b/graphify-demo/README.md
@@ -19,7 +19,7 @@ flox activate -r flox/graphify-demo
 
 The `/graphify` skill is pre-installed via
 `flox/skills-graphify` and auto-discovered by
-`claude-managed` — no `graphify install` step needed.
+`flox-ai` — no `graphify install` step needed.
 
 Open Claude Code in any directory and type:
 
@@ -38,7 +38,7 @@ graphify .
 - Everything from the `graphify` base environment
   (Python 3.11, `graphify` CLI, Claude Code)
 - The `flox/claude` env via `[include]` for
-  `claude-managed` (which auto-discovers skills under
+  `flox-ai` (which auto-discovers skills under
   `$FLOX_ENV/share/claude-code/skills/`)
 - `flox/skills-graphify` — ships the `/graphify` SKILL.md
   so Claude Code finds it on activate

--- a/graphify-demo/test.sh
+++ b/graphify-demo/test.sh
@@ -10,8 +10,8 @@ if ! command -v claude >/dev/null 2>&1; then
   echo "Error: 'claude' command not found."
   exit 1
 fi
-if ! command -v claude-managed >/dev/null 2>&1; then
-  echo "Error: 'claude-managed' command not found."
+if ! command -v flox-ai >/dev/null 2>&1; then
+  echo "Error: 'flox-ai' command not found."
   exit 1
 fi
 if ! command -v graphify >/dev/null 2>&1; then
@@ -25,22 +25,22 @@ fi
 
 echo ">>> python3 version: $(python3 --version)"
 echo ">>> claude version: $(claude --version 2>&1 | head -1)"
-echo ">>> claude-managed version: $(claude-managed --version 2>&1 | head -1)"
+echo ">>> flox-ai version: $(flox-ai --version 2>&1 | head -1)"
 echo ">>> graphify available: $(command -v graphify)"
 echo ">>> gum version: $(gum --version)"
 
 # Verify graphify is a working CLI (no Claude session required).
 graphify --help >/dev/null
 
-# Verify claude-managed discovered the bundled /graphify skill.
+# Verify flox-ai discovered the bundled /graphify skill.
 # Strip ANSI colors so grep matches regardless of terminal style.
-doctor_out="$(claude-managed doctor 2>&1 \
+doctor_out="$(flox-ai doctor 2>&1 \
   | sed $'s/\x1b\\[[0-9;]*[A-Za-z]//g')"
 if ! echo "$doctor_out" | grep -qE '✓[[:space:]]+graphify'; then
-  echo "Error: claude-managed did not discover the graphify skill."
+  echo "Error: flox-ai did not discover the graphify skill."
   echo "$doctor_out" | tail -20
   exit 1
 fi
-echo ">>> claude-managed discovered the /graphify skill"
+echo ">>> flox-ai discovered the /graphify skill"
 
 echo ">>> graphify-demo environment is working"

--- a/gstack-demo/.flox/env/manifest.lock
+++ b/gstack-demo/.flox/env/manifest.lock
@@ -11,10 +11,10 @@
         "pkg-path": "flox/claude-code-plugin-gstack",
         "pkg-group": "claude-code-plugin-gstack"
       },
-      "claude-managed": {
-        "pkg-path": "flox/claude-managed",
-        "pkg-group": "claude-managed",
-        "version": "^0.4.1"
+      "flox-ai": {
+        "pkg-path": "flox/flox-ai",
+        "pkg-group": "flox-ai",
+        "version": "^0.5.0"
       },
       "gum": {
         "pkg-path": "gum",
@@ -22,12 +22,12 @@
       }
     },
     "hook": {
-      "on-activate": "eval \"$(claude-managed setup-hook)\"\n\nif [ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]; then\n  gum style \\\n    --foreground 212 --border-foreground 212 \\\n    --border double --align center \\\n    --width 60 --margin \"1 2\" --padding \"1 2\" \\\n    \"gstack\" \"Garry Tan's Claude Code stack\"\n  echo \"\"\n  echo \"  claude                 — start Claude Code\"\n  echo \"  claude-managed doctor  — show config and validate\"\n  echo \"\"\n  echo \"  Try one of:\"\n  echo \"    /office-hours    Pitch an idea, get a CEO grill\"\n  echo \"    /plan-ceo-review Strategic challenge of a plan\"\n  echo \"    /review          Pre-landing review of a branch\"\n  echo \"    /qa              Browser-driven QA on a URL\"\n  echo \"    /ship            Open a PR with the gstack flow\"\n  echo \"\"\nfi\n"
+      "on-activate": "eval \"$(flox-ai setup-hook)\"\n\nif [ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]; then\n  gum style \\\n    --foreground 212 --border-foreground 212 \\\n    --border double --align center \\\n    --width 60 --margin \"1 2\" --padding \"1 2\" \\\n    \"gstack\" \"Garry Tan's Claude Code stack\"\n  echo \"\"\n  echo \"  claude                 — start Claude Code\"\n  echo \"  flox-ai doctor  — show config and validate\"\n  echo \"\"\n  echo \"  Try one of:\"\n  echo \"    /office-hours    Pitch an idea, get a CEO grill\"\n  echo \"    /plan-ceo-review Strategic challenge of a plan\"\n  echo \"    /review          Pre-landing review of a branch\"\n  echo \"    /qa              Browser-driven QA on a URL\"\n  echo \"    /ship            Open a PR with the gstack flow\"\n  echo \"\"\nfi\n"
     },
     "profile": {
-      "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
-      "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
-      "fish": "claude-managed setup-profile-fish | source\n"
+      "bash": "eval \"$(flox-ai setup-profile-bash)\"\n",
+      "zsh": "eval \"$(flox-ai setup-profile-zsh)\"\n",
+      "fish": "flox-ai setup-profile-fish | source\n"
     },
     "options": {}
   },
@@ -273,126 +273,6 @@
       "priority": 5
     },
     {
-      "attr_path": "claude-managed",
-      "broken": false,
-      "derivation": "/nix/store/jrvmawn988xs2da7mg9dzfg3h3jf5gm3-claude-managed-0.4.1.drv",
-      "description": "Flox-native config management for Claude Code CLI",
-      "install_id": "claude-managed",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "name": "claude-managed-0.4.1",
-      "pname": "claude-managed",
-      "rev": "ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "rev_count": 3677,
-      "rev_date": "2026-05-20T12:30:23Z",
-      "scrape_date": "2026-06-15T02:19:31.911999410Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.4.1",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/c4caj5rhq2l7p7j5p569a1f08pz5s41v-claude-managed-0.4.1"
-      },
-      "system": "aarch64-darwin",
-      "group": "claude-managed",
-      "priority": 5
-    },
-    {
-      "attr_path": "claude-managed",
-      "broken": false,
-      "derivation": "/nix/store/b0iga9ysmq5jga9xmnqf5884qhl7idjp-claude-managed-0.4.1.drv",
-      "description": "Flox-native config management for Claude Code CLI",
-      "install_id": "claude-managed",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "name": "claude-managed-0.4.1",
-      "pname": "claude-managed",
-      "rev": "ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "rev_count": 3677,
-      "rev_date": "2026-05-20T12:30:23Z",
-      "scrape_date": "2026-06-15T02:19:31.912000061Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.4.1",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/ikmmb7a0zfdwsyzcgczv7sam426n7y82-claude-managed-0.4.1"
-      },
-      "system": "aarch64-linux",
-      "group": "claude-managed",
-      "priority": 5
-    },
-    {
-      "attr_path": "claude-managed",
-      "broken": false,
-      "derivation": "/nix/store/nv6viy7wixxv9f92jh5pbzss4ipkmsaz-claude-managed-0.4.1.drv",
-      "description": "Flox-native config management for Claude Code CLI",
-      "install_id": "claude-managed",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "name": "claude-managed-0.4.1",
-      "pname": "claude-managed",
-      "rev": "ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "rev_count": 3677,
-      "rev_date": "2026-05-20T12:30:23Z",
-      "scrape_date": "2026-06-15T02:19:31.912000452Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.4.1",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/6mavy5l8gbcq21qxnlxip78dqdr960lm-claude-managed-0.4.1"
-      },
-      "system": "x86_64-darwin",
-      "group": "claude-managed",
-      "priority": 5
-    },
-    {
-      "attr_path": "claude-managed",
-      "broken": false,
-      "derivation": "/nix/store/xql8a4pin3z899a09rs9hbc5axcnbi93-claude-managed-0.4.1.drv",
-      "description": "Flox-native config management for Claude Code CLI",
-      "install_id": "claude-managed",
-      "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "name": "claude-managed-0.4.1",
-      "pname": "claude-managed",
-      "rev": "ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "rev_count": 3677,
-      "rev_date": "2026-05-20T12:30:23Z",
-      "scrape_date": "2026-06-15T02:19:31.912001183Z",
-      "stabilities": [
-        "staging",
-        "unstable"
-      ],
-      "unfree": false,
-      "version": "0.4.1",
-      "outputs_to_install": [
-        "out"
-      ],
-      "outputs": {
-        "out": "/nix/store/ak71ws4lbp04ik1cvqws4drjbiaw5cin-claude-managed-0.4.1"
-      },
-      "system": "x86_64-linux",
-      "group": "claude-managed",
-      "priority": 5
-    },
-    {
       "attr_path": "gum",
       "broken": false,
       "derivation": "/nix/store/jsk66asqq2wnckkllv9sm1y94mxl0asm-gum-0.17.0.drv",
@@ -511,6 +391,126 @@
       "system": "x86_64-linux",
       "group": "demo-tools",
       "priority": 5
+    },
+    {
+      "attr_path": "flox-ai",
+      "broken": false,
+      "derivation": "/nix/store/3c69hqd40j8kpxjhc6qcz7ij502c9l10-flox-ai-0.5.0.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "flox-ai",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=b70958050f38ef6f333914e083379ad6b2c201f0",
+      "name": "flox-ai-0.5.0",
+      "pname": "flox-ai",
+      "rev": "b70958050f38ef6f333914e083379ad6b2c201f0",
+      "rev_count": 7638,
+      "rev_date": "2026-06-13T13:06:59Z",
+      "scrape_date": "2026-06-15T16:50:30.583847Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.5.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/yjn7g3y8a1zhrjzih6ycd00pban7bijm-flox-ai-0.5.0"
+      },
+      "system": "aarch64-darwin",
+      "group": "flox-ai",
+      "priority": 5
+    },
+    {
+      "attr_path": "flox-ai",
+      "broken": false,
+      "derivation": "/nix/store/8ck474yn2l0dic0srxvml5l6szmlv0xf-flox-ai-0.5.0.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "flox-ai",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=b70958050f38ef6f333914e083379ad6b2c201f0",
+      "name": "flox-ai-0.5.0",
+      "pname": "flox-ai",
+      "rev": "b70958050f38ef6f333914e083379ad6b2c201f0",
+      "rev_count": 7638,
+      "rev_date": "2026-06-13T13:06:59Z",
+      "scrape_date": "2026-06-15T16:50:30.583850Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.5.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/l1wxijmjnmx66i7f15qkplpr5j2jsd2y-flox-ai-0.5.0"
+      },
+      "system": "aarch64-linux",
+      "group": "flox-ai",
+      "priority": 5
+    },
+    {
+      "attr_path": "flox-ai",
+      "broken": false,
+      "derivation": "/nix/store/pzgvpxjipsxjmqbdjjsyvmb3v14h178a-flox-ai-0.5.0.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "flox-ai",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=b70958050f38ef6f333914e083379ad6b2c201f0",
+      "name": "flox-ai-0.5.0",
+      "pname": "flox-ai",
+      "rev": "b70958050f38ef6f333914e083379ad6b2c201f0",
+      "rev_count": 7638,
+      "rev_date": "2026-06-13T13:06:59Z",
+      "scrape_date": "2026-06-15T16:50:30.583851Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.5.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/minnw6ndg1g8bi4s1khyi2r9a1p2ggp5-flox-ai-0.5.0"
+      },
+      "system": "x86_64-darwin",
+      "group": "flox-ai",
+      "priority": 5
+    },
+    {
+      "attr_path": "flox-ai",
+      "broken": false,
+      "derivation": "/nix/store/rqx8dk2f34057zvlxp4518hh5jz390yz-flox-ai-0.5.0.drv",
+      "description": "Flox-native config management for Claude Code CLI",
+      "install_id": "flox-ai",
+      "license": "MIT",
+      "locked_url": "https://github.com/flox/floxenvs?rev=b70958050f38ef6f333914e083379ad6b2c201f0",
+      "name": "flox-ai-0.5.0",
+      "pname": "flox-ai",
+      "rev": "b70958050f38ef6f333914e083379ad6b2c201f0",
+      "rev_count": 7638,
+      "rev_date": "2026-06-13T13:06:59Z",
+      "scrape_date": "2026-06-15T16:50:30.583852Z",
+      "stabilities": [
+        "staging",
+        "unstable"
+      ],
+      "unfree": false,
+      "version": "0.5.0",
+      "outputs_to_install": [
+        "out"
+      ],
+      "outputs": {
+        "out": "/nix/store/hwnzrnlas0knhcjxd3imscx71dygj0cg-flox-ai-0.5.0"
+      },
+      "system": "x86_64-linux",
+      "group": "flox-ai",
+      "priority": 5
     }
   ],
   "compose": {
@@ -523,7 +523,7 @@
         }
       },
       "hook": {
-        "on-activate": "if [ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]; then\n  gum style \\\n    --foreground 212 --border-foreground 212 \\\n    --border double --align center \\\n    --width 60 --margin \"1 2\" --padding \"1 2\" \\\n    \"gstack\" \"Garry Tan's Claude Code stack\"\n  echo \"\"\n  echo \"  claude                 — start Claude Code\"\n  echo \"  claude-managed doctor  — show config and validate\"\n  echo \"\"\n  echo \"  Try one of:\"\n  echo \"    /office-hours    Pitch an idea, get a CEO grill\"\n  echo \"    /plan-ceo-review Strategic challenge of a plan\"\n  echo \"    /review          Pre-landing review of a branch\"\n  echo \"    /qa              Browser-driven QA on a URL\"\n  echo \"    /ship            Open a PR with the gstack flow\"\n  echo \"\"\nfi\n"
+        "on-activate": "if [ \"${FLOX_ENVS_TESTING:-}\" != \"1\" ]; then\n  gum style \\\n    --foreground 212 --border-foreground 212 \\\n    --border double --align center \\\n    --width 60 --margin \"1 2\" --padding \"1 2\" \\\n    \"gstack\" \"Garry Tan's Claude Code stack\"\n  echo \"\"\n  echo \"  claude                 — start Claude Code\"\n  echo \"  flox-ai doctor  — show config and validate\"\n  echo \"\"\n  echo \"  Try one of:\"\n  echo \"    /office-hours    Pitch an idea, get a CEO grill\"\n  echo \"    /plan-ceo-review Strategic challenge of a plan\"\n  echo \"    /review          Pre-landing review of a branch\"\n  echo \"    /qa              Browser-driven QA on a URL\"\n  echo \"    /ship            Open a PR with the gstack flow\"\n  echo \"\"\nfi\n"
       },
       "options": {},
       "include": {
@@ -547,19 +547,19 @@
               "pkg-path": "flox/claude-code-plugin-gstack",
               "pkg-group": "claude-code-plugin-gstack"
             },
-            "claude-managed": {
-              "pkg-path": "flox/claude-managed",
-              "pkg-group": "claude-managed",
-              "version": "^0.4.1"
+            "flox-ai": {
+              "pkg-path": "flox/flox-ai",
+              "pkg-group": "flox-ai",
+              "version": "^0.5.0"
             }
           },
           "hook": {
-            "on-activate": "eval \"$(claude-managed setup-hook)\"\n"
+            "on-activate": "eval \"$(flox-ai setup-hook)\"\n"
           },
           "profile": {
-            "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
-            "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
-            "fish": "claude-managed setup-profile-fish | source\n"
+            "bash": "eval \"$(flox-ai setup-profile-bash)\"\n",
+            "zsh": "eval \"$(flox-ai setup-profile-zsh)\"\n",
+            "fish": "flox-ai setup-profile-fish | source\n"
           },
           "options": {}
         },

--- a/gstack-demo/.flox/env/manifest.toml
+++ b/gstack-demo/.flox/env/manifest.toml
@@ -19,7 +19,7 @@ if [ "${FLOX_ENVS_TESTING:-}" != "1" ]; then
     "gstack" "Garry Tan's Claude Code stack"
   echo ""
   echo "  claude                 — start Claude Code"
-  echo "  claude-managed doctor  — show config and validate"
+  echo "  flox-ai doctor  — show config and validate"
   echo ""
   echo "  Try one of:"
   echo "    /office-hours    Pitch an idea, get a CEO grill"

--- a/gstack-demo/test.sh
+++ b/gstack-demo/test.sh
@@ -12,19 +12,19 @@ command_exists() {
 
 # ── Required commands (inherited from flox/claude + demo) ─
 command_exists claude
-command_exists claude-managed
+command_exists flox-ai
 command_exists gum
 
 echo ">>> claude version: $(claude --version)"
-echo ">>> claude-managed version: $(claude-managed version)"
+echo ">>> flox-ai version: $(flox-ai version)"
 echo ">>> gum version: $(gum --version)"
 
 # ── Managed mode ──────────────────────────────────────
-if [ "${CLAUDE_MANAGED:-}" != "1" ]; then
-  echo "Error: CLAUDE_MANAGED not set."
+if [ "${FLOX_AI:-}" != "1" ]; then
+  echo "Error: FLOX_AI not set."
   exit 1
 fi
-echo ">>> CLAUDE_MANAGED=1"
+echo ">>> FLOX_AI=1"
 
 # ── gstack plugin is installed ────────────────────────
 GSTACK_ROOT="$FLOX_ENV/share/claude-code/plugins/gstack"
@@ -41,7 +41,7 @@ fi
 echo ">>> plugin.json present"
 
 # ── Doctor check ──────────────────────────────────────
-echo ">>> claude-managed doctor"
-claude-managed doctor
+echo ">>> flox-ai doctor"
+flox-ai doctor
 
 echo ">>> gstack-demo environment is working"

--- a/gstack/.flox/env/manifest.lock
+++ b/gstack/.flox/env/manifest.lock
@@ -11,19 +11,19 @@
         "pkg-path": "flox/claude-code-plugin-gstack",
         "pkg-group": "claude-code-plugin-gstack"
       },
-      "claude-managed": {
-        "pkg-path": "flox/claude-managed",
-        "pkg-group": "claude-managed",
-        "version": "^0.4.1"
+      "flox-ai": {
+        "pkg-path": "flox/flox-ai",
+        "pkg-group": "flox-ai",
+        "version": "^0.5.0"
       }
     },
     "hook": {
-      "on-activate": "eval \"$(claude-managed setup-hook)\"\n"
+      "on-activate": "eval \"$(flox-ai setup-hook)\"\n"
     },
     "profile": {
-      "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
-      "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
-      "fish": "claude-managed setup-profile-fish | source\n"
+      "bash": "eval \"$(flox-ai setup-profile-bash)\"\n",
+      "zsh": "eval \"$(flox-ai setup-profile-zsh)\"\n",
+      "fish": "flox-ai setup-profile-fish | source\n"
     },
     "options": {}
   },
@@ -269,123 +269,123 @@
       "priority": 5
     },
     {
-      "attr_path": "claude-managed",
+      "attr_path": "flox-ai",
       "broken": false,
-      "derivation": "/nix/store/jrvmawn988xs2da7mg9dzfg3h3jf5gm3-claude-managed-0.4.1.drv",
+      "derivation": "/nix/store/3c69hqd40j8kpxjhc6qcz7ij502c9l10-flox-ai-0.5.0.drv",
       "description": "Flox-native config management for Claude Code CLI",
-      "install_id": "claude-managed",
+      "install_id": "flox-ai",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "name": "claude-managed-0.4.1",
-      "pname": "claude-managed",
-      "rev": "ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "rev_count": 3677,
-      "rev_date": "2026-05-20T12:30:23Z",
-      "scrape_date": "2026-06-15T02:19:09.535807177Z",
+      "locked_url": "https://github.com/flox/floxenvs?rev=b70958050f38ef6f333914e083379ad6b2c201f0",
+      "name": "flox-ai-0.5.0",
+      "pname": "flox-ai",
+      "rev": "b70958050f38ef6f333914e083379ad6b2c201f0",
+      "rev_count": 7638,
+      "rev_date": "2026-06-13T13:06:59Z",
+      "scrape_date": "2026-06-15T16:50:08.905869Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "0.4.1",
+      "version": "0.5.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/c4caj5rhq2l7p7j5p569a1f08pz5s41v-claude-managed-0.4.1"
+        "out": "/nix/store/yjn7g3y8a1zhrjzih6ycd00pban7bijm-flox-ai-0.5.0"
       },
       "system": "aarch64-darwin",
-      "group": "claude-managed",
+      "group": "flox-ai",
       "priority": 5
     },
     {
-      "attr_path": "claude-managed",
+      "attr_path": "flox-ai",
       "broken": false,
-      "derivation": "/nix/store/b0iga9ysmq5jga9xmnqf5884qhl7idjp-claude-managed-0.4.1.drv",
+      "derivation": "/nix/store/8ck474yn2l0dic0srxvml5l6szmlv0xf-flox-ai-0.5.0.drv",
       "description": "Flox-native config management for Claude Code CLI",
-      "install_id": "claude-managed",
+      "install_id": "flox-ai",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "name": "claude-managed-0.4.1",
-      "pname": "claude-managed",
-      "rev": "ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "rev_count": 3677,
-      "rev_date": "2026-05-20T12:30:23Z",
-      "scrape_date": "2026-06-15T02:19:09.535808189Z",
+      "locked_url": "https://github.com/flox/floxenvs?rev=b70958050f38ef6f333914e083379ad6b2c201f0",
+      "name": "flox-ai-0.5.0",
+      "pname": "flox-ai",
+      "rev": "b70958050f38ef6f333914e083379ad6b2c201f0",
+      "rev_count": 7638,
+      "rev_date": "2026-06-13T13:06:59Z",
+      "scrape_date": "2026-06-15T16:50:08.905874Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "0.4.1",
+      "version": "0.5.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/ikmmb7a0zfdwsyzcgczv7sam426n7y82-claude-managed-0.4.1"
+        "out": "/nix/store/l1wxijmjnmx66i7f15qkplpr5j2jsd2y-flox-ai-0.5.0"
       },
       "system": "aarch64-linux",
-      "group": "claude-managed",
+      "group": "flox-ai",
       "priority": 5
     },
     {
-      "attr_path": "claude-managed",
+      "attr_path": "flox-ai",
       "broken": false,
-      "derivation": "/nix/store/nv6viy7wixxv9f92jh5pbzss4ipkmsaz-claude-managed-0.4.1.drv",
+      "derivation": "/nix/store/pzgvpxjipsxjmqbdjjsyvmb3v14h178a-flox-ai-0.5.0.drv",
       "description": "Flox-native config management for Claude Code CLI",
-      "install_id": "claude-managed",
+      "install_id": "flox-ai",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "name": "claude-managed-0.4.1",
-      "pname": "claude-managed",
-      "rev": "ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "rev_count": 3677,
-      "rev_date": "2026-05-20T12:30:23Z",
-      "scrape_date": "2026-06-15T02:19:09.535808920Z",
+      "locked_url": "https://github.com/flox/floxenvs?rev=b70958050f38ef6f333914e083379ad6b2c201f0",
+      "name": "flox-ai-0.5.0",
+      "pname": "flox-ai",
+      "rev": "b70958050f38ef6f333914e083379ad6b2c201f0",
+      "rev_count": 7638,
+      "rev_date": "2026-06-13T13:06:59Z",
+      "scrape_date": "2026-06-15T16:50:08.905875Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "0.4.1",
+      "version": "0.5.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/6mavy5l8gbcq21qxnlxip78dqdr960lm-claude-managed-0.4.1"
+        "out": "/nix/store/minnw6ndg1g8bi4s1khyi2r9a1p2ggp5-flox-ai-0.5.0"
       },
       "system": "x86_64-darwin",
-      "group": "claude-managed",
+      "group": "flox-ai",
       "priority": 5
     },
     {
-      "attr_path": "claude-managed",
+      "attr_path": "flox-ai",
       "broken": false,
-      "derivation": "/nix/store/xql8a4pin3z899a09rs9hbc5axcnbi93-claude-managed-0.4.1.drv",
+      "derivation": "/nix/store/rqx8dk2f34057zvlxp4518hh5jz390yz-flox-ai-0.5.0.drv",
       "description": "Flox-native config management for Claude Code CLI",
-      "install_id": "claude-managed",
+      "install_id": "flox-ai",
       "license": "MIT",
-      "locked_url": "https://github.com/flox/floxenvs?rev=ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "name": "claude-managed-0.4.1",
-      "pname": "claude-managed",
-      "rev": "ec0dd4c37eabe9042c0d7dccbe550d407b51a28b",
-      "rev_count": 3677,
-      "rev_date": "2026-05-20T12:30:23Z",
-      "scrape_date": "2026-06-15T02:19:09.535809551Z",
+      "locked_url": "https://github.com/flox/floxenvs?rev=b70958050f38ef6f333914e083379ad6b2c201f0",
+      "name": "flox-ai-0.5.0",
+      "pname": "flox-ai",
+      "rev": "b70958050f38ef6f333914e083379ad6b2c201f0",
+      "rev_count": 7638,
+      "rev_date": "2026-06-13T13:06:59Z",
+      "scrape_date": "2026-06-15T16:50:08.905877Z",
       "stabilities": [
         "staging",
         "unstable"
       ],
       "unfree": false,
-      "version": "0.4.1",
+      "version": "0.5.0",
       "outputs_to_install": [
         "out"
       ],
       "outputs": {
-        "out": "/nix/store/ak71ws4lbp04ik1cvqws4drjbiaw5cin-claude-managed-0.4.1"
+        "out": "/nix/store/hwnzrnlas0knhcjxd3imscx71dygj0cg-flox-ai-0.5.0"
       },
       "system": "x86_64-linux",
-      "group": "claude-managed",
+      "group": "flox-ai",
       "priority": 5
     }
   ],
@@ -416,19 +416,19 @@
               "pkg-path": "flox/claude-code",
               "pkg-group": "claude-code"
             },
-            "claude-managed": {
-              "pkg-path": "flox/claude-managed",
-              "pkg-group": "claude-managed",
-              "version": "^0.4.1"
+            "flox-ai": {
+              "pkg-path": "flox/flox-ai",
+              "pkg-group": "flox-ai",
+              "version": "^0.5.0"
             }
           },
           "hook": {
-            "on-activate": "eval \"$(claude-managed setup-hook)\"\n"
+            "on-activate": "eval \"$(flox-ai setup-hook)\"\n"
           },
           "profile": {
-            "bash": "eval \"$(claude-managed setup-profile-bash)\"\n",
-            "zsh": "eval \"$(claude-managed setup-profile-zsh)\"\n",
-            "fish": "claude-managed setup-profile-fish | source\n"
+            "bash": "eval \"$(flox-ai setup-profile-bash)\"\n",
+            "zsh": "eval \"$(flox-ai setup-profile-zsh)\"\n",
+            "fish": "flox-ai setup-profile-fish | source\n"
           },
           "options": {}
         },

--- a/gstack/README.md
+++ b/gstack/README.md
@@ -31,7 +31,7 @@ Everything from [`claude`](../claude/) plus the
 gstack plugin tree at
 `$FLOX_ENV/share/claude-code/plugins/gstack/`.
 
-`claude-managed` discovers the plugin and symlinks it
+`flox-ai` discovers the plugin and symlinks it
 into the project-local `$CLAUDE_CONFIG_DIR/plugins/`,
 so all 45 skills become available without touching
 `~/.claude/`.
@@ -107,7 +107,7 @@ dir, not into the nix store.
 If you already have gstack cloned at
 `~/.claude/skills/gstack/` (the upstream-recommended
 install), the plugin install is independent and
-non-conflicting — `claude-managed` only touches its
+non-conflicting — `flox-ai` only touches its
 own config dir. Both can coexist, though Claude Code
 may surface duplicate skill names.
 

--- a/gstack/test.sh
+++ b/gstack/test.sh
@@ -12,17 +12,17 @@ command_exists() {
 
 # ── Required commands (inherited from flox/claude) ────
 command_exists claude
-command_exists claude-managed
+command_exists flox-ai
 
 echo ">>> claude version: $(claude --version)"
-echo ">>> claude-managed version: $(claude-managed version)"
+echo ">>> flox-ai version: $(flox-ai version)"
 
 # ── Managed mode ──────────────────────────────────────
-if [ "${CLAUDE_MANAGED:-}" != "1" ]; then
-  echo "Error: CLAUDE_MANAGED not set."
+if [ "${FLOX_AI:-}" != "1" ]; then
+  echo "Error: FLOX_AI not set."
   exit 1
 fi
-echo ">>> CLAUDE_MANAGED=1"
+echo ">>> FLOX_AI=1"
 
 if [ -z "${CLAUDE_CONFIG_DIR:-}" ]; then
   echo "Error: CLAUDE_CONFIG_DIR not set."
@@ -61,8 +61,8 @@ for tool in bun node git jq curl; do
 done
 echo ">>> bundled tools present"
 
-# ── Plugin is discoverable through claude-managed ─────
-echo ">>> claude-managed doctor"
-claude-managed doctor
+# ── Plugin is discoverable through flox-ai ─────
+echo ">>> flox-ai doctor"
+flox-ai doctor
 
 echo ">>> gstack environment is working"


### PR DESCRIPTION
Phase 3 of AI-220, follow-up to #3813.

Now that Phase 2 landed on main and CI republished `flox/claude` with
the flox-ai contract, this repoints the remaining consumers that
include `flox/claude` *remotely* (deferred in #3813).

## Changes

- binary `claude-managed` -> `flox-ai` in `test.sh` and manifest
  on-activate hooks (gstack, gstack-demo, graphify-demo)
- env var `CLAUDE_MANAGED` -> `FLOX_AI` in gstack/gstack-demo tests
- docs/comments in gstack, graphify-demo, and firecrawl READMEs
- relocked gstack, gstack-demo, graphify-demo via `flox include
  upgrade` / `flox edit -f` — the republished `flox/claude` snapshot
  now installs `flox/flox-ai ^0.5.0` in place of
  `flox/claude-managed ^0.4.1`

## Verification

- `git grep claude-managed` / `CLAUDE_MANAGED` (excluding locks) is now
  empty repo-wide
- lockfile relock is idempotent (re-running produces no further drift)