### PR TITLE
ci(pkgs): build-or-publish per leg, drop all-or-nothing publish job

### DIFF
--- a/.github/workflows/ci_pkgs.yml
+++ b/.github/workflows/ci_pkgs.yml
@@ -41,7 +41,6 @@ jobs:
       aarch64-linux: "${{ steps.discover.outputs.aarch64-linux }}"
       x86_64-darwin: "${{ steps.discover.outputs.x86_64-darwin }}"
       x86_64-linux: "${{ steps.discover.outputs.x86_64-linux }}"
-      publish_matrix: "${{ steps.discover.outputs.publish_matrix }}"
 
     steps:
       - name: "Checkout"
@@ -102,7 +101,10 @@ jobs:
           echo "packages=$pkgs" >> "$GITHUB_OUTPUT"
           echo "Packages: $pkgs"
 
-          # Per-system package lists from publish.json
+          # Per-system package lists from publish.json. A package
+          # builds (and, on main, publishes) only on the systems it
+          # declares; missing publish.json or no "systems" field
+          # means all four.
           for sys in $ALL_SYSTEMS; do
             sys_pkgs="[]"
             for pkg in $(echo "$pkgs" | jq -r '.[]'); do
@@ -132,31 +134,17 @@ jobs:
             echo "  $sys: $sys_pkgs"
           done
 
-          # Per-(package, system) tuples for the publish matrix
-          DEFAULT_SYS='["aarch64-darwin","aarch64-linux","x86_64-darwin","x86_64-linux"]'
-          publish_matrix="[]"
-          for pkg in $(echo "$pkgs" | jq -r '.[]'); do
-            PJ=".flox/pkgs/$pkg/publish.json"
-            if [ -f "$PJ" ]; then
-              pkg_sys=$(jq -rc \
-                ".systems // $DEFAULT_SYS" "$PJ")
-            else
-              pkg_sys="$DEFAULT_SYS"
-            fi
-            for sys in $(echo "$pkg_sys" | jq -r '.[]'); do
-              publish_matrix=$(echo "$publish_matrix" \
-                | jq -c \
-                  --arg p "$pkg" --arg s "$sys" \
-                  '. + [{package: $p, system: $s}]')
-            done
-          done
-          echo "publish_matrix=$publish_matrix" >> "$GITHUB_OUTPUT"
-          echo "  publish_matrix: $publish_matrix"
+  # ── Build (PRs) or publish (main): one job per (package, system) ──
+  #
+  # Each (package, system) leg is independent — fail-fast is off, so
+  # one package failing on one system fails only that leg and leaves
+  # every other publish intact. On a push to main or a manual
+  # dispatch the leg runs `flox publish`; otherwise it runs
+  # `flox build`. There is no separate aggregate publish job, so no
+  # single failure can gate the whole catalog.
 
-  # ── Build: one job per system ───────────────────────
-
-  build-aarch64-darwin:
-    name: "Build '${{ matrix.package }}' (aarch64-darwin)"
+  aarch64-darwin:
+    name: "Package '${{ matrix.package }}' (aarch64-darwin)"
     runs-on: "ubuntu-latest"
     timeout-minutes: 90
     needs: ["discover"]
