### PR TITLE
feat(skills-ponytail): package ponytail skill bundle

### DIFF
--- a/.flox/pkgs/skills-ponytail/default.nix
+++ b/.flox/pkgs/skills-ponytail/default.nix
@@ -1,0 +1,62 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+}:
+
+let
+  data = builtins.fromJSON
+    (builtins.readFile ./hashes.json);
+
+  src = fetchFromGitHub {
+    owner = "DietrichGebert";
+    repo = "ponytail";
+    rev = data.rev;
+    hash = data.srcHash;
+  };
+
+  # The repo ships a bundle of skills under skills/ — the entry
+  # `ponytail` skill plus the per-mode skills (audit, debt, help,
+  # review). Install the whole bundle so the agent gets the full
+  # set of laziness modes and commands.
+  skillsSubdir = "skills";
+in
+stdenvNoCC.mkDerivation {
+  pname = "skills-ponytail";
+  version = data.version;
+  inherit src;
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    for root in \
+      "$out/share/claude-code/skills" \
+      "$out/share/opencode/skills"; do
+      mkdir -p "$root"
+      cp -r "$src/${skillsSubdir}"/. "$root/"
+    done
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description =
+      "Ponytail skill bundle for Claude Code and OpenCode "
+      + "— makes your agent think like the laziest senior "
+      + "dev in the room: question whether the task needs "
+      + "to exist, reach for stdlib before custom code, one "
+      + "line before fifty.";
+    homepage =
+      "https://github.com/DietrichGebert/ponytail";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/skills-ponytail/hashes.json
+++ b/.flox/pkgs/skills-ponytail/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "0+unstable-2026-06-16.99139a2",
+  "rev": "99139a25d07e3523d3f6871419798dda600db49a",
+  "srcHash": "sha256-nB8NuYJw4fgUQ51T7j4Az6Z+SnH4j0P+uqTL9BkukUY="
+}

--- a/.flox/pkgs/skills-ponytail/meta.yaml
+++ b/.flox/pkgs/skills-ponytail/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: skill
+name: skills-ponytail
+title: Ponytail
+skill_for: claude-code
+publisher: flox
+tagline: >
+  Anti-over-engineering skill for Claude Code — forces the laziest
+  solution that actually works.
+category: ai
+ai_role: tooling
+tags: [claude-code, skill, ponytail, yagni, refactoring, code-review]
+status: stable
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    skills-ponytail.pkg-path = "flox/skills-ponytail"
+    skills-ponytail.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/skills-ponytail
+  floxhub: https://hub.flox.dev/flox/skills-ponytail

--- a/.flox/pkgs/skills-ponytail/publish.json
+++ b/.flox/pkgs/skills-ponytail/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/skills-ponytail/upgrade.sh
+++ b/.flox/pkgs/skills-ponytail/upgrade.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+OWNER="DietrichGebert"
+REPO="ponytail"
+BRANCH="main"
+
+current_version=$(jq -r '.version // ""' "$HASHES_FILE")
+
+rev=$(git ls-remote "https://github.com/$OWNER/$REPO.git" \
+  "refs/heads/$BRANCH" | awk '{print $1}')
+
+if [ -z "$rev" ]; then
+  echo "Failed to resolve $BRANCH on $OWNER/$REPO" >&2
+  exit 1
+fi
+
+short_sha="${rev:0:7}"
+
+commit_json=$(curl -sfL \
+  -H "Accept: application/vnd.github+json" \
+  "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
+commit_date=$(echo "$commit_json" \
+  | jq -r '.commit.committer.date' | cut -c1-10)
+
+new_version="0+unstable-${commit_date}.${short_sha}"
+
+echo "Current: $current_version"
+echo "Latest:  $new_version"
+
+if [ "$current_version" = "$new_version" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating skills-ponytail to $new_version"
+
+sha256_base32=$(nix-prefetch-url --unpack \
+  "https://github.com/$OWNER/$REPO/archive/$rev.tar.gz")
+sri_hash=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$sha256_base32")
+
+jq -n \
+  --arg v "$new_version" \
+  --arg r "$rev" \
+  --arg h "$sri_hash" \
+  '{version: $v, rev: $r, srcHash: $h}' \
+  > "$HASHES_FILE"
+
+echo "Wrote $HASHES_FILE:"
+cat "$HASHES_FILE"


### PR DESCRIPTION
## What

Packages [DietrichGebert/ponytail](https://github.com/DietrichGebert/ponytail) as `skills-ponytail` — an anti-over-engineering skill bundle for Claude Code and OpenCode.

Installs the `ponytail` entry skill plus the per-mode skills: `ponytail-audit`, `ponytail-debt`, `ponytail-help`, `ponytail-review`.

## Layout

- `default.nix` — `fetchFromGitHub`, copies the upstream `skills/` bundle into `share/claude-code/skills` and `share/opencode/skills`
- `meta.yaml` — flox skill metadata (MIT)
- `hashes.json` — pinned to `99139a2` (2026-06-16)
- `upgrade.sh` — tracks `main`
- `publish.json` — 4 systems

Modeled on `skills-firecrawl-cli` (same bundle shape). Upstream frontmatter is already agentskills.io-compliant, so no `trigger:` fixup needed.

## Verification

- `nix-build` succeeds
- All 5 `SKILL.md` files land under both `claude-code` and `opencode` skill roots