### PR TITLE
AI-254 refactor(flox-ai): move fragment validation from setup-hook to doctor

### DIFF
--- a/.flox/pkgs/flox-ai/README.md
+++ b/.flox/pkgs/flox-ai/README.md
@@ -60,12 +60,15 @@ flox-ai version         # print version
 Emits shell code for the on-activate hook phase:
 
 1. Exports env vars (`CLAUDE_CONFIG_DIR`, etc.)
-2. Validates fragments and prints warnings to stderr
-3. Bridges macOS Keychain credentials for the isolated
+2. Bridges macOS Keychain credentials for the isolated
    config dir
-4. Copies `~/.claude.json` for OAuth account metadata
-5. Cleans stale symlinks and creates fresh ones in
+3. Copies `~/.claude.json` for OAuth account metadata
+4. Cleans stale symlinks and creates fresh ones in
    `$CLAUDE_CONFIG_DIR/{rules,skills,agents}/`
+
+The hook does not validate fragments: surfacing frontmatter
+warnings on every activation is noisy. Run `flox-ai doctor`
+to see frontmatter and structure validation on demand.
 
 ### setup-profile
 
@@ -318,7 +321,7 @@ internal/
   discover/                 Scan $FLOX_ENV/share/claude-code/
   emit/                     Generate shell code
                             hook: env vars, keychain,
-                                  symlinks, validation
+                                  symlinks
                             profile: cleanup function,
                                      trap
   doctor/                   Fragment validation

--- a/.flox/pkgs/flox-ai/e2e/setup-hook.bats
+++ b/.flox/pkgs/flox-ai/e2e/setup-hook.bats
@@ -65,28 +65,13 @@ load test_helper/common
   assert_output --partial 'security add-generic-password'
 }
 