@@ -167,151 +155,6 @@ jobs:
       max-parallel: 2
       matrix:
         package: ${{ fromJSON(needs.discover.outputs.aarch64-darwin) }}
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6
-      - name: "Install flox"
-        uses: "flox/install-flox-action@f6002ed63e483f134001de7b4b45be891e00b09f" # v2.5.1
-      - name: "Setup Tailscale"
-        uses: "tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8" # v4
-        with:
-          oauth-secret: "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
-          tags: "tag:ci"
-          timeout: "30s"
-          use-cache: true
-      - name: "Configure Nix remote builders"
-        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
-        with:
-          ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
-          remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
-      - name: "Build"
-        run: flox build "${{ matrix.package }}" --system aarch64-darwin
-
-  build-aarch64-linux:
-    name: "Build '${{ matrix.package }}' (aarch64-linux)"
-    runs-on: "ubuntu-latest"
-    timeout-minutes: 90
-    needs: ["discover"]
-    if: needs.discover.outputs.aarch64-linux != '[]'
-
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        package: ${{ fromJSON(needs.discover.outputs.aarch64-linux) }}
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6
-      - name: "Install flox"
-        uses: "flox/install-flox-action@f6002ed63e483f134001de7b4b45be891e00b09f" # v2.5.1
-      - name: "Setup Tailscale"
-        uses: "tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8" # v4
-        with:
-          oauth-secret: "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
-          tags: "tag:ci"
-          timeout: "30s"
-          use-cache: true
-      - name: "Configure Nix remote builders"
-        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
-        with:
-          ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
-          remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
-      - name: "Build"
-        run: flox build "${{ matrix.package }}" --system aarch64-linux
-
-  build-x86_64-darwin:
-    name: "Build '${{ matrix.package }}' (x86_64-darwin)"
-    runs-on: "ubuntu-latest"
-    timeout-minutes: 90
-    needs: ["discover"]
-    if: needs.discover.outputs.x86_64-darwin != '[]'
-
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        package: ${{ fromJSON(needs.discover.outputs.x86_64-darwin) }}
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6
-      - name: "Install flox"
-        uses: "flox/install-flox-action@f6002ed63e483f134001de7b4b45be891e00b09f" # v2.5.1
-      - name: "Setup Tailscale"
-        uses: "tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8" # v4
-        with:
-          oauth-secret: "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
-          tags: "tag:ci"
-          timeout: "30s"
-          use-cache: true
-      - name: "Configure Nix remote builders"
-        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
-        with:
-          ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
-          remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
-      - name: "Build"
-        run: flox build "${{ matrix.package }}" --system x86_64-darwin
-
-  build-x86_64-linux:
-    name: "Build '${{ matrix.package }}' (x86_64-linux)"
-    runs-on: "ubuntu-latest"
-    timeout-minutes: 90
-    needs: ["discover"]
-    if: needs.discover.outputs.x86_64-linux != '[]'
-
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        package: ${{ fromJSON(needs.discover.outputs.x86_64-linux) }}
-
-    steps:
-      - name: "Checkout"
-        uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6
-      - name: "Install flox"
-        uses: "flox/install-flox-action@f6002ed63e483f134001de7b4b45be891e00b09f" # v2.5.1
-      - name: "Setup Tailscale"
-        uses: "tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8" # v4
-        with:
-          oauth-secret: "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
-          tags: "tag:ci"
-          timeout: "30s"
-          use-cache: true
-      - name: "Configure Nix remote builders"
-        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
-        with:
-          ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
-          remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
-      - name: "Build"
-        run: flox build "${{ matrix.package }}" --system x86_64-linux
-
-  # ── Publish: one job per (package, system) ──────────
-
-  publish:
-    name: "Publish '${{ matrix.package }}' (${{ matrix.system }})"
-    runs-on: "ubuntu-latest"
-    timeout-minutes: 30
-    needs:
-      - "discover"
-      - "build-aarch64-darwin"
-      - "build-aarch64-linux"
-      - "build-x86_64-darwin"
-      - "build-x86_64-linux"
-    if: >-
-      always()
-      && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
-      && github.ref_name == 'main'
-      && needs.discover.outputs.publish_matrix != '[]'
-      && !contains(needs.*.result, 'failure')
-      && !contains(needs.*.result, 'cancelled')
-
-    strategy:
-      fail-fast: false
-      max-parallel: 4
-      matrix:
-        include: ${{ fromJSON(needs.discover.outputs.publish_matrix) }}
 
     steps:
       - name: "Checkout"
@@ -333,13 +176,173 @@ jobs:
         with:
           ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
           remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
-      - name: "Get FloxHub token"
-        run: echo "FLOX_FLOXHUB_TOKEN=${{ secrets.FLOX_FLOXHUB_TOKEN }}" >> $GITHUB_ENV
-      - name: "Publish"
+      - name: "Build or publish"
+        env:
+          PUBLISH: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"
+          FLOX_FLOXHUB_TOKEN: "${{ secrets.FLOX_FLOXHUB_TOKEN }}"
         run: |
+          set -euo pipefail
           PKG="${{ matrix.package }}"
