### PR TITLE
fix(ci): build all packages on manual dispatch

### DIFF
--- a/.github/workflows/ci_pkgs.yml
+++ b/.github/workflows/ci_pkgs.yml
@@ -15,7 +15,7 @@ on:
       package:
         description: >
           Package to build. Leave empty to build all
-          changed packages.
+          packages.
         required: false
         default: ""
         type: string
@@ -58,6 +58,15 @@ jobs:
           # Collect package names
           if [ -n "$SINGLE_PKG" ]; then
             pkgs="[\"$SINGLE_PKG\"]"
+          elif [ "$EVENT" = "workflow_dispatch" ]; then
+            # Manual dispatch with no package input: build every
+            # package, regardless of what the last commit changed.
+            pkgs="[]"
+            for dir in .flox/pkgs/*/; do
+              name="$(basename "$dir")"
+              pkgs=$(echo "$pkgs" | jq -c \
+                ". + [\"$name\"]")
+            done
           else
             if [ "$EVENT" = "pull_request" ]; then
               DIFF_BASE="$BASE_SHA"
@@ -83,16 +92,6 @@ jobs:
                   ". + [\"$name\"]")
               fi
             done
-
-            # On workflow_dispatch with no input, build all
-            if [ "$EVENT" = "workflow_dispatch" ] \
-                && [ "$pkgs" = "[]" ]; then
-              for dir in .flox/pkgs/*/; do
-                name="$(basename "$dir")"
-                pkgs=$(echo "$pkgs" | jq -c \
-                  ". + [\"$name\"]")
-              done
-            fi
           fi
 
           echo "packages=$pkgs" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

Manual `workflow_dispatch` of **CI Packages** with no package input built only a single package instead of all packages. ([run](https://github.com/flox/floxenvs/actions/runs/27743155924))

## Cause

The "build all" fallback was gated behind `pkgs == "[]"` — it only fired when the `HEAD~1` diff found zero changed packages. On `main` the last commit always changes one package (the merged PR), so `pkgs` was never empty and the fallback never ran.

## Fix

On `workflow_dispatch` with no package input, build every package directly, skipping the diff. Behavior:

| Trigger | Result |
| ------- | ------ |
| dispatch + package set | just that package |
| dispatch + empty | all packages |
| push / PR | only changed packages |

Also fixed the misleading input description ("all changed" → "all").