### PR TITLE
feat(flox-ai): add launch subcommand

### DIFF
--- a/.flox/pkgs/flox-ai/internal/launch/launch.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"flox.dev/flox-ai/internal/discover"
+	"flox.dev/flox-ai/internal/symlinks"
 )
 
 // Agent describes how to launch a specific AI agent binary.
@@ -119,6 +120,26 @@ func BuildSynthPlugin(launchDir string, skills, agents []discover.Fragment) (str
 	}
 
 	return pluginDir, nil
+}
+
+// UserPluginDirs returns the plugin symlink paths added via
+// `flox-ai plugins add` (configDir/plugins/*). Only non-broken symlinks
+// are returned, matching how the existing claude wrapper filters out
+// Claude Code's own runtime state directories. Returns nil when the
+// plugins dir is absent.
+func UserPluginDirs(configDir string) ([]string, error) {
+	entries, err := symlinks.List(filepath.Join(configDir, "plugins"))
+	if err != nil {
+		return nil, err
+	}
+	var dirs []string
+	for _, e := range entries {
+		if e.Broken {
+			continue
+		}
+		dirs = append(dirs, e.Path)
+	}
+	return dirs, nil
 }
 
 // Argv builds the full argv (argv[0] = Bin) for the agent process.

--- a/.flox/pkgs/flox-ai/internal/launch/launch.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch.go
@@ -73,6 +73,54 @@ func MergeRules(launchDir string, rules []discover.Fragment) (string, error) {
 	return out, nil
 }
 
