### PR TITLE
fix(flox-ai): isolate agent-deck via AGENT_DECK_HOME, not XDG hijack

### DIFF
--- a/.flox/pkgs/agent-deck/agent-deck-home.patch
+++ b/.flox/pkgs/agent-deck/agent-deck-home.patch
@@ -1,0 +1,125 @@
+Add AGENT_DECK_HOME override for embedders (e.g. flox-ai).
+
+agent-deck resolves its config, data, and cache directories from the
+generic XDG_* base directories. An embedding tool that wants a private,
+per-project agent-deck home has no choice but to override XDG_CONFIG_HOME
+and XDG_DATA_HOME -- which are then inherited by the tmux server agent-deck
+spawns and leak into every pane, so unrelated programs in those panes read
+their own config from the wrong place and break.
+
+Add a dedicated AGENT_DECK_HOME environment variable. When set to an
+absolute path it becomes the agent-deck home directly (config, data, and
+cache all resolve under it), taking precedence over XDG_* and the legacy
+~/.agent-deck fallback, and leaving the XDG_* variables untouched so they
+no longer have to be hijacked.
+
+All path resolution already funnels through agentpaths.xdgDir (ConfigDir,
+DataDir, CacheDir), and the internal/tmux helpers go through
+agentpaths.Effective{Config,Data}Path, so a single override point covers
+config.toml, logs, ack-signal, and badge-updates alike.
+
+--- a/internal/agentpaths/paths.go
++++ b/internal/agentpaths/paths.go
+@@ -13,6 +13,18 @@ import (
+
+ const AppDirName = "agent-deck"
+
++// AgentDeckHomeEnv, when set to an absolute path, is the agent-deck home:
++// ConfigDir, DataDir, and CacheDir all resolve directly to it, taking
++// precedence over the XDG_* base directories and the legacy ~/.agent-deck
++// fallback.
++//
++// It lets an embedding tool (e.g. flox-ai, which runs a per-project
++// agent-deck) isolate agent-deck's state WITHOUT hijacking the generic
++// XDG_CONFIG_HOME / XDG_DATA_HOME variables. Those would otherwise be
++// inherited by the tmux server agent-deck spawns and leak into every pane,
++// breaking unrelated programs that read XDG_* to locate their own config.
++const AgentDeckHomeEnv = "AGENT_DECK_HOME"
++
+ // S4 data-loss safeguard (2026-06-04 incident).
+ //
+ // Path resolution uses $HOME and XDG_* env vars. Under go test, a package that
+@@ -118,6 +130,17 @@ func LegacyDir() (string, error) {
+ }
+
+ func xdgDir(envName string, fallbackParts ...string) (string, error) {
++	// A dedicated agent-deck home overrides every other source. Only an
++	// absolute path is honored; a relative value is ignored so a stray
++	// export cannot silently anchor agent-deck state at the cwd.
++	if home := strings.TrimSpace(os.Getenv(AgentDeckHomeEnv)); home != "" && filepath.IsAbs(home) {
++		dir := filepath.Clean(home)
++		if err := ensureSafeForTest(dir); err != nil {
++			return "", err
++		}
++		return dir, nil
++	}
++
+ 	if value := strings.TrimSpace(os.Getenv(envName)); value != "" {
+ 		if filepath.IsAbs(value) {
+ 			dir := filepath.Join(value, AppDirName)
+--- /dev/null
++++ b/internal/agentpaths/agentdeckhome_test.go
+@@ -0,0 +1,63 @@
++package agentpaths
++
++import (
++	"path/filepath"
++	"testing"
++)
++
++// AGENT_DECK_HOME, when absolute, is the agent-deck home for config, data,
++// and cache alike -- overriding XDG_* entirely.
++func TestAgentDeckHomeOverridesXDG(t *testing.T) {
++	root := t.TempDir()
++	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, "xdg-config"))
++	t.Setenv("XDG_DATA_HOME", filepath.Join(root, "xdg-data"))
++	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "xdg-cache"))
++
++	deck := filepath.Join(root, "deck")
++	t.Setenv(AgentDeckHomeEnv, deck)
++
++	cases := map[string]func() (string, error){
++		"config": ConfigDir,
++		"data":   DataDir,
++		"cache":  CacheDir,
++	}
++	for name, fn := range cases {
++		got, err := fn()
++		if err != nil {
++			t.Fatalf("%s: %v", name, err)
++		}
++		if got != deck {
++			t.Fatalf("%s: got %q want %q", name, got, deck)
++		}
++	}
++}
++
++// A relative AGENT_DECK_HOME is ignored; resolution falls back to XDG.
++func TestAgentDeckHomeIgnoredWhenRelative(t *testing.T) {
++	xdg := t.TempDir()
++	t.Setenv("XDG_CONFIG_HOME", xdg)
++	t.Setenv(AgentDeckHomeEnv, filepath.Join("relative", "path"))
++
++	got, err := ConfigDir()
++	if err != nil {
++		t.Fatal(err)
++	}
++	if want := filepath.Join(xdg, AppDirName); got != want {
++		t.Fatalf("relative AGENT_DECK_HOME must be ignored: got %q want %q", got, want)
++	}
++}
++
++// An unset AGENT_DECK_HOME leaves XDG resolution unchanged.
++func TestAgentDeckHomeUnsetUsesXDG(t *testing.T) {
++	xdg := t.TempDir()
++	t.Setenv("XDG_DATA_HOME", xdg)
++	t.Setenv(AgentDeckHomeEnv, "")
++
++	got, err := DataDir()
++	if err != nil {
++		t.Fatal(err)
++	}
++	if want := filepath.Join(xdg, AppDirName); got != want {
++		t.Fatalf("got %q want %q", got, want)
++	}
++}