-@test "setup-hook warns on bad frontmatter" {
+# Fragment validation moved to `flox-ai doctor`; the hook stays silent so it
+# does not spam warnings on every environment activation. See doctor.bats for
+# the frontmatter validation coverage.
+@test "setup-hook does not validate fragments (no warnings)" {
   run_cm_split setup-hook
-  [[ "$CM_STDERR" == *"WARN:"* ]]
-  [[ "$CM_STDERR" == *"unknown frontmatter key"* ]]
-}
-
-@test "setup-hook warns on forbidden agent key" {
-  run_cm_split setup-hook
-  [[ "$CM_STDERR" == *"WARN:"* ]]
-  [[ "$CM_STDERR" == *"forbidden frontmatter key"* ]]
-}
-
-@test "setup-hook warns on invalid skill name" {
-  run_cm_split setup-hook
-  [[ "$CM_STDERR" == *"WARN:"* ]]
-  [[ "$CM_STDERR" == *"must be kebab-case"* ]]
-}
-
-@test "setup-hook warns on invalid effort" {
-  run_cm_split setup-hook
-  [[ "$CM_STDERR" == *"WARN:"* ]]
-  [[ "$CM_STDERR" == *"must be low|medium|high|max"* ]]
+  [[ "$CM_STDERR" != *"WARN:"* ]]
+  [[ "$CM_STDERR" != *"frontmatter"* ]]
 }
 
 @test "setup-hook without --dir or FLOX_ENV fails" {

--- a/.flox/pkgs/flox-ai/main.go
+++ b/.flox/pkgs/flox-ai/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -74,19 +73,19 @@ func main() {
 	switch cmd {
 	case "setup-hook":
 		requireShareDir()
-		if err := runSetup(shareDir, configDir, "hook", os.Stderr); err != nil {
+		if err := runSetup(shareDir, configDir, "hook"); err != nil {
 			fmt.Fprintf(os.Stderr, red("ERROR:")+" %v\n", err)
 			os.Exit(1)
 		}
 	case "setup-profile", "setup-profile-bash", "setup-profile-zsh":
 		requireShareDir()
-		if err := runSetup(shareDir, configDir, "profile", os.Stderr); err != nil {
+		if err := runSetup(shareDir, configDir, "profile"); err != nil {
 			fmt.Fprintf(os.Stderr, red("ERROR:")+" %v\n", err)
 			os.Exit(1)
 		}
 	case "setup-profile-fish":
 		requireShareDir()
-		if err := runSetup(shareDir, configDir, "profile-fish", os.Stderr); err != nil {
+		if err := runSetup(shareDir, configDir, "profile-fish"); err != nil {
 			fmt.Fprintf(os.Stderr, red("ERROR:")+" %v\n", err)
 			os.Exit(1)
 		}
@@ -168,22 +167,14 @@ Flags:
   --config-dir   Config dir (default: $FLOX_ENV_PROJECT/.flox-ai)`)
 }
 
-func runSetup(shareDir, configDir, mode string, warn io.Writer) error {
+// runSetup emits the shell code for the requested setup phase. Fragment
+// validation is intentionally NOT performed here: surfacing frontmatter
+// warnings on every environment activation is noisy. Those checks now live
+// solely in `flox-ai doctor`, which users run on demand.
+func runSetup(shareDir, configDir, mode string) error {
 	frags, err := discover.Scan(shareDir)
 	if err != nil {
 		return fmt.Errorf("discover: %w", err)
-	}
-
-	// validate fragments and warn (don't block activation)
-	if mode == "hook" {
-		result := doctor.Check(frags)
-		for _, issue := range result.Issues {
-			label := yellow("WARN:")
-			if issue.IsError() {
-				label = red("ERROR:")
-			}
-			fmt.Fprintf(warn, "%s %s\n", label, issue)
-		}
 	}
 
 	params := &emit.Params{

--- a/.flox/pkgs/flox-ai/main_test.go
+++ b/.flox/pkgs/flox-ai/main_test.go
@@ -1,89 +1,42 @@
 package main
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
-func TestRunSetup_HookWarnsOnUnknownRuleKey(t *testing.T) {
+// Fragment validation moved out of setup entirely (it lives in `flox-ai
+// doctor`). A bad fragment must never cause setup to warn, error, or block
+// activation — in any mode.
+
+func TestRunSetup_HookSkipsValidation(t *testing.T) {
 	dir := t.TempDir()
 
-	// create share/claude-code/rules/ with a rule that has an unknown key
+	// bad rule (unknown frontmatter key) + skill missing required name:
+	// neither must block or fail the hook.
 	rulesDir := filepath.Join(dir, "rules")
 	os.MkdirAll(rulesDir, 0755)
 	os.WriteFile(filepath.Join(rulesDir, "bad.md"), []byte("---\nfoo: bar\n---\n# Bad rule\n"), 0644)
 
-	var warn bytes.Buffer
-	err := runSetup(dir, "/tmp/config", "hook", &warn)
-	if err != nil {
-		t.Fatalf("runSetup failed: %v", err)
-	}
-
-	if !strings.Contains(warn.String(), "WARN") {
-		t.Errorf("expected WARN on stderr, got: %q", warn.String())
-	}
-	if !strings.Contains(warn.String(), "unknown frontmatter key") {
-		t.Errorf("expected 'unknown frontmatter key' in warning, got: %q", warn.String())
-	}
-}
-
-func TestRunSetup_HookErrorsOnMissingSkillName(t *testing.T) {
-	dir := t.TempDir()
-
-	// skill with frontmatter but no name → error severity
 	skillDir := filepath.Join(dir, "skills", "broken")
 	os.MkdirAll(skillDir, 0755)
 	os.WriteFile(filepath.Join(skillDir, "SKILL.md"),
 		[]byte("---\ndescription: x\n---\n# Skill\n"), 0644)
 
-	var warn bytes.Buffer
-	err := runSetup(dir, "/tmp/config", "hook", &warn)
-	if err != nil {
+	if err := runSetup(dir, "/tmp/config", "hook"); err != nil {
 		t.Fatalf("runSetup failed: %v", err)
-	}
-
-	if !strings.Contains(warn.String(), "ERROR") {
-		t.Errorf("expected ERROR prefix for missing name, got: %q", warn.String())
-	}
-}
-
-func TestRunSetup_HookNoWarningsForValid(t *testing.T) {
-	dir := t.TempDir()
-
-	// create share/claude-code/rules/ with a valid rule
-	rulesDir := filepath.Join(dir, "rules")
-	os.MkdirAll(rulesDir, 0755)
-	os.WriteFile(filepath.Join(rulesDir, "good.md"), []byte("# Good rule\nDo things.\n"), 0644)
-
-	var warn bytes.Buffer
-	err := runSetup(dir, "/tmp/config", "hook", &warn)
-	if err != nil {
-		t.Fatalf("runSetup failed: %v", err)
-	}
-
-	if warn.Len() != 0 {
-		t.Errorf("expected no warnings, got: %q", warn.String())
 	}
 }
 
 func TestRunSetup_ProfileSkipsValidation(t *testing.T) {
 	dir := t.TempDir()
 
-	// create share/claude-code/rules/ with a bad rule
 	rulesDir := filepath.Join(dir, "rules")
 	os.MkdirAll(rulesDir, 0755)
 	os.WriteFile(filepath.Join(rulesDir, "bad.md"), []byte("---\nfoo: bar\n---\n# Bad\n"), 0644)
 
-	var warn bytes.Buffer
-	err := runSetup(dir, "/tmp/config", "profile", &warn)
-	if err != nil {
+	if err := runSetup(dir, "/tmp/config", "profile"); err != nil {
 		t.Fatalf("runSetup failed: %v", err)
-	}
-
-	if warn.Len() != 0 {
-		t.Errorf("profile should not validate, got warnings: %q", warn.String())
 	}
 }


### PR DESCRIPTION
## Summary

`flox-ai setup-hook` ran `doctor.Check()` and printed `WARN:`/`ERROR:`
frontmatter lines to stderr on **every** environment activation. The
`doctor` command already runs the exact same checks, so the activation-time
output was redundant noise.

This drops fragment validation from `runSetup` entirely. `flox-ai doctor` is
now the sole validator, surfacing frontmatter and structure checks on demand.

## Changes

- `main.go` — remove the validation block, the `warn io.Writer` param, and
  the now-unused `io` import. Setup just emits shell code.
- `main_test.go` — replace the hook-validation unit tests with
  skips-validation tests (a bad rule + nameless skill must not warn, error,
  or block in any mode).
- `e2e/setup-hook.bats` — 4 "warns on…" tests replaced by one asserting the
  hook emits no warnings. Frontmatter coverage stays in `doctor.bats`.
- `README.md` — update the setup-hook step list + arch diagram, point users
  to `flox-ai doctor`.

## Testing

- `go vet ./...` + `go test ./...` — clean
- Full e2e suite (`nix run .#run-test-flox-ai-with-nix`) — 103/103, including
  the new `setup-hook does not validate fragments (no warnings)` and the
  unchanged `doctor` frontmatter checks.

## Notes

Removed **all** activation-time validation (warnings and the non-blocking
errors), since `doctor` covers both.

Closes AI-254
https://linear.app/floxdotdev/issue/AI-254/move-skill-frontmatter-warning-to-doctor-command