### PR TITLE
feat(flox-ai): add codex launch support

### DIFF
--- a/.flox/pkgs/codex/default.nix
+++ b/.flox/pkgs/codex/default.nix
@@ -64,6 +64,15 @@ rustPlatform.buildRustPackage {
 
   sourceRoot = "source/codex-rs";
 
+  # flox-fragments.patch teaches Codex to read two env vars set by
+  # `flox-ai launch codex`: CODEX_FLOX_SKILL_ROOTS (extra skill-root dirs)
+  # and CODEX_FLOX_INSTRUCTIONS_FILE (extra project instructions). This lets
+  # flox inject environment-managed skills and rules without mutating
+  # ~/.codex or the working tree. Re-verify on every version bump
+  # (see upgrade.sh) — the patch targets core-skills/loader.rs and
+  # core/agents_md.rs. Paths are relative to codex-rs (the sourceRoot).
+  patches = [ ./flox-fragments.patch ];
+
   cargoBuildFlags = [
     "--package"
     "codex-cli"

--- a/.flox/pkgs/codex/flox-fragments.patch
+++ b/.flox/pkgs/codex/flox-fragments.patch
@@ -1,0 +1,56 @@
+diff --git a/core-skills/src/loader.rs b/core-skills/src/loader.rs
+index 3b59e90..c52b93a 100644
+--- a/core-skills/src/loader.rs
++++ b/core-skills/src/loader.rs
+@@ -275,6 +275,25 @@ async fn skill_roots_with_home_dir(
+         plugin_id: None,
+         plugin_root: None,
+     }));
++    // flox-ai: extra skill roots injected via the CODEX_FLOX_SKILL_ROOTS env
++    // var (colon-separated absolute paths). Added by the flox downstream
++    // patch so `flox-ai launch codex` can surface environment-managed skills
++    // without mutating ~/.codex or the working tree.
++    if let Ok(raw) = std::env::var("CODEX_FLOX_SKILL_ROOTS") {
++        for entry in raw.split(':').filter(|s| !s.is_empty()) {
++            if let Ok(path) =
++                AbsolutePathBuf::from_absolute_path_checked(std::path::PathBuf::from(entry))
++            {
++                roots.push(SkillRoot {
++                    path,
++                    scope: SkillScope::User,
++                    file_system: Arc::clone(&LOCAL_FS),
++                    plugin_id: None,
++                    plugin_root: None,
++                });
++            }
++        }
++    }
+     roots.extend(repo_agents_skill_roots(fs, config_layer_stack, cwd).await);
+     dedupe_skill_roots_by_path(&mut roots);
+     roots
+diff --git a/core/src/agents_md.rs b/core/src/agents_md.rs
+index d63342b..3dd345d 100644
+--- a/core/src/agents_md.rs
++++ b/core/src/agents_md.rs
+@@ -72,6 +72,21 @@ pub(crate) async fn load_project_instructions(
+         }
+     }
+ 
++    // flox-ai: extra project instructions injected via the
++    // CODEX_FLOX_INSTRUCTIONS_FILE env var pointing at a file. Added by the
++    // flox downstream patch so `flox-ai launch codex` can inject
++    // environment-managed rules without writing AGENTS.md into the user's
++    // repo or ~/.codex.
++    if let Ok(path) = std::env::var("CODEX_FLOX_INSTRUCTIONS_FILE")
++        && let Ok(contents) = tokio::fs::read_to_string(&path).await
++        && !contents.trim().is_empty()
++    {
++        loaded.entries.push(InstructionEntry {
++            contents,
++            provenance: InstructionProvenance::Internal,
++        });
++    }
++
+     if config.features.enabled(Feature::ChildAgentsMd) {
+         loaded.entries.push(InstructionEntry {
+             contents: HIERARCHICAL_AGENTS_MESSAGE.to_string(),

--- a/.flox/pkgs/codex/upgrade.sh
+++ b/.flox/pkgs/codex/upgrade.sh
@@ -97,3 +97,7 @@ trap - EXIT
 echo "Updated to $latest_version"
 echo "NOTE: librusty_v8 and livekit_webrtc hashes were kept as-is."
 echo "      If the build fails, check if those deps changed upstream."
+echo "WARNING: flox-fragments.patch must be re-verified against the new"
+echo "         version. It targets core-skills/src/loader.rs and"
+echo "         core/src/agents_md.rs. If 'flox build codex' fails on the"
+echo "         patchPhase, regenerate it (see default.nix for details)."

--- a/.flox/pkgs/flox-ai/e2e/launch.bats
+++ b/.flox/pkgs/flox-ai/e2e/launch.bats
@@ -24,6 +24,8 @@ printf '%s\n' "$@" > "$REC_ARGV"
   echo "FLOX_AI_DIR=$FLOX_AI_DIR"
   echo "XDG_CONFIG_HOME=$XDG_CONFIG_HOME"
   echo "XDG_DATA_HOME=$XDG_DATA_HOME"
+  echo "CODEX_FLOX_SKILL_ROOTS=$CODEX_FLOX_SKILL_ROOTS"
+  echo "CODEX_FLOX_INSTRUCTIONS_FILE=$CODEX_FLOX_INSTRUCTIONS_FILE"
 } > "$REC_ENV"
 exit 0
 EOF
@@ -117,6 +119,36 @@ EOF
 
   [[ "$first" == "$second" ]]
   [[ -n "$first" ]]
+}
+
+# ---- codex agent ---------------------------------------------------------
+
+@test "launch codex execs codex with fragments injected via env vars" {
+  local dir config_dir
+  dir="$(setup_fixtures)"
+  config_dir="$(setup_config_dir)"
+  make_fake_agent codex
+
+  run flox-ai --dir "$dir" --config-dir "$config_dir" \
+    launch codex -- exec "hello"
+  assert_success
+
+  # Codex takes no --plugin-dir / --append-system-prompt-file flags: the
+  # fragments are injected through the patch env vars, pointing at staged
+  # copies under the per-env codex launch dir.
+  grep -qx "CODEX_FLOX_SKILL_ROOTS=$config_dir/codex/skills" "$REC_ENV"
+  grep -qx "CODEX_FLOX_INSTRUCTIONS_FILE=$config_dir/codex/rules.md" "$REC_ENV"
+  grep -qx 'FLOX_AI=1' "$REC_ENV"
+
+  # the staged skill root and rules file exist on disk
+  [[ -d "$config_dir/codex/skills" ]]
+  [[ -f "$config_dir/codex/rules.md" ]]
+
+  # passthrough reaches codex without the -- delimiter
+  grep -qx -- 'exec' "$REC_ARGV"
+  grep -qx -- 'hello' "$REC_ARGV"
+  run grep -cx -- '--' "$REC_ARGV"
+  assert_output '0'
 }
 
 # ---- errors --------------------------------------------------------------

--- a/.flox/pkgs/flox-ai/internal/launch/codex.go
+++ b/.flox/pkgs/flox-ai/internal/launch/codex.go
@@ -1,0 +1,120 @@
+// codex.go: runs OpenAI Codex with flox-managed fragments injected via the
+// env-var hooks added by the flox codex patch (flox-fragments.patch). Unlike
+// the claude path, Codex takes no --plugin-dir / --append-system-prompt-file
+// flags: it discovers skills from skill-root directories and rules from
+// project instructions. The patch lets us point Codex at flox-staged copies
+// through CODEX_FLOX_SKILL_ROOTS and CODEX_FLOX_INSTRUCTIONS_FILE, so nothing
+// in ~/.codex or the working tree is mutated.
+
+package launch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	"flox.dev/flox-ai/internal/discover"
+)
+
+const (
+	// EnvCodexSkillRoots is the colon-separated list of extra skill-root
+	// directories the flox codex patch appends to Codex's skill discovery.
+	EnvCodexSkillRoots = "CODEX_FLOX_SKILL_ROOTS"
+	// EnvCodexInstructionsFile is the extra project-instructions file the
+	// flox codex patch appends to Codex's loaded instructions.
+	EnvCodexInstructionsFile = "CODEX_FLOX_INSTRUCTIONS_FILE"
+)
+
+// BuildCodexSkillRoot creates a Codex skill-root directory under
+// launchDir/skills containing the given skills and agents as skill
+// subdirectories, and returns the root path. Each skill is linked as its
+// SKILL.md-holding directory; each standalone agent is wrapped as
+// <name>/SKILL.md (Codex discovers it as a skill). Codex follows symlinked
+// skill folders when scanning. Returns "" (and writes nothing) when there
+// are no skills or agents.
+func BuildCodexSkillRoot(launchDir string, skills, agents []discover.Fragment) (string, error) {
+	if len(skills) == 0 && len(agents) == 0 {
+		return "", nil
+	}
+	root := filepath.Join(launchDir, "skills")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		return "", err
+	}
+	for _, s := range skills {
+		// s.Path is the SKILL.md file; link its directory as a skill.
+		target := filepath.Dir(s.Path)
+		if err := os.Symlink(target, filepath.Join(root, s.Name)); err != nil {
+			return "", err
+		}
+	}
+	for _, a := range agents {
+		// Standalone agents have no skill directory; synthesize one whose
+		// SKILL.md is the agent file so Codex surfaces it as a skill.
+		dir := filepath.Join(root, a.Name)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return "", err
+		}
+		if err := os.Symlink(a.Path, filepath.Join(dir, "SKILL.md")); err != nil {
+			return "", err
+		}
+	}
+	return root, nil
+}
+
+// PrepareCodex wipes launchDir and rebuilds the synth skill root and merged
+// rules file from the discovered fragments. Like Prepare, wiping each run
+// keeps the tree free of stale entries. Returns the skill-root path ("" if
+// none) and the rules file path ("" if none).
+func PrepareCodex(launchDir string, frags *discover.Result) (skillRoot, rulesFile string, err error) {
+	if err := os.RemoveAll(launchDir); err != nil {
+		return "", "", err
+	}
+	if err := os.MkdirAll(launchDir, 0755); err != nil {
+		return "", "", err
+	}
+	skillRoot, err = BuildCodexSkillRoot(launchDir, frags.Skills, frags.Agents)
+	if err != nil {
+		return "", "", err
+	}
+	rulesFile, err = MergeRules(launchDir, frags.Rules)
+	if err != nil {
+		return "", "", err
+	}
+	return skillRoot, rulesFile, nil
+}
+
+// RunCodex resolves the codex binary, stages this environment's skills and
+// rules under the flox config dir, points Codex at them via the patch env
+// vars, and execs codex (replacing this process). Codex plugins are not
+// mapped: the flox/Claude plugin format differs from Codex's. It only
+// returns when something fails before exec.
+func RunCodex(opts Options) error {
+	agent := Supported[opts.AgentName] // caller guarantees codex
+	bin, err := resolveBinary(agent)
+	if err != nil {
+		return err
+	}
+
+	frags, err := discover.Scan(opts.ShareDir)
+	if err != nil {
+		return fmt.Errorf("discover: %w", err)
+	}
+
+	launchDir := filepath.Join(opts.ConfigDir, "codex")
+	skillRoot, rulesFile, err := PrepareCodex(launchDir, frags)
+	if err != nil {
+		return err
+	}
+
+	env := setEnvVar(os.Environ(), "FLOX_AI", "1")
+	if skillRoot != "" {
+		env = setEnvVar(env, EnvCodexSkillRoots, skillRoot)
+	}
+	if rulesFile != "" {
+		env = setEnvVar(env, EnvCodexInstructionsFile, rulesFile)
+	}
+
+	argv := append([]string{bin}, opts.Passthrough...)
+	return syscall.Exec(bin, argv, env)
+}