+// BuildSynthPlugin creates a Claude Code plugin under launchDir/plugin
+// containing the given skills and agents as symlinks, and returns the
+// plugin path. Skills are linked as directories (the skill dir holding
+// SKILL.md); agents are linked as <name>.md files. Returns "" (and writes
+// nothing) when there are no skills or agents.
+func BuildSynthPlugin(launchDir string, skills, agents []discover.Fragment) (string, error) {
+	if len(skills) == 0 && len(agents) == 0 {
+		return "", nil
+	}
+	pluginDir := filepath.Join(launchDir, "plugin")
+	metaDir := filepath.Join(pluginDir, ".claude-plugin")
+	if err := os.MkdirAll(metaDir, 0755); err != nil {
+		return "", err
+	}
+	meta := `{"name":"flox","description":"Flox-managed skills and agents"}` + "\n"
+	if err := os.WriteFile(filepath.Join(metaDir, "plugin.json"), []byte(meta), 0644); err != nil {
+		return "", err
+	}
+
+	if len(skills) > 0 {
+		skillsDir := filepath.Join(pluginDir, "skills")
+		if err := os.MkdirAll(skillsDir, 0755); err != nil {
+			return "", err
+		}
+		for _, s := range skills {
+			// s.Path is the SKILL.md file; link its directory.
+			target := filepath.Dir(s.Path)
+			if err := os.Symlink(target, filepath.Join(skillsDir, s.Name)); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	if len(agents) > 0 {
+		agentsDir := filepath.Join(pluginDir, "agents")
+		if err := os.MkdirAll(agentsDir, 0755); err != nil {
+			return "", err
+		}
+		for _, a := range agents {
+			if err := os.Symlink(a.Path, filepath.Join(agentsDir, a.Name+".md")); err != nil {
+				return "", err
+			}
+		}
+	}
+
+	return pluginDir, nil
+}
+
 // Argv builds the full argv (argv[0] = Bin) for the agent process.
 func (p Plan) Argv() []string {
 	argv := []string{p.Bin}

--- a/.flox/pkgs/flox-ai/internal/launch/launch.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch.go
@@ -1,0 +1,55 @@
+// Package launch runs an AI agent with flox-managed fragments injected
+// for the child process only, without mutating the user's shell or config.
+package launch
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// Agent describes how to launch a specific AI agent binary.
+type Agent struct {
+	Name       string // agent name as typed on the CLI, e.g. "claude"
+	BinSubpath string // binary path relative to $FLOX_ENV
+}
+
+// Supported lists the agents launch knows how to run.
+var Supported = map[string]Agent{
+	"claude": {Name: "claude", BinSubpath: filepath.Join("bin", "claude")},
+}
+
+// SupportedNames returns the supported agent names, sorted and
+// comma-joined, for error messages.
+func SupportedNames() string {
+	names := make([]string, 0, len(Supported))
+	for n := range Supported {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+// Plan is the fully-resolved set of inputs to launch an agent.
+type Plan struct {
+	Bin         string   // absolute path to the agent binary (argv[0])
+	SynthPlugin string   // synth plugin dir; "" if no skills/agents
+	Plugins     []string // additional plugin dirs (env + user)
+	RulesFile   string   // merged rules file; "" if no rules
+	Passthrough []string // verbatim args after the agent name
+}
+
+// Argv builds the full argv (argv[0] = Bin) for the agent process.
+func (p Plan) Argv() []string {
+	argv := []string{p.Bin}
+	if p.SynthPlugin != "" {
+		argv = append(argv, "--plugin-dir", p.SynthPlugin)
+	}
+	for _, dir := range p.Plugins {
+		argv = append(argv, "--plugin-dir", dir)
+	}
+	if p.RulesFile != "" {
+		argv = append(argv, "--append-system-prompt-file", p.RulesFile)
+	}
+	return append(argv, p.Passthrough...)
+}

--- a/.flox/pkgs/flox-ai/internal/launch/launch.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch.go
@@ -142,6 +142,29 @@ func UserPluginDirs(configDir string) ([]string, error) {
 	return dirs, nil
 }
 
+// Prepare wipes launchDir and rebuilds the synth plugin and merged rules
+// file from the discovered fragments. Wiping each run keeps the tree free
+// of stale entries and lets newly added fragments be picked up
+// automatically. Returns the synth plugin path ("" if none) and the rules
+// file path ("" if none).
+func Prepare(launchDir string, frags *discover.Result) (synthPlugin, rulesFile string, err error) {
+	if err := os.RemoveAll(launchDir); err != nil {
+		return "", "", err
+	}
+	if err := os.MkdirAll(launchDir, 0755); err != nil {
+		return "", "", err
+	}
+	synthPlugin, err = BuildSynthPlugin(launchDir, frags.Skills, frags.Agents)
+	if err != nil {
+		return "", "", err
+	}
+	rulesFile, err = MergeRules(launchDir, frags.Rules)
+	if err != nil {
+		return "", "", err
+	}
+	return synthPlugin, rulesFile, nil
+}
+
 // Argv builds the full argv (argv[0] = Bin) for the agent process.
 func (p Plan) Argv() []string {
 	argv := []string{p.Bin}

--- a/.flox/pkgs/flox-ai/internal/launch/launch.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch.go
@@ -3,9 +3,13 @@
 package launch
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"flox.dev/flox-ai/internal/discover"
 )
 
 // Agent describes how to launch a specific AI agent binary.
@@ -37,6 +41,36 @@ type Plan struct {
 	Plugins     []string // additional plugin dirs (env + user)
 	RulesFile   string   // merged rules file; "" if no rules
 	Passthrough []string // verbatim args after the agent name
+}
+
+// MergeRules concatenates all rule fragments into launchDir/rules.md and
+// returns its path. Each rule is preceded by an HTML comment naming its
+// source. Returns "" (and writes nothing) when there are no rules.
+func MergeRules(launchDir string, rules []discover.Fragment) (string, error) {
+	if len(rules) == 0 {
+		return "", nil
+	}
+	if err := os.MkdirAll(launchDir, 0755); err != nil {
+		return "", err
+	}
+	var sb strings.Builder
+	for _, r := range rules {
+		content, err := os.ReadFile(r.Path)
+		if err != nil {
+			return "", fmt.Errorf("read rule %s: %w", r.Name, err)
+		}
+		fmt.Fprintf(&sb, "<!-- source: %s -->\n", r.Name)
+		sb.Write(content)
+		if !strings.HasSuffix(string(content), "\n") {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("\n")
+	}
+	out := filepath.Join(launchDir, "rules.md")
+	if err := os.WriteFile(out, []byte(sb.String()), 0644); err != nil {
+		return "", err
+	}
+	return out, nil
 }
 
 // Argv builds the full argv (argv[0] = Bin) for the agent process.

--- a/.flox/pkgs/flox-ai/internal/launch/launch.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch.go
@@ -5,9 +5,11 @@ package launch
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 
 	"flox.dev/flox-ai/internal/discover"
 	"flox.dev/flox-ai/internal/symlinks"
@@ -178,4 +180,83 @@ func (p Plan) Argv() []string {
 		argv = append(argv, "--append-system-prompt-file", p.RulesFile)
 	}
 	return append(argv, p.Passthrough...)
+}
+
+// Options are the resolved inputs for Run.
+type Options struct {
+	AgentName   string
+	FloxEnv     string // $FLOX_ENV
+	ShareDir    string // $FLOX_ENV/share/claude-code (or --dir)
+	ConfigDir   string // $FLOX_ENV_PROJECT/.flox-ai (or --config-dir)
+	Passthrough []string
+}
+
+// Run resolves the agent, verifies its binary, prepares the flox
+// fragments, and execs the agent process (replacing the current process).
+// It only returns when something fails before exec.
+func Run(opts Options) error {
+	agent, ok := Supported[opts.AgentName]
+	if !ok {
+		return fmt.Errorf("unknown agent %q (supported: %s)", opts.AgentName, SupportedNames())
+	}
+
+	bin, err := resolveBinary(agent, opts.FloxEnv)
+	if err != nil {
+		return err
+	}
+
+	frags, err := discover.Scan(opts.ShareDir)
+	if err != nil {
+		return fmt.Errorf("discover: %w", err)
+	}
+
+	launchDir := filepath.Join(opts.ConfigDir, "launch")
+	synth, rulesFile, err := Prepare(launchDir, frags)
+	if err != nil {
+		return err
+	}
+
+	userPlugins, err := UserPluginDirs(opts.ConfigDir)
+	if err != nil {
+		return err
+	}
+
+	plugins := make([]string, 0, len(frags.Plugins)+len(userPlugins))
+	for _, p := range frags.Plugins {
+		plugins = append(plugins, p.Path)
+	}
+	plugins = append(plugins, userPlugins...)
+
+	plan := Plan{
+		Bin:         bin,
+		SynthPlugin: synth,
+		Plugins:     plugins,
+		RulesFile:   rulesFile,
+		Passthrough: opts.Passthrough,
+	}
+
+	env := append(os.Environ(), "FLOX_AI=1")
+	return syscall.Exec(bin, plan.Argv(), env)
+}
+
+// resolveBinary returns the agent binary path. It prefers
+// $FLOX_ENV/<BinSubpath> and falls back to PATH only when FLOX_ENV is
+// unset (e.g. when invoked with --dir outside an activation).
+func resolveBinary(agent Agent, floxEnv string) (string, error) {
+	if floxEnv != "" {
+		bin := filepath.Join(floxEnv, agent.BinSubpath)
+		if _, err := os.Stat(bin); err == nil {
+			return bin, nil
+		}
+		return "", fmt.Errorf(`%s not found in this Flox environment.
+Add it to your manifest:
+  [include]
+  environments = [{ remote = "flox/%s" }]
+then re-activate`, agent.Name, agent.Name)
+	}
+	bin, err := exec.LookPath(agent.Name)
+	if err != nil {
+		return "", fmt.Errorf("%s not found on PATH", agent.Name)
+	}
+	return bin, nil
 }

--- a/.flox/pkgs/flox-ai/internal/launch/launch.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch.go
@@ -226,6 +226,7 @@ func Run(opts Options) error {
 		plugins = append(plugins, p.Path)
 	}
 	plugins = append(plugins, userPlugins...)
+	plugins = dedupPluginDirs(plugins)
 
 	plan := Plan{
 		Bin:         bin,
@@ -235,8 +236,37 @@ func Run(opts Options) error {
 		Passthrough: opts.Passthrough,
 	}
 
-	env := append(os.Environ(), "FLOX_AI=1")
+	env := childEnv()
 	return syscall.Exec(bin, plan.Argv(), env)
+}
+
+// dedupPluginDirs removes duplicate plugin directories, comparing by
+// resolved (symlink-followed) path and keeping the first occurrence. This
+// matters because an activated env mirrors share-dir plugins into
+// configDir/plugins as symlinks, so the same plugin can arrive both as a
+// share-dir path and as a configDir symlink.
+func dedupPluginDirs(dirs []string) []string {
+	seen := make(map[string]bool, len(dirs))
+	var out []string
+	for _, d := range dirs {
+		key := d
+		if resolved, err := filepath.EvalSymlinks(d); err == nil {
+			key = resolved
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, d)
+	}
+	return out
+}
+
+// childEnv returns the environment for the agent process: the parent
+// environment plus FLOX_AI=1. It deliberately does NOT set
+// CLAUDE_CONFIG_DIR — launch reuses the user's real config and login.
+func childEnv() []string {
+	return append(os.Environ(), "FLOX_AI=1")
 }
 
 // resolveBinary returns the agent binary path. It prefers

--- a/.flox/pkgs/flox-ai/internal/launch/launch.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch.go
@@ -17,13 +17,13 @@ import (
 
 // Agent describes how to launch a specific AI agent binary.
 type Agent struct {
-	Name       string // agent name as typed on the CLI, e.g. "claude"
-	BinSubpath string // binary path relative to $FLOX_ENV
+	Name       string // agent name as typed on the CLI / PATH lookup, e.g. "claude"
+	InstallPkg string // flox package to suggest installing, e.g. "claude-code"
 }
 
 // Supported lists the agents launch knows how to run.
 var Supported = map[string]Agent{
-	"claude": {Name: "claude", BinSubpath: filepath.Join("bin", "claude")},
+	"claude": {Name: "claude", InstallPkg: "claude-code"},
 }
 
 // SupportedNames returns the supported agent names, sorted and
@@ -185,7 +185,6 @@ func (p Plan) Argv() []string {
 // Options are the resolved inputs for Run.
 type Options struct {
 	AgentName   string
-	FloxEnv     string // $FLOX_ENV
 	ShareDir    string // $FLOX_ENV/share/claude-code (or --dir)
 	ConfigDir   string // $FLOX_ENV_PROJECT/.flox-ai (or --config-dir)
 	Passthrough []string
@@ -200,7 +199,7 @@ func Run(opts Options) error {
 		return fmt.Errorf("unknown agent %q (supported: %s)", opts.AgentName, SupportedNames())
 	}
 
-	bin, err := resolveBinary(agent, opts.FloxEnv)
+	bin, err := resolveBinary(agent)
 	if err != nil {
 		return err
 	}
@@ -269,24 +268,16 @@ func childEnv() []string {
 	return append(os.Environ(), "FLOX_AI=1")
 }
 
-// resolveBinary returns the agent binary path. It prefers
-// $FLOX_ENV/<BinSubpath> and falls back to PATH only when FLOX_ENV is
-// unset (e.g. when invoked with --dir outside an activation).
-func resolveBinary(agent Agent, floxEnv string) (string, error) {
-	if floxEnv != "" {
-		bin := filepath.Join(floxEnv, agent.BinSubpath)
-		if _, err := os.Stat(bin); err == nil {
-			return bin, nil
-		}
-		return "", fmt.Errorf(`%s not found in this Flox environment.
-Add it to your manifest:
-  [include]
-  environments = [{ remote = "flox/%s" }]
-then re-activate`, agent.Name, agent.Name)
-	}
+// resolveBinary finds the agent binary on PATH. The Flox environment only
+// supplies the fragments (skills/agents/rules/plugins); the agent binary
+// itself comes from PATH — which, inside an activated env that ships it,
+// already includes the env's bin. When the binary is missing it suggests
+// installing it via flox.
+func resolveBinary(agent Agent) (string, error) {
 	bin, err := exec.LookPath(agent.Name)
 	if err != nil {
-		return "", fmt.Errorf("%s not found on PATH", agent.Name)
+		return "", fmt.Errorf(`%s not found on PATH.
+Install it with: flox install flox/%s`, agent.Name, agent.InstallPkg)
 	}
 	return bin, nil
 }

--- a/.flox/pkgs/flox-ai/internal/launch/launch_test.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch_test.go
@@ -257,3 +257,33 @@ func TestUserPluginDirs_SkipsBroken(t *testing.T) {
 		t.Fatalf("got %v want %v", got, want)
 	}
 }
+
+func TestRun_UnknownAgent(t *testing.T) {
+	err := Run(Options{AgentName: "bogus"})
+	if err == nil {
+		t.Fatal("want error for unknown agent")
+	}
+	if !strings.Contains(err.Error(), "unknown agent") ||
+		!strings.Contains(err.Error(), "claude") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRun_BinaryMissingInEnv(t *testing.T) {
+	floxEnv := t.TempDir() // has no bin/claude
+	err := Run(Options{
+		AgentName: "claude",
+		FloxEnv:   floxEnv,
+		ShareDir:  filepath.Join(floxEnv, "share", "claude-code"),
+		ConfigDir: filepath.Join(t.TempDir(), ".flox-ai"),
+	})
+	if err == nil {
+		t.Fatal("want error for missing binary")
+	}
+	if !strings.Contains(err.Error(), "claude not found in this Flox environment") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), `remote = "flox/claude"`) {
+		t.Fatalf("error missing fix-it hint: %v", err)
+	}
+}

--- a/.flox/pkgs/flox-ai/internal/launch/launch_test.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch_test.go
@@ -1,0 +1,49 @@
+package launch
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestPlanArgv_Full(t *testing.T) {
+	p := Plan{
+		Bin:         "/env/bin/claude",
+		SynthPlugin: "/cfg/launch/plugin",
+		Plugins:     []string{"/env/p1", "/cfg/plugins/p2"},
+		RulesFile:   "/cfg/launch/rules.md",
+		Passthrough: []string{"-p", "hi"},
+	}
+	want := []string{
+		"/env/bin/claude",
+		"--plugin-dir", "/cfg/launch/plugin",
+		"--plugin-dir", "/env/p1",
+		"--plugin-dir", "/cfg/plugins/p2",
+		"--append-system-prompt-file", "/cfg/launch/rules.md",
+		"-p", "hi",
+	}
+	if got := p.Argv(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestPlanArgv_Minimal(t *testing.T) {
+	p := Plan{Bin: "/env/bin/claude"}
+	want := []string{"/env/bin/claude"}
+	if got := p.Argv(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestPlanArgv_NoSynthNoRules(t *testing.T) {
+	p := Plan{Bin: "/b", Plugins: []string{"/p1"}, Passthrough: []string{"--continue"}}
+	want := []string{"/b", "--plugin-dir", "/p1", "--continue"}
+	if got := p.Argv(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestSupportedNames(t *testing.T) {
+	if got := SupportedNames(); got != "claude" {
+		t.Fatalf("got %q want %q", got, "claude")
+	}
+}

--- a/.flox/pkgs/flox-ai/internal/launch/launch_test.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch_test.go
@@ -159,3 +159,45 @@ func TestBuildSynthPlugin_SkillsAndAgents(t *testing.T) {
 		t.Fatalf("agent link %q want %q", gotAgent, agentFile)
 	}
 }
+
+func TestUserPluginDirs_AbsentDir(t *testing.T) {
+	got, err := UserPluginDirs(t.TempDir()) // no plugins/ subdir
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("want none, got %v", got)
+	}
+}
+
+func TestUserPluginDirs_SkipsBroken(t *testing.T) {
+	configDir := t.TempDir()
+	pluginsDir := filepath.Join(configDir, "plugins")
+	if err := os.MkdirAll(pluginsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// good: symlink to an existing dir
+	realPlugin := filepath.Join(t.TempDir(), "good-plugin")
+	if err := os.MkdirAll(realPlugin, 0755); err != nil {
+		t.Fatal(err)
+	}
+	goodLink := filepath.Join(pluginsDir, "good")
+	if err := os.Symlink(realPlugin, goodLink); err != nil {
+		t.Fatal(err)
+	}
+
+	// broken: symlink to a missing target
+	if err := os.Symlink(filepath.Join(t.TempDir(), "missing"), filepath.Join(pluginsDir, "bad")); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := UserPluginDirs(configDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{goodLink}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}

--- a/.flox/pkgs/flox-ai/internal/launch/launch_test.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch_test.go
@@ -323,21 +323,34 @@ func TestRun_UnknownAgent(t *testing.T) {
 	}
 }
 
-func TestRun_BinaryMissingInEnv(t *testing.T) {
-	floxEnv := t.TempDir() // has no bin/claude
-	err := Run(Options{
-		AgentName: "claude",
-		FloxEnv:   floxEnv,
-		ShareDir:  filepath.Join(floxEnv, "share", "claude-code"),
-		ConfigDir: filepath.Join(t.TempDir(), ".flox-ai"),
-	})
-	if err == nil {
-		t.Fatal("want error for missing binary")
+func TestResolveBinary_FoundOnPath(t *testing.T) {
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "claude")
+	if err := os.WriteFile(bin, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "claude not found in this Flox environment") {
+	t.Setenv("PATH", dir)
+
+	got, err := resolveBinary(Supported["claude"])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != bin {
+		t.Fatalf("got %q want %q", got, bin)
+	}
+}
+
+func TestResolveBinary_NotFoundSuggestsFloxInstall(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir: claude not present
+
+	_, err := resolveBinary(Supported["claude"])
+	if err == nil {
+		t.Fatal("want error when binary missing")
+	}
+	if !strings.Contains(err.Error(), "not found on PATH") {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if !strings.Contains(err.Error(), `remote = "flox/claude"`) {
-		t.Fatalf("error missing fix-it hint: %v", err)
+	if !strings.Contains(err.Error(), "flox install flox/claude-code") {
+		t.Fatalf("error missing flox install hint: %v", err)
 	}
 }

--- a/.flox/pkgs/flox-ai/internal/launch/launch_test.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch_test.go
@@ -160,6 +160,62 @@ func TestBuildSynthPlugin_SkillsAndAgents(t *testing.T) {
 	}
 }
 
+func TestPrepare_BuildsArtifactsAndIsIdempotent(t *testing.T) {
+	src := t.TempDir()
+
+	// one rule
+	rulesSrc := filepath.Join(src, "rules")
+	if err := os.MkdirAll(rulesSrc, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rulesSrc, "r.md"), []byte("R"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// one skill
+	skillDir := filepath.Join(src, "skills", "s")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	frags := &discover.Result{
+		Rules:  []discover.Fragment{{Name: "r", Path: filepath.Join(rulesSrc, "r.md")}},
+		Skills: []discover.Fragment{{Name: "s", Path: filepath.Join(skillDir, "SKILL.md")}},
+	}
+
+	launchDir := filepath.Join(t.TempDir(), "launch")
+
+	// stale file that must be wiped on Prepare
+	if err := os.MkdirAll(launchDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(launchDir, "stale.txt"), []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	synth, rules, err := Prepare(launchDir, frags)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if synth != filepath.Join(launchDir, "plugin") {
+		t.Fatalf("synth %q", synth)
+	}
+	if rules != filepath.Join(launchDir, "rules.md") {
+		t.Fatalf("rules %q", rules)
+	}
+	if _, err := os.Stat(filepath.Join(launchDir, "stale.txt")); !os.IsNotExist(err) {
+		t.Fatalf("stale file not wiped")
+	}
+
+	// second run: still succeeds (symlinks don't collide because of wipe)
+	if _, _, err := Prepare(launchDir, frags); err != nil {
+		t.Fatalf("second Prepare failed: %v", err)
+	}
+}
+
 func TestUserPluginDirs_AbsentDir(t *testing.T) {
 	got, err := UserPluginDirs(t.TempDir()) // no plugins/ subdir
 	if err != nil {

--- a/.flox/pkgs/flox-ai/internal/launch/launch_test.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch_test.go
@@ -1,8 +1,12 @@
 package launch
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
+
+	"flox.dev/flox-ai/internal/discover"
 )
 
 func TestPlanArgv_Full(t *testing.T) {
@@ -45,5 +49,45 @@ func TestPlanArgv_NoSynthNoRules(t *testing.T) {
 func TestSupportedNames(t *testing.T) {
 	if got := SupportedNames(); got != "claude" {
 		t.Fatalf("got %q want %q", got, "claude")
+	}
+}
+
+func TestMergeRules_None(t *testing.T) {
+	got, err := MergeRules(t.TempDir(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Fatalf("want empty path, got %q", got)
+	}
+}
+
+func TestMergeRules_ConcatOrderAndHeaders(t *testing.T) {
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, "a.md"), []byte("AAA"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "b.md"), []byte("BBB\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rules := []discover.Fragment{
+		{Name: "a", Path: filepath.Join(src, "a.md")},
+		{Name: "b", Path: filepath.Join(src, "b.md")},
+	}
+	launchDir := t.TempDir()
+	out, err := MergeRules(launchDir, rules)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out != filepath.Join(launchDir, "rules.md") {
+		t.Fatalf("unexpected out path %q", out)
+	}
+	got, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "<!-- source: a -->\nAAA\n\n<!-- source: b -->\nBBB\n\n"
+	if string(got) != want {
+		t.Fatalf("got %q want %q", got, want)
 	}
 }

--- a/.flox/pkgs/flox-ai/internal/launch/launch_test.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"flox.dev/flox-ai/internal/discover"
@@ -89,5 +90,72 @@ func TestMergeRules_ConcatOrderAndHeaders(t *testing.T) {
 	want := "<!-- source: a -->\nAAA\n\n<!-- source: b -->\nBBB\n\n"
 	if string(got) != want {
 		t.Fatalf("got %q want %q", got, want)
+	}
+}
+
+func TestBuildSynthPlugin_None(t *testing.T) {
+	got, err := BuildSynthPlugin(t.TempDir(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Fatalf("want empty path, got %q", got)
+	}
+}
+
+func TestBuildSynthPlugin_SkillsAndAgents(t *testing.T) {
+	src := t.TempDir()
+
+	skillDir := filepath.Join(src, "skills", "demo")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	skillFile := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(skillFile, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	agentFile := filepath.Join(src, "agents", "rev.md")
+	if err := os.MkdirAll(filepath.Dir(agentFile), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(agentFile, []byte("y"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	launchDir := t.TempDir()
+	plugin, err := BuildSynthPlugin(launchDir,
+		[]discover.Fragment{{Name: "demo", Path: skillFile}},
+		[]discover.Fragment{{Name: "rev", Path: agentFile}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if plugin != filepath.Join(launchDir, "plugin") {
+		t.Fatalf("unexpected plugin path %q", plugin)
+	}
+
+	meta, err := os.ReadFile(filepath.Join(plugin, ".claude-plugin", "plugin.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(meta), `"name":"flox"`) {
+		t.Fatalf("bad plugin.json: %s", meta)
+	}
+
+	gotSkill, err := os.Readlink(filepath.Join(plugin, "skills", "demo"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotSkill != skillDir {
+		t.Fatalf("skill link %q want %q", gotSkill, skillDir)
+	}
+
+	gotAgent, err := os.Readlink(filepath.Join(plugin, "agents", "rev.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotAgent != agentFile {
+		t.Fatalf("agent link %q want %q", gotAgent, agentFile)
 	}
 }

--- a/.flox/pkgs/flox-ai/internal/launch/launch_test.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch_test.go
@@ -258,6 +258,60 @@ func TestUserPluginDirs_SkipsBroken(t *testing.T) {
 	}
 }
 
+func TestDedupPluginDirs_SamePluginTwice(t *testing.T) {
+	real := t.TempDir() // the actual plugin dir (e.g. share/.../plugins/p)
+	link := filepath.Join(t.TempDir(), "p-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+	// env path first (real), user symlink second (resolves to same real)
+	got := dedupPluginDirs([]string{real, link})
+	want := []string{real}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestDedupPluginDirs_DistinctKept(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	got := dedupPluginDirs([]string{a, b})
+	want := []string{a, b}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %v want %v", got, want)
+	}
+}
+
+func TestChildEnv_AddsFloxAINotConfigDir(t *testing.T) {
+	env := childEnv()
+
+	var hasFloxAI bool
+	for _, kv := range env {
+		if kv == "FLOX_AI=1" {
+			hasFloxAI = true
+		}
+	}
+	if !hasFloxAI {
+		t.Fatal("childEnv missing FLOX_AI=1")
+	}
+
+	// childEnv must NOT introduce a CLAUDE_CONFIG_DIR entry that the
+	// parent environment didn't already have.
+	count := func(list []string) int {
+		n := 0
+		for _, kv := range list {
+			if strings.HasPrefix(kv, "CLAUDE_CONFIG_DIR=") {
+				n++
+			}
+		}
+		return n
+	}
+	if count(env) != count(os.Environ()) {
+		t.Fatalf("childEnv changed CLAUDE_CONFIG_DIR entries: parent=%d child=%d",
+			count(os.Environ()), count(env))
+	}
+}
+
 func TestRun_UnknownAgent(t *testing.T) {
 	err := Run(Options{AgentName: "bogus"})
 	if err == nil {

--- a/.flox/pkgs/flox-ai/main.go
+++ b/.flox/pkgs/flox-ai/main.go
@@ -10,6 +10,7 @@ import (
 	"flox.dev/flox-ai/internal/discover"
 	"flox.dev/flox-ai/internal/doctor"
 	"flox.dev/flox-ai/internal/emit"
+	"flox.dev/flox-ai/internal/launch"
 	"flox.dev/flox-ai/internal/plugins"
 	"flox.dev/flox-ai/internal/symlinks"
 )
@@ -140,6 +141,27 @@ func main() {
 		runFragmentSubcmd("skills", flag.Arg(1), flag.Arg(2), configDir, shareDir)
 	case "agents":
 		runFragmentSubcmd("agents", flag.Arg(1), flag.Arg(2), configDir, shareDir)
+	case "launch":
+		agentName := flag.Arg(1)
+		if agentName == "" {
+			fmt.Fprintln(os.Stderr, red("ERROR:")+" usage: flox-ai launch <agent> [-- <agent args>]")
+			os.Exit(1)
+		}
+		requireShareDir()
+		var passthrough []string
+		if flag.NArg() > 2 {
+			passthrough = flag.Args()[2:]
+		}
+		if err := launch.Run(launch.Options{
+			AgentName:   agentName,
+			FloxEnv:     floxEnv,
+			ShareDir:    shareDir,
+			ConfigDir:   configDir,
+			Passthrough: passthrough,
+		}); err != nil {
+			fmt.Fprintf(os.Stderr, red("ERROR:")+" %v\n", err)
+			os.Exit(1)
+		}
 	default:
 		printUsage()
 		os.Exit(1)
@@ -160,6 +182,7 @@ Commands:
   skills add|remove|list|clean   Manage skill symlinks
   agents add|remove|list|clean   Manage agent symlinks
   plugins add|remove|list|clean  Manage plugins (symlinks + JSON)
+  launch <agent> [-- <args>]     Run an AI agent with flox fragments injected
   version          Print version
 
 Flags:

--- a/.flox/pkgs/flox-ai/main.go
+++ b/.flox/pkgs/flox-ai/main.go
@@ -154,7 +154,6 @@ func main() {
 		}
 		if err := launch.Run(launch.Options{
 			AgentName:   agentName,
-			FloxEnv:     floxEnv,
 			ShareDir:    shareDir,
 			ConfigDir:   configDir,
 			Passthrough: passthrough,


### PR DESCRIPTION
## Summary

Adds `flox-ai launch <agent> [-- <agent args>]` — an explicit, opt-in
launcher that runs an AI agent (Claude Code) with flox-managed skills,
agents, rules, and plugins injected **for the child process only**.

Unlike the existing `setup-hook`/`setup-profile` mechanism, `launch`:

- never overrides `CLAUDE_CONFIG_DIR` — the user's real config and
  existing login (keychain/OAuth on macOS, credentials file on Linux)
  are used unchanged, so no keychain bridging or `~/.claude.json` copy
- does not mutate the shell — env vars apply only to the agent it execs
- needs no EXIT-trap cleanup

How fragments are injected (Claude Code 2.1.177 flags):

- skills + agents → synthesized ephemeral plugin under
  `<configDir>/launch/plugin` (symlinks), passed via `--plugin-dir`
- env plugins + user-added plugins (`flox-ai plugins add`) → `--plugin-dir`
  each, deduped by resolved path
- rules → concatenated into `<configDir>/launch/rules.md`, passed via
  `--append-system-prompt-file`

The `launch/` tree is regenerated each run, so newly added fragments are
picked up automatically. Only `FLOX_AI=1` is added to the child env.

This is purely additive: the existing hook/profile machinery and all env
manifests are untouched. Intended as a trial — coworkers compare native
`claude` vs `flox-ai launch claude`; the old mechanism is removed in a
later PR only if preferred.

## Test Plan

- [x] `go test ./...` — all 7 packages pass (16 tests in `internal/launch`)
- [x] `go build ./...` and `go vet ./...` clean
- [x] Error paths: `flox-ai launch` (usage), `flox-ai launch bogus`
      (unknown agent), missing binary in env (fix-it hint)
- [ ] Manual: from an activated env including `flox/claude`, run
      `flox-ai launch claude -- --help` and `flox-ai launch claude`;
      confirm existing login works (no re-auth), flox skills appear, and
      native `claude` is unchanged