### PR TITLE
fix(ci): diff the full push range in package discovery

### DIFF
--- a/.github/workflows/ci_pkgs.yml
+++ b/.github/workflows/ci_pkgs.yml
@@ -82,6 +82,7 @@ jobs:
           SINGLE_PKG: "${{ inputs.package }}"
           EVENT: "${{ github.event_name }}"
           BASE_SHA: "${{ github.event.pull_request.base.sha }}"
+          BEFORE_SHA: "${{ github.event.before }}"
           ITEMS: "${{ inputs.items }}"
         run: |
           set -euo pipefail
@@ -102,7 +103,17 @@ jobs:
             if [ "$EVENT" = "pull_request" ]; then
               DIFF_BASE="$BASE_SHA"
             else
-              DIFF_BASE="HEAD~1"
+              # A push can carry several coalesced merge commits (bot
+              # merge waves land seconds apart), so diff the whole push
+              # via the event's `before` SHA — HEAD~1 sees only the head
+              # commit and silently skips every other package in the
+              # push. Fall back to HEAD~1 when `before` is unavailable
+              # (force push, new branch).
+              DIFF_BASE="$BEFORE_SHA"
+              if [ -z "$DIFF_BASE" ] \
+                 || ! git cat-file -e "$DIFF_BASE" 2>/dev/null; then
+                DIFF_BASE="HEAD~1"
+              fi
             fi
             # upgrade.sh isn't part of the build — skip rebuilds when only
             # it changed.


### PR DESCRIPTION
## Problem

`flox/claude-code` on FloxHub is stuck at 2.1.196 while main has 2.1.204 — the last six upgrade PRs (2.1.198 through 2.1.204) merged but never published. Reported in Slack by James.

The `discover` job in `ci_pkgs.yml` diffs `HEAD~1..HEAD` on push events, assuming one commit per push. The nightly auto-merge wave lands many merge commits seconds apart and GitHub coalesces them into a single push event, so only the head commit's package is discovered. Every other package in the push is silently skipped.

Concrete example from last night: claude-code PR 6471 (`80ec0fb7`) and amp PR 6470 (`5df22814`, parent `80ec0fb7`) merged two seconds apart and arrived as one push with amp at the head. The discover log shows `Packages: ["amp"]` — claude-code never entered the publish matrix. All six recent claude-code merge commits have zero push-triggered runs. The 02:01 skills wave (about 30 merges, only about 8 push runs) is hit the same way, so this affects any package that merges inside a wave.

## Fix

Use the push event's `before` SHA as the diff base so the whole push range is covered, falling back to `HEAD~1` when `before` is unavailable (force push, new branch — `git cat-file -e` also rejects the all-zero SHA GitHub sends on branch creation). Checkout already uses `fetch-depth: 0`, so the `before` commit is present.

PR and dispatch behavior are unchanged (`BASE_SHA` / full-list paths). In the meantime 2.1.204 was published via a manual dispatch: https://github.com/flox/floxenvs/actions/runs/28948428443

---
*Via Forge (interactive) • ee155982*