-          SYS="${{ matrix.system }}"
-          PJ=".flox/pkgs/$PKG/publish.json"
-          ORG=$(jq -r '.org // "flox"' "$PJ" 2>/dev/null || echo flox)
-          echo "Publishing $PKG to $ORG ($SYS)"
-          flox publish -o "$ORG" "$PKG" --system "$SYS"
+          SYS="aarch64-darwin"
+          if [ "$PUBLISH" = "true" ]; then
+            PJ=".flox/pkgs/$PKG/publish.json"
+            ORG=$(jq -r '.org // "flox"' "$PJ" 2>/dev/null || echo flox)
+            echo "Publishing $PKG to $ORG ($SYS)"
+            flox publish -o "$ORG" "$PKG" --system "$SYS"
+          else
+            echo "Building $PKG ($SYS)"
+            flox build "$PKG" --system "$SYS"
+          fi
+
+  aarch64-linux:
+    name: "Package '${{ matrix.package }}' (aarch64-linux)"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 90
+    needs: ["discover"]
+    if: needs.discover.outputs.aarch64-linux != '[]'
+
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        package: ${{ fromJSON(needs.discover.outputs.aarch64-linux) }}
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6
+        with:
+          fetch-depth: 0
+          filter: "blob:none"
+      - name: "Install flox"
+        uses: "flox/install-flox-action@f6002ed63e483f134001de7b4b45be891e00b09f" # v2.5.1
+      - name: "Setup Tailscale"
+        uses: "tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8" # v4
+        with:
+          oauth-secret: "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
+          tags: "tag:ci"
+          timeout: "30s"
+          use-cache: true
+      - name: "Configure Nix remote builders"
+        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
+        with:
+          ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
+          remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
+      - name: "Build or publish"
+        env:
+          PUBLISH: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"
+          FLOX_FLOXHUB_TOKEN: "${{ secrets.FLOX_FLOXHUB_TOKEN }}"
+        run: |
+          set -euo pipefail
+          PKG="${{ matrix.package }}"
+          SYS="aarch64-linux"
+          if [ "$PUBLISH" = "true" ]; then
+            PJ=".flox/pkgs/$PKG/publish.json"
+            ORG=$(jq -r '.org // "flox"' "$PJ" 2>/dev/null || echo flox)
+            echo "Publishing $PKG to $ORG ($SYS)"
+            flox publish -o "$ORG" "$PKG" --system "$SYS"
+          else
+            echo "Building $PKG ($SYS)"
+            flox build "$PKG" --system "$SYS"
+          fi
+
+  x86_64-darwin:
+    name: "Package '${{ matrix.package }}' (x86_64-darwin)"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 90
+    needs: ["discover"]
+    if: needs.discover.outputs.x86_64-darwin != '[]'
+
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        package: ${{ fromJSON(needs.discover.outputs.x86_64-darwin) }}
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6
+        with:
+          fetch-depth: 0
+          filter: "blob:none"
+      - name: "Install flox"
+        uses: "flox/install-flox-action@f6002ed63e483f134001de7b4b45be891e00b09f" # v2.5.1
+      - name: "Setup Tailscale"
+        uses: "tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8" # v4
+        with:
+          oauth-secret: "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
+          tags: "tag:ci"
+          timeout: "30s"
+          use-cache: true
+      - name: "Configure Nix remote builders"
+        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
+        with:
+          ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
+          remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
+      - name: "Build or publish"
+        env:
+          PUBLISH: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"
+          FLOX_FLOXHUB_TOKEN: "${{ secrets.FLOX_FLOXHUB_TOKEN }}"
+        run: |
+          set -euo pipefail
+          PKG="${{ matrix.package }}"
+          SYS="x86_64-darwin"
+          if [ "$PUBLISH" = "true" ]; then
+            PJ=".flox/pkgs/$PKG/publish.json"
+            ORG=$(jq -r '.org // "flox"' "$PJ" 2>/dev/null || echo flox)
+            echo "Publishing $PKG to $ORG ($SYS)"
+            flox publish -o "$ORG" "$PKG" --system "$SYS"
+          else
+            echo "Building $PKG ($SYS)"
+            flox build "$PKG" --system "$SYS"
+          fi
+
+  x86_64-linux:
+    name: "Package '${{ matrix.package }}' (x86_64-linux)"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 90
+    needs: ["discover"]
+    if: needs.discover.outputs.x86_64-linux != '[]'
+
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        package: ${{ fromJSON(needs.discover.outputs.x86_64-linux) }}
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10" # v6
+        with:
+          fetch-depth: 0
+          filter: "blob:none"
+      - name: "Install flox"
+        uses: "flox/install-flox-action@f6002ed63e483f134001de7b4b45be891e00b09f" # v2.5.1
+      - name: "Setup Tailscale"
+        uses: "tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8" # v4
+        with:
+          oauth-secret: "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
+          tags: "tag:ci"
+          timeout: "30s"
+          use-cache: true
+      - name: "Configure Nix remote builders"
+        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
+        with:
+          ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
+          remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
+      - name: "Build or publish"
+        env:
+          PUBLISH: "${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref_name == 'main' }}"
+          FLOX_FLOXHUB_TOKEN: "${{ secrets.FLOX_FLOXHUB_TOKEN }}"
+        run: |
+          set -euo pipefail
+          PKG="${{ matrix.package }}"
+          SYS="x86_64-linux"
+          if [ "$PUBLISH" = "true" ]; then
+            PJ=".flox/pkgs/$PKG/publish.json"
+            ORG=$(jq -r '.org // "flox"' "$PJ" 2>/dev/null || echo flox)
+            echo "Publishing $PKG to $ORG ($SYS)"
+            flox publish -o "$ORG" "$PKG" --system "$SYS"
+          else
+            echo "Building $PKG ($SYS)"
+            flox build "$PKG" --system "$SYS"
+          fi


### PR DESCRIPTION
## Problem

\`CI Packages\` had one aggregate \`publish\` job gated on
\`!contains(needs.*.result, 'failure')\`. A single build leg failing —
even an unrelated package (a flaky \`ollama-cuda\`, a Tailscale timeout
on one x86_64-darwin leg) — skipped publishing for **every** package.
That is exactly what blocked the post-#4475 catalog publish from main.

## Change

Fold publish into the build legs. Each per-(package, system) matrix
leg now runs:

- \`flox publish\` when on \`main\` (push or \`workflow_dispatch\`)
- \`flox build\` otherwise (PRs)

\`fail-fast: false\` means a leg failing fails **only that leg** — every
other package still publishes. Re-run a single broken leg with
\`gh run rerun --failed\`. Publishing from the checked-out \`main\` commit
also gives correct publish provenance.

### Details
- rename \`build-<system>\` jobs → \`<system>\` (build *or* publish)
- checkouts get \`fetch-depth: 0\` + \`filter: blob:none\` (publish needs
  full history + a clean tree)
- delete the \`publish\` job and the now-unused \`publish_matrix\`
  discover output

No behavioral change for PRs (build-only). On main, same total work,
isolated per leg instead of one gate.