### PR TITLE
fix(openclaw): preserve runtime assets under src/ during build prune

### DIFF
--- a/.flox/pkgs/openclaw/default.nix
+++ b/.flox/pkgs/openclaw/default.nix
@@ -124,7 +124,6 @@ stdenv.mkDerivation (finalAttrs: {
 
     pushd $libdir
     rm -rf \
-      src \
       test \
       apps \
       Swabble \
@@ -144,6 +143,15 @@ stdenv.mkDerivation (finalAttrs: {
     find . -name "__screenshots__" -type d -exec rm -rf {} + 2>/dev/null || true
     find . -name "*.test.ts" -delete
     find . -name "*.test.js" -delete
+
+    # src/ carries runtime assets (agent + HTML templates, TUI themes,
+    # SQL schemas, bundled hooks, security policies) that openclaw loads
+    # by path relative to the package root. The bundled openclaw.mjs needs
+    # none of the .ts/.js under src/, so strip only those and drop the
+    # emptied directories, keeping the data files.
+    find src -type f \( -name '*.ts' -o -name '*.tsx' -o -name '*.js' \
+      -o -name '*.jsx' -o -name '*.mjs' -o -name '*.cjs' -o -name '*.map' \) -delete
+    find src -type d -empty -delete
     popd
 
     rm -f $libdir/node_modules/.pnpm/node_modules/clawdbot \


### PR DESCRIPTION
## Problem

Launching openclaw via the TUI fails immediately:

```
run error: Missing workspace template: HEARTBEAT.md
(/nix/store/.../lib/openclaw/src/agents/templates/HEARTBEAT.md).
Ensure workspace templates are packaged.
```

The `installPhase` in `.flox/pkgs/openclaw/default.nix` ran `rm -rf src`
as a dev/test prune. But openclaw loads several runtime asset files by
path relative to the package root, under `src/`:

| Asset class     | Path                                                   |
| --------------- | ------------------------------------------------------ |
| Agent template  | `src/agents/templates/HEARTBEAT.md`                    |
| TUI themes      | `src/agents/modes/interactive/theme/*.json`            |
| HTML export     | `src/auto-reply/reply/export-html/template.{css,html}` |
| Bundled hooks   | `src/hooks/bundled/**/HOOK.md`                          |
| Security policy | `src/infra/host-env-security*.json`                    |
| DB schemas      | `src/state/openclaw-*-schema.sql`                      |

Keeping only `templates/` (the issue's Option A) would just shift the
failure to the next asset loaded. The current build deletes all of
`src/` and the only error is the missing `.md` template — proving the
bundled `openclaw.mjs` is self-contained and needs no `.ts`/`.js` from
`src/`.

## Fix

Drop `src` from the `rm -rf` prune list; instead strip only code files
under `src/` and remove emptied directories, keeping the data assets.
Scoped to `src/` only, so the bundled `openclaw.mjs` and built output
under `packages/`/`ui/` are untouched. Verified the asset layout is
identical at the pinned tag `v2026.6.6`.

## Verification

Local build blocked by network timeouts fetching the deps FOD (~1GB of
prebuilt npm binaries); the change is downstream of that phase. Relying
on CI to build and confirm startup reaches the prompt.

Closes #3167