--- a/.flox/pkgs/flox-ai/internal/launch/codex_test.go
+++ b/.flox/pkgs/flox-ai/internal/launch/codex_test.go
@@ -1,0 +1,79 @@
+package launch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"flox.dev/flox-ai/internal/discover"
+)
+
+func TestBuildCodexSkillRoot_None(t *testing.T) {
+	got, err := BuildCodexSkillRoot(t.TempDir(), nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "" {
+		t.Fatalf("want empty root, got %q", got)
+	}
+}
+
+func TestBuildCodexSkillRoot_SkillsAndAgents(t *testing.T) {
+	src := t.TempDir()
+
+	// A skill is a directory holding SKILL.md.
+	skillDir := filepath.Join(src, "myskill")
+	if err := os.MkdirAll(skillDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	skillMD := filepath.Join(skillDir, "SKILL.md")
+	if err := os.WriteFile(skillMD, []byte("# skill\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A standalone agent is a bare .md file.
+	agentMD := filepath.Join(src, "myagent.md")
+	if err := os.WriteFile(agentMD, []byte("# agent\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	launchDir := t.TempDir()
+	root, err := BuildCodexSkillRoot(launchDir,
+		[]discover.Fragment{{Name: "myskill", Path: skillMD}},
+		[]discover.Fragment{{Name: "myagent", Path: agentMD}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if root == "" {
+		t.Fatal("want non-empty root")
+	}
+
+	// Skill links its directory; the linked dir must carry SKILL.md.
+	if _, err := os.Stat(filepath.Join(root, "myskill", "SKILL.md")); err != nil {
+		t.Fatalf("skill not linked: %v", err)
+	}
+	// Agent is wrapped as <name>/SKILL.md.
+	if _, err := os.Stat(filepath.Join(root, "myagent", "SKILL.md")); err != nil {
+		t.Fatalf("agent not wrapped as skill: %v", err)
+	}
+}
+
+func TestPrepareCodex_Wipes(t *testing.T) {
+	launchDir := filepath.Join(t.TempDir(), "codex")
+	// Pre-seed a stale entry that must be wiped.
+	if err := os.MkdirAll(filepath.Join(launchDir, "skills", "stale"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	skillRoot, rulesFile, err := PrepareCodex(launchDir, &discover.Result{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if skillRoot != "" || rulesFile != "" {
+		t.Fatalf("want empty outputs for no fragments, got %q / %q", skillRoot, rulesFile)
+	}
+	if _, err := os.Stat(filepath.Join(launchDir, "skills", "stale")); !os.IsNotExist(err) {
+		t.Fatal("stale entry was not wiped")
+	}
+}

--- a/.flox/pkgs/flox-ai/internal/launch/launch.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch.go
@@ -25,6 +25,7 @@ type Agent struct {
 var Supported = map[string]Agent{
 	"claude":     {Name: "claude", InstallPkg: "claude-code"},
 	"agent-deck": {Name: "agent-deck", InstallPkg: "agent-deck"},
+	"codex":      {Name: "codex", InstallPkg: "codex"},
 }
 
 // SupportedNames returns the supported agent names, sorted and
@@ -202,6 +203,10 @@ func Run(opts Options) error {
 
 	if opts.AgentName == "agent-deck" {
 		return RunDeck(opts)
+	}
+
+	if opts.AgentName == "codex" {
+		return RunCodex(opts)
 	}
 
 	bin, err := resolveBinary(agent)

--- a/.flox/pkgs/flox-ai/internal/launch/launch_test.go
+++ b/.flox/pkgs/flox-ai/internal/launch/launch_test.go
@@ -48,8 +48,8 @@ func TestPlanArgv_NoSynthNoRules(t *testing.T) {
 }
 
 func TestSupportedNames(t *testing.T) {
-	if got := SupportedNames(); got != "agent-deck, claude" {
-		t.Fatalf("got %q want %q", got, "agent-deck, claude")
+	if got := SupportedNames(); got != "agent-deck, claude, codex" {
+		t.Fatalf("got %q want %q", got, "agent-deck, claude, codex")
 	}
 }
 

--- a/.flox/pkgs/flox-ai/internal/tui/agentbar.go
+++ b/.flox/pkgs/flox-ai/internal/tui/agentbar.go
@@ -20,6 +20,8 @@ func agentDisplay(name string) string {
 		return "Claude"
 	case "agent-deck":
 		return "Agent Deck"
+	case "codex":
+		return "Codex"
 	case "":
 		return ""
 	default:
@@ -41,6 +43,12 @@ func agentInfo(name string) (title, desc string) {
 			"Terminal session manager for AI coding agents. Spawns Claude " +
 				"Code sessions through flox-ai, so this environment's " +
 				"fragments are injected into every session it manages."
+	case "codex":
+		return "Codex",
+			"OpenAI's Codex CLI. Injects this environment's skills, agents " +
+				"and rules via Codex's skill roots and project " +
+				"instructions. Plugins are not injected (Codex uses a " +
+				"different plugin format)."
 	default:
 		return name, "AI coding agent."
 	}
@@ -60,6 +68,14 @@ func agentLaunch(name string) string {
 			"skills, agents and rules are injected into each one.\n\n" +
 			"Agent Deck keeps its config and tmux socket isolated per " +
 			"environment.\n\n" +
+			"You can install or remove fragments and relaunch any time."
+	case "codex":
+		return "Starts Codex with this environment's skills, agents and " +
+			"rules injected via Codex's skill roots and project " +
+			"instructions — your ~/.codex and working tree are left " +
+			"untouched.\n\n" +
+			"Plugins are not injected: Codex uses a different plugin " +
+			"format.\n\n" +
 			"You can install or remove fragments and relaunch any time."
 	default:
 		return "Starts the agent with the installed plugins, skills, agents and rules."

--- a/.flox/pkgs/flox-ai/internal/tui/agentbar_codex_test.go
+++ b/.flox/pkgs/flox-ai/internal/tui/agentbar_codex_test.go
@@ -1,0 +1,24 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCodexDisplay(t *testing.T) {
+	if got := agentDisplay("codex"); got != "Codex" {
+		t.Errorf("agentDisplay(codex) = %q, want %q", got, "Codex")
+	}
+	title, desc := agentInfo("codex")
+	if title != "Codex" || !strings.Contains(desc, "skill roots") {
+		t.Errorf("agentInfo(codex) = %q / %q", title, desc)
+	}
+	launch := agentLaunch("codex")
+	if !strings.Contains(launch, "Codex") {
+		t.Errorf("agentLaunch(codex) missing name: %q", launch)
+	}
+	// Codex must advertise that plugins are not injected.
+	if !strings.Contains(launch, "Plugins are not injected") {
+		t.Errorf("agentLaunch(codex) missing plugin caveat: %q", launch)
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /.direnv/
 /result
+/result-*
 /*/.flox/cache
 /*/.flox/log
 /*/.flox/run


### PR DESCRIPTION
## What

Adds OpenAI **Codex** as a launchable agent in `flox-ai`, alongside `claude` and `agent-deck`.

## How

Codex takes no `--plugin-dir` / `--append-system-prompt-file` flags (its discovery is location-fixed: `.agents/skills/`, `AGENTS.md`). To inject fragments without mutating `~/.codex` or the working tree, a small downstream patch teaches Codex to read two env vars:

| Env var | Injects |
| ------- | ------- |
| `CODEX_FLOX_SKILL_ROOTS` | extra skill-root dirs (skills + agents) |
| `CODEX_FLOX_INSTRUCTIONS_FILE` | extra project instructions (rules) |

`flox-ai launch codex` stages a synth skill root (skills as `SKILL.md` dirs via symlink; standalone agents wrapped as `<name>/SKILL.md`) and a merged rules file under the per-env config dir, sets the env vars, and execs codex.

**Plugins are not mapped** — the flox/Claude plugin format differs from Codex's (`.codex-plugin/` + marketplace.json).

## Changes

- `.flox/pkgs/codex/flox-fragments.patch` — two ~5-line env-var seams in `core-skills/loader.rs` and `core/agents_md.rs`; wired via `patches` in `default.nix`
- `upgrade.sh` warns to re-verify the patch on version bumps
- `internal/launch/codex.go` — `RunCodex`, `BuildCodexSkillRoot`, `PrepareCodex`
- registry entry + dispatch in `launch.go`; TUI display in `agentbar.go`
- unit tests, TUI test, e2e `launch.bats` block
- gitignore `result-*` build artifacts

## Verification

- Go: builds, `go vet` clean, all tests pass, gofmt clean
- Patch: applies clean to `rust-v0.140.0`; `flox build codex` succeeds; both env-var strings confirmed compiled into the binary

## Caveats

- Building codex from source is slow (Rust + V8) and the patch is a maintenance cost on every codex version bump (flagged in `upgrade.sh`)