### PR TITLE
fix(ci): isolate site deploy concurrency per ref

### DIFF
--- a/.github/workflows/ci_pkgs.yml
+++ b/.github/workflows/ci_pkgs.yml
@@ -367,10 +367,14 @@ jobs:
     if: always() && needs.discover.result == 'success'
     runs-on: "ubuntu-latest"
     timeout-minutes: 30
-    # Serialize only the site/deploy half (gh-pages) — the build legs
-    # must NOT share a concurrency group or runs cancel each other.
+    # Serialize the site/deploy half (gh-pages) per ref. A single global
+    # group means every PR's site job lands in the same queue; GitHub keeps
+    # only one running + one pending per group and CANCELS the rest, which
+    # cancels the whole CI Packages run and fails the Summary gate. Keying
+    # the group on github.ref isolates each PR while still serialising the
+    # only ref that actually deploys (refs/heads/main) against itself.
     concurrency:
-      group: "pages"
+      group: "pages-${{ github.ref }}"
       cancel-in-progress: false
     # Every run step executes inside the .website flox env (node, jq, …).
     # Absolute -d path so steps with `working-directory: .website` still


### PR DESCRIPTION
## Problem

Most open PRs show a failing **Summary** check even though all package builds and env tests pass. Root cause: the `Build + deploy site` job (`site:` in `ci_pkgs.yml`) uses a single global concurrency group:

```yaml
concurrency:
  group: "pages"
  cancel-in-progress: false
```

The job runs on **every** PR (its deploy step is main-gated via `is_publish`, but the job itself still runs and joins the group). With many open PRs all queuing in one `pages` group, GitHub keeps only **one running + one pending** run per group and **cancels the rest**. A cancelled `site` job cancels the whole **CI Packages** run → `Wait Pkgs` reports it as failed → the **Summary** gate fails an otherwise-green PR.

## Fix

Key the concurrency group on `github.ref`:

```yaml
group: "pages-${{ github.ref }}"
```

- Each PR (`refs/pull/N/merge`) gets its own group → no cross-PR cancellation.
- `main` (`refs/heads/main`) still serialises against itself → gh-pages deploys stay safe (the original intent).
- PR-time site build validation is preserved.

## Note

`pull_request` runs use the workflow file from the PR's own base, so existing open PRs need a **rebase onto this** once merged to pick up the fix.