--- a/.flox/pkgs/agent-deck/default.nix
+++ b/.flox/pkgs/agent-deck/default.nix
@@ -37,6 +37,17 @@ buildGoModule (finalAttrs: {
 
   subPackages = [ "cmd/agent-deck" ];
 
+  # Downstream patch: add an AGENT_DECK_HOME env var that overrides XDG_*
+  # path resolution, so flox-ai can isolate a per-project agent-deck home
+  # without hijacking XDG_CONFIG_HOME/XDG_DATA_HOME (which would otherwise
+  # leak into agent-deck's tmux panes and break unrelated programs). The
+  # override is added in internal/agentpaths, the single funnel every config,
+  # data, and cache path resolves through. Applied in patchPhase, before the
+  # postPatch surgery below; affects neither srcHash (fixed-output fetch) nor
+  # vendorHash (Go module graph unchanged). Upstream PR pending; drop this
+  # once merged.
+  patches = [ ./agent-deck-home.patch ];
+
   # agent-deck 1.9.49 added a test-only data-loss guard (internal/agentpaths)
   # that, while testing.Testing() is true, refuses to resolve any agent-deck
   # path under the OS user's *real* home -- read from the passwd database via

--- a/.flox/pkgs/flox-ai/README.md
+++ b/.flox/pkgs/flox-ai/README.md
@@ -192,17 +192,21 @@ themselves launched through `flox-ai launch claude`, so they
 inherit this environment's flox-managed skills, rules,
 agents, and plugins.
 
-agent-deck is pointed at the seeded home via
-`XDG_CONFIG_HOME` and `XDG_DATA_HOME` (both the deck home, so
-config and session state live together per environment), and
-`FLOX_AI_DIR` is exported so the nested `flox-ai launch
-claude` resolves this environment's fragments. The seeded
-config also forces a per-environment `[tmux].socket_name`
-derived from the config dir, so each environment's deck runs
-on its own tmux server — distinct environments do not share
-session state or shell environment, while relaunching the
-same environment reuses its server. `XDG_CACHE_HOME` is left
-untouched.
+agent-deck is pointed at the seeded home via `AGENT_DECK_HOME`
+(a flox patch to agent-deck makes this take precedence over
+the `XDG_*` base directories for config, data, and cache),
+and `FLOX_AI_DIR` is exported so the nested `flox-ai launch
+claude` resolves this environment's fragments. The `XDG_*`
+variables are deliberately left untouched: agent-deck spawns
+a tmux server that every pane inherits its environment from,
+so hijacking `XDG_CONFIG_HOME`/`XDG_DATA_HOME` would leak the
+deck home into those panes and break unrelated programs that
+read `XDG_*` to find their own config. The seeded config also
+forces a per-environment `[tmux].socket_name` derived from
+the config dir, so each environment's deck runs on its own
+tmux server — distinct environments do not share session
+state or shell environment, while relaunching the same
+environment reuses its server.
 
 Because session state lives under `.flox/cache`, it is
 ephemeral: a flox cache clear or env rebuild resets the

--- a/.flox/pkgs/flox-ai/e2e/launch.bats
+++ b/.flox/pkgs/flox-ai/e2e/launch.bats
@@ -22,6 +22,7 @@ printf '%s\n' "$@" > "$REC_ARGV"
 {
   echo "FLOX_AI=$FLOX_AI"
   echo "FLOX_AI_DIR=$FLOX_AI_DIR"
+  echo "AGENT_DECK_HOME=$AGENT_DECK_HOME"
   echo "XDG_CONFIG_HOME=$XDG_CONFIG_HOME"
   echo "XDG_DATA_HOME=$XDG_DATA_HOME"
 } > "$REC_ENV"
@@ -89,11 +90,16 @@ EOF
   grep -q '\[tmux\]' "$cfg"
   grep -q "socket_name = 'flox-ai-" "$cfg"
 
-  # isolated env: config + data home co-located, FLOX_AI_DIR pinned
-  grep -qx "XDG_CONFIG_HOME=$config_dir/agents" "$REC_ENV"
-  grep -qx "XDG_DATA_HOME=$config_dir/agents" "$REC_ENV"
+  # isolated env: the deck home is pinned via AGENT_DECK_HOME, FLOX_AI_DIR set
+  grep -qx "AGENT_DECK_HOME=$config_dir/agents/agent-deck" "$REC_ENV"
   grep -qx "FLOX_AI_DIR=$config_dir" "$REC_ENV"
   grep -qx 'FLOX_AI=1' "$REC_ENV"
+
+  # XDG must NOT be hijacked -- overriding it would leak the deck home into
+  # agent-deck's tmux panes and break unrelated programs. Assert neither XDG
+  # var was repointed at the deck home.
+  ! grep -qx "XDG_CONFIG_HOME=$config_dir/agents" "$REC_ENV"
+  ! grep -qx "XDG_DATA_HOME=$config_dir/agents" "$REC_ENV"
 
   # passthrough reaches agent-deck without the -- delimiter
   run cat "$REC_ARGV"

--- a/.flox/pkgs/flox-ai/e2e/launch.bats
+++ b/.flox/pkgs/flox-ai/e2e/launch.bats
@@ -125,6 +125,65 @@ EOF
   [[ -n "$first" ]]
 }
 
+# A fake agent-deck that spawns tmux exactly like the real binary
+# (new-session -d on the seeded per-env socket) and records a pane's
+# environment. This reaches the actual leak path -- the env recorder above
+# only sees the agent-deck process env, not what its tmux panes inherit.
+make_tmux_probe_deck() {
+  local bindir="$BATS_TEST_TMPDIR/fakebin"
+  mkdir -p "$bindir"
+  export REC="$BATS_TEST_TMPDIR/deck-rec.txt"
+  cat > "$bindir/agent-deck" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+{
+  echo "PROC_AGENT_DECK_HOME=$AGENT_DECK_HOME"
+  echo "PROC_XDG_CONFIG_HOME=${XDG_CONFIG_HOME:-}"
+  echo "PROC_XDG_DATA_HOME=${XDG_DATA_HOME:-}"
+} > "$REC"
+# socket flox-ai seeded into the deck config (go-toml emits single quotes)
+sock="$(sed -n "s/^socket_name = '\(.*\)'/\1/p" "$AGENT_DECK_HOME/config.toml")"
+echo "SOCKET=$sock" >> "$REC"
+pane="$REC.pane"
+tmux -L "$sock" new-session -d -s probe \
+  "env | grep -E '^(XDG_CONFIG_HOME|XDG_DATA_HOME|AGENT_DECK_HOME)=' > '$pane'; tmux -L '$sock' wait -S done"
+tmux -L "$sock" wait done
+sed 's/^/PANE_/' "$pane" >> "$REC"
+tmux -L "$sock" kill-server 2>/dev/null || true
+EOF
+  chmod +x "$bindir/agent-deck"
+  export PATH="$bindir:$PATH"
+}
+
+@test "launch agent-deck does not leak XDG into tmux panes" {
+  command -v tmux >/dev/null || skip "tmux not available"
+  local dir config_dir
+  dir="$(setup_fixtures)"
+  config_dir="$(setup_config_dir)"
+  make_tmux_probe_deck
+
+  # sentinel "real" XDG that must survive untouched into the tmux pane
+  export XDG_CONFIG_HOME="$BATS_TEST_TMPDIR/real-config"
+  export XDG_DATA_HOME="$BATS_TEST_TMPDIR/real-data"
+  mkdir -p "$XDG_CONFIG_HOME" "$XDG_DATA_HOME"
+
+  run flox-ai --dir "$dir" --config-dir "$config_dir" launch agent-deck
+  assert_success
+
+  local deck="$config_dir/agents/agent-deck"
+  # agent-deck process: deck home pinned via AGENT_DECK_HOME, XDG untouched
+  grep -qx "PROC_AGENT_DECK_HOME=$deck" "$REC"
+  grep -qx "PROC_XDG_CONFIG_HOME=$XDG_CONFIG_HOME" "$REC"
+  grep -qx "PROC_XDG_DATA_HOME=$XDG_DATA_HOME" "$REC"
+
+  # the leak test: the tmux pane inherits the host XDG, NOT the deck home --
+  # overriding XDG (the old bug) would surface the deck home here and break
+  # unrelated programs in the pane.
+  grep -qx "PANE_XDG_CONFIG_HOME=$XDG_CONFIG_HOME" "$REC"
+  grep -qx "PANE_XDG_DATA_HOME=$XDG_DATA_HOME" "$REC"
+  grep -qx "PANE_AGENT_DECK_HOME=$deck" "$REC"
+}
+
 # ---- errors --------------------------------------------------------------
 
 @test "launch rejects an unknown agent" {

--- a/.flox/pkgs/flox-ai/internal/launch/agentdeck.go
+++ b/.flox/pkgs/flox-ai/internal/launch/agentdeck.go
@@ -105,14 +105,12 @@ func SeedDeckConfig(deckDir, sourcePath, socketName string) error {
 	return os.WriteFile(filepath.Join(deckDir, "config.toml"), out, 0644)
 }
 
-// DeckHome derives the agent-deck XDG layout from the flox-ai configDir.
-// agent-deck resolves ConfigDir as $XDG_CONFIG_HOME/agent-deck, so the
-// XDG_CONFIG_HOME we hand it is <configDir>/agents and the deck config
-// home is <configDir>/agents/agent-deck.
-func DeckHome(configDir string) (xdgConfigHome, deckDir string) {
-	xdgConfigHome = filepath.Join(configDir, "agents")
-	deckDir = filepath.Join(xdgConfigHome, "agent-deck")
-	return
+// DeckHome derives the agent-deck home from the flox-ai configDir. The
+// patched agent-deck reads config, data, and cache directly from the
+// directory named by AGENT_DECK_HOME, so this single path is both where we
+// seed config.toml and what we export to the deck.
+func DeckHome(configDir string) string {
+	return filepath.Join(configDir, "agents", "agent-deck")
 }
 
 // DeckSocketName returns a stable, per-environment tmux socket name
@@ -147,14 +145,18 @@ func setEnvVar(env []string, key, val string) []string {
 }
 
 // deckChildEnv builds the environment for the agent-deck process: the
-// parent env with XDG_CONFIG_HOME and XDG_DATA_HOME both pointed at the
-// flox deck home (so config and per-env session state live together under
-// one isolated home), FLOX_AI=1, and FLOX_AI_DIR pinned to configDir so
-// the nested `flox-ai launch claude` resolves this env's fragments.
-// XDG_CACHE_HOME is intentionally left untouched.
-func deckChildEnv(base []string, xdgConfigHome, configDir string) []string {
-	env := setEnvVar(base, "XDG_CONFIG_HOME", xdgConfigHome)
-	env = setEnvVar(env, "XDG_DATA_HOME", xdgConfigHome)
+// parent env with AGENT_DECK_HOME pointed at the flox deck home (so the
+// deck's config, data, and cache live together under one isolated, per-env
+// home), FLOX_AI=1, and FLOX_AI_DIR pinned to configDir so the nested
+// `flox-ai launch claude` resolves this env's fragments.
+//
+// Crucially it leaves XDG_CONFIG_HOME/XDG_DATA_HOME untouched. agent-deck
+// spawns a tmux server that inherits this env, and every pane inherits the
+// server's env; overriding XDG here would leak the deck home into those
+// panes and break unrelated programs that read XDG to find their own config.
+// AGENT_DECK_HOME isolates the deck without that side effect.
+func deckChildEnv(base []string, deckHome, configDir string) []string {
+	env := setEnvVar(base, "AGENT_DECK_HOME", deckHome)
 	env = setEnvVar(env, "FLOX_AI", "1")
 	env = setEnvVar(env, "FLOX_AI_DIR", configDir)
 	return env
@@ -162,9 +164,8 @@ func deckChildEnv(base []string, xdgConfigHome, configDir string) []string {
 
 // RunDeck seeds the flox-managed agent-deck config (forcing the claude
 // command to route through flox-ai and a per-env tmux socket), points
-// agent-deck at it via XDG_CONFIG_HOME/XDG_DATA_HOME, exports FLOX_AI_DIR
-// for nested flox-ai invocations, and execs agent-deck (replacing this
-// process).
+// agent-deck at it via AGENT_DECK_HOME, exports FLOX_AI_DIR for nested
+// flox-ai invocations, and execs agent-deck (replacing this process).
 func RunDeck(opts Options) error {
 	agent := Supported[opts.AgentName] // caller guarantees agent-deck
 	bin, err := resolveBinary(agent)
@@ -172,15 +173,15 @@ func RunDeck(opts Options) error {
 		return err
 	}
 
-	xdgConfigHome, deckDir := DeckHome(opts.ConfigDir)
+	deckHome := DeckHome(opts.ConfigDir)
 	socketName := DeckSocketName(opts.ConfigDir)
 
 	source := findUserDeckConfig(os.Getenv("XDG_CONFIG_HOME"), os.Getenv("HOME"))
-	if err := SeedDeckConfig(deckDir, source, socketName); err != nil {
+	if err := SeedDeckConfig(deckHome, source, socketName); err != nil {
 		return err
 	}
 
 	argv := append([]string{bin}, opts.Passthrough...)
-	env := deckChildEnv(os.Environ(), xdgConfigHome, opts.ConfigDir)
+	env := deckChildEnv(os.Environ(), deckHome, opts.ConfigDir)
 	return syscall.Exec(bin, argv, env)
 }

--- a/.flox/pkgs/flox-ai/internal/launch/agentdeck_test.go
+++ b/.flox/pkgs/flox-ai/internal/launch/agentdeck_test.go
@@ -221,18 +221,14 @@ func TestSeedDeckConfig_NoSource(t *testing.T) {
 }
 
 func TestDeckHome(t *testing.T) {
-	xdg, deck := DeckHome("/proj/.flox/cache/flox-ai")
-	if xdg != "/proj/.flox/cache/flox-ai/agents" {
-		t.Fatalf("xdg: %q", xdg)
-	}
-	if deck != "/proj/.flox/cache/flox-ai/agents/agent-deck" {
-		t.Fatalf("deck: %q", deck)
+	if got := DeckHome("/proj/.flox/cache/flox-ai"); got != "/proj/.flox/cache/flox-ai/agents/agent-deck" {
+		t.Fatalf("deck home: %q", got)
 	}
 }
 
 func TestDeckChildEnv(t *testing.T) {
-	base := []string{"PATH=/bin", "XDG_CONFIG_HOME=/old", "FLOX_ENV=/env"}
-	env := deckChildEnv(base, "/new/agents", "/cfg")
+	base := []string{"PATH=/bin", "XDG_CONFIG_HOME=/old", "XDG_DATA_HOME=/olddata", "FLOX_ENV=/env"}
+	env := deckChildEnv(base, "/deck/home", "/cfg")
 	has := func(want string) bool {
 		for _, e := range env {
 			if e == want {
@@ -241,30 +237,26 @@ func TestDeckChildEnv(t *testing.T) {
 		}
 		return false
 	}
-	if !has("XDG_CONFIG_HOME=/new/agents") {
-		t.Fatalf("XDG_CONFIG_HOME not overridden: %v", env)
+	if !has("AGENT_DECK_HOME=/deck/home") {
+		t.Fatalf("AGENT_DECK_HOME not set: %v", env)
 	}
 	if !has("FLOX_AI=1") || !has("FLOX_AI_DIR=/cfg") {
 		t.Fatalf("flox vars missing: %v", env)
 	}
-	// data home co-located with config home (per-env session isolation)
-	if !has("XDG_DATA_HOME=/new/agents") {
-		t.Fatalf("XDG_DATA_HOME not set to deck home: %v", env)
+	// XDG must be left exactly as the parent had it -- the whole point is to
+	// not hijack XDG, which would leak the deck home into agent-deck's tmux
+	// panes and break unrelated programs there.
+	if !has("XDG_CONFIG_HOME=/old") || !has("XDG_DATA_HOME=/olddata") {
+		t.Fatalf("XDG vars must be untouched: %v", env)
 	}
-	// no duplicate XDG_CONFIG_HOME
+	// no duplicate AGENT_DECK_HOME
 	n := 0
 	for _, e := range env {
-		if strings.HasPrefix(e, "XDG_CONFIG_HOME=") {
+		if strings.HasPrefix(e, "AGENT_DECK_HOME=") {
 			n++
 		}
 	}
 	if n != 1 {
-		t.Fatalf("duplicate XDG_CONFIG_HOME: %v", env)
-	}
-	// cache left untouched
-	for _, e := range env {
-		if strings.HasPrefix(e, "XDG_CACHE_HOME=") {
-			t.Fatalf("XDG_CACHE_HOME must not be set: %v", env)
-		}
+		t.Fatalf("duplicate AGENT_DECK_HOME: %v", env)
 	}
 }

--- a/docs/flox-ai/architecture/launch.md
+++ b/docs/flox-ai/architecture/launch.md
@@ -30,9 +30,13 @@ a flox-managed, per-environment configuration. On every launch it:
 - forces the deck's claude command to `flox-ai launch claude --`, so every
   session Agent Deck spawns runs back through flox-ai and inherits this
   environment's fragments;
-- isolates the deck per environment with its own data home and a stable,
+- isolates the deck per environment via `AGENT_DECK_HOME` (a flox patch to
+  agent-deck makes it override the `XDG_*` base dirs) plus a stable,
   per-config-dir tmux socket, so decks in different environments do not share
-  state or collide.
+  state or collide. `AGENT_DECK_HOME` is used instead of overriding
+  `XDG_CONFIG_HOME`/`XDG_DATA_HOME` because the deck's tmux server propagates
+  its environment to every pane; hijacking `XDG_*` would leak the deck home
+  into those panes and break unrelated programs.
 
 `RunDeck` (in `internal/launch/agentdeck.go`) implements this; `go-toml/v2`
 parses and rewrites the config.

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
               flox-ai
               batsWithLibs
               pkgs.coreutils
+              pkgs.tmux # launch.bats: agent-deck XDG-leak test spawns tmux
             ]
           }:$PATH"
           export BATS_SUPPORT_LIB="${pkgs.bats.libraries.bats-support}/share/bats/bats-support"
@@ -53,6 +54,7 @@
             lib.makeBinPath [
               batsWithLibs
               pkgs.coreutils
+              pkgs.tmux # launch.bats: agent-deck XDG-leak test spawns tmux
             ]
           }:$PATH"
           export BATS_SUPPORT_LIB="${pkgs.bats.libraries.bats-support}/share/bats/bats-support"


### PR DESCRIPTION
## Problem

`flox-ai launch agent-deck` pointed the deck at its per-environment home by
overriding `XDG_CONFIG_HOME` and `XDG_DATA_HOME`. agent-deck spawns a tmux
server whose environment every pane inherits, so those overrides leaked into
the panes and broke unrelated programs that read `XDG_*` to find their own
config (nvim, gh, git, starship, …).

## Fix

Patch agent-deck to honor a dedicated `AGENT_DECK_HOME` env var that takes
precedence over the `XDG_*` base dirs (and legacy `~/.agent-deck`) for config,
data, and cache alike. The override lives in `internal/agentpaths` — the single
funnel every path resolves through, so it also covers logs, ack-signal, and
badge-updates. flox-ai now exports `AGENT_DECK_HOME` and leaves `XDG_*`
untouched, so the deck stays isolated without leaking into its tmux panes.

## Changes

- `.flox/pkgs/agent-deck/agent-deck-home.patch` — downstream patch adding the
  `AGENT_DECK_HOME` override + Go tests; wired into `default.nix` via `patches`.
- `internal/launch/agentdeck.go` — `deckChildEnv` sets `AGENT_DECK_HOME`;
  `DeckHome`/`RunDeck` simplified.
- Updated unit tests, e2e bats, README, and launch architecture doc.

## Verification

- Patch applies clean on upstream v1.9.70.
- Full `flox build agent-deck` green: patch applied, checkPhase (~40 tests) +
  new agentpaths tests pass, version check OK.
- flox-ai `go build` / `go vet` / `go test ./internal/launch` pass.
- `srcHash` and `vendorHash` unchanged.
- Patched agent-deck 1.9.70 published to all 4 systems.

## Follow-up

- Upstream the `AGENT_DECK_HOME` patch to asheshgoplani/agent-deck; once merged,
  drop the local patch + `default.nix` entry.