### PR TITLE
fix(skills-avoid-ai-writing): avoid SIGPIPE 141 in upgrade.sh

### DIFF
--- a/.flox/pkgs/skills-avoid-ai-writing/upgrade.sh
+++ b/.flox/pkgs/skills-avoid-ai-writing/upgrade.sh
@@ -34,8 +34,10 @@ commit_date=$(echo "$commit_json" \
 # Frontmatter `version:` from raw SKILL.md at this rev.
 skill_md=$(curl -sfL \
   "https://raw.githubusercontent.com/$OWNER/$REPO/$rev/SKILL.md")
-frontmatter_version=$(echo "$skill_md" \
-  | awk '
+# Feed awk via a here-string, not `echo … | awk`. awk `exit`s early
+# once it finds the version, which would SIGPIPE the upstream `echo`
+# and, under `set -o pipefail`, abort the script with exit 141.
+frontmatter_version=$(awk '
       BEGIN { in_fm = 0 }
       /^---[[:space:]]*$/ {
         if (in_fm == 0) { in_fm = 1; next }
@@ -47,7 +49,7 @@ frontmatter_version=$(echo "$skill_md" \
         print
         exit
       }
-    ')
+    ' <<<"$skill_md")
 
 if [ -z "$frontmatter_version" ]; then
   echo "Failed to extract frontmatter version from SKILL.md" >&2


### PR DESCRIPTION
## Problem

The scheduled `Upgrade Packages` job for `skills-avoid-ai-writing` fails with exit code 141 (SIGPIPE).

`upgrade.sh` extracts the frontmatter version with:

```bash
frontmatter_version=$(echo "$skill_md" | awk '... exit ...')
```

The `awk` program `exit`s as soon as it finds the `version:` line. When `SKILL.md` is large enough that `echo` hasn't finished writing, `echo` receives SIGPIPE, and under `set -o pipefail` the pipeline returns 141, aborting the script.

## Fix

Feed `awk` via a here-string (`awk '...' <<<"$skill_md"`) so there is no upstream writer process to receive SIGPIPE. No behavior change otherwise.

Verified locally: script now runs to completion (exit 0) and resolves the version correctly.