### PR TITLE
perf(ci): coexist substitutes from private cache instead of rebuilding all packages

### DIFF
--- a/.github/workflows/ci_pkgs.yml
+++ b/.github/workflows/ci_pkgs.yml
@@ -192,11 +192,18 @@ jobs:
           tags: "tag:ci"
           timeout: "30s"
           use-cache: true
-      - name: "Configure Nix remote builders"
+      - name: "Configure Nix remote builders + private cache"
         uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
         with:
           ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
           remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
+          # Push each build output to the private S3 cache so the
+          # `coexist` job can substitute exactly these artifacts instead
+          # of rebuilding all packages from source.
+          substituter: "${{ vars.MANAGED_CACHE_PRIVATE_S3_BUCKET }}"
+          substituter-key: "${{ secrets.MANAGED_CACHE_PRIVATE_SECRET_KEY }}"
+          aws-access-key-id: "${{ secrets.MANAGED_CACHE_PRIVATE_AWS_ACCESS_KEY_ID }}"
+          aws-secret-access-key: "${{ secrets.MANAGED_CACHE_PRIVATE_AWS_SECRET_ACCESS_KEY }}"
       - name: "Build"
         if: ${{ needs.discover.outputs.is_publish != 'true' }}
         run: |
@@ -237,11 +244,18 @@ jobs:
           tags: "tag:ci"
           timeout: "30s"
           use-cache: true
-      - name: "Configure Nix remote builders"
+      - name: "Configure Nix remote builders + private cache"
         uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
         with:
           ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
           remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
+          # Push each build output to the private S3 cache so the
+          # `coexist` job can substitute exactly these artifacts instead
+          # of rebuilding all packages from source.
+          substituter: "${{ vars.MANAGED_CACHE_PRIVATE_S3_BUCKET }}"
+          substituter-key: "${{ secrets.MANAGED_CACHE_PRIVATE_SECRET_KEY }}"
+          aws-access-key-id: "${{ secrets.MANAGED_CACHE_PRIVATE_AWS_ACCESS_KEY_ID }}"
+          aws-secret-access-key: "${{ secrets.MANAGED_CACHE_PRIVATE_AWS_SECRET_ACCESS_KEY }}"
       - name: "Build"
         if: ${{ needs.discover.outputs.is_publish != 'true' }}
         run: |
@@ -282,11 +296,18 @@ jobs:
           tags: "tag:ci"
           timeout: "30s"
           use-cache: true
-      - name: "Configure Nix remote builders"
+      - name: "Configure Nix remote builders + private cache"
         uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
         with:
           ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
           remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
+          # Push each build output to the private S3 cache so the
+          # `coexist` job can substitute exactly these artifacts instead
+          # of rebuilding all packages from source.
+          substituter: "${{ vars.MANAGED_CACHE_PRIVATE_S3_BUCKET }}"
+          substituter-key: "${{ secrets.MANAGED_CACHE_PRIVATE_SECRET_KEY }}"
+          aws-access-key-id: "${{ secrets.MANAGED_CACHE_PRIVATE_AWS_ACCESS_KEY_ID }}"
+          aws-secret-access-key: "${{ secrets.MANAGED_CACHE_PRIVATE_AWS_SECRET_ACCESS_KEY }}"
       - name: "Build"
         if: ${{ needs.discover.outputs.is_publish != 'true' }}
         run: |
@@ -327,11 +348,18 @@ jobs:
           tags: "tag:ci"
           timeout: "30s"
           use-cache: true
-      - name: "Configure Nix remote builders"
+      - name: "Configure Nix remote builders + private cache"
         uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
         with:
           ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
           remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
+          # Push each build output to the private S3 cache so the
+          # `coexist` job can substitute exactly these artifacts instead
+          # of rebuilding all packages from source.
+          substituter: "${{ vars.MANAGED_CACHE_PRIVATE_S3_BUCKET }}"
+          substituter-key: "${{ secrets.MANAGED_CACHE_PRIVATE_SECRET_KEY }}"
+          aws-access-key-id: "${{ secrets.MANAGED_CACHE_PRIVATE_AWS_ACCESS_KEY_ID }}"
+          aws-secret-access-key: "${{ secrets.MANAGED_CACHE_PRIVATE_AWS_SECRET_ACCESS_KEY }}"
       # Always build x86_64-linux so the audit has a build output (and,
       # on main, so publish has its artifact).
       - name: "Build"
@@ -519,6 +547,26 @@ jobs:
         uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
       - name: "Install flox"
         uses: "flox/install-flox-action@3b80351ae97bbe063f264dc88fbd505507054963" # v2.5.3
+      - name: "Setup Tailscale"
+        uses: "tailscale/github-action@306e68a486fd2350f2bfc3b19fcd143891a4a2d8" # v4
+        with:
+          oauth-secret: "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
+          tags: "tag:ci"
+          timeout: "30s"
+          use-cache: true
+      - name: "Configure Nix remote builders + private cache"
+        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
+        with:
+          ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
+          remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
+          # Read from the same private S3 cache the build matrix pushed
+          # to, so the per-package `flox build` in coexist-check.sh
+          # substitutes the already-built artifacts instead of compiling
+          # every package from source (which chronically hit the 60m cap).
+          substituter: "${{ vars.MANAGED_CACHE_PRIVATE_S3_BUCKET }}"
+          substituter-key: "${{ secrets.MANAGED_CACHE_PRIVATE_SECRET_KEY }}"
+          aws-access-key-id: "${{ secrets.MANAGED_CACHE_PRIVATE_AWS_ACCESS_KEY_ID }}"
+          aws-secret-access-key: "${{ secrets.MANAGED_CACHE_PRIVATE_AWS_SECRET_ACCESS_KEY }}"
       - name: "Assert coexistence"
         env:
           FLOX_FLOXHUB_TOKEN: "${{ secrets.FLOX_FLOXHUB_TOKEN }}"


### PR DESCRIPTION
## Problem

The `All skills + agents + audit tools coexist in one Flox env` job chronically hits its 60-minute timeout (e.g. [run 29153632760](https://github.com/flox/floxenvs/actions/runs/29153632760/job/86547252720) — cancelled at 1h). `coexist-check.sh` builds all ~73 packages **from source, serially**, and the coexist job (unlike every build-matrix job) has **no remote builders and no cache configured** — so every `flox build` is a cold local compile.

It's also pure duplication: the build matrix already built every one of those packages moments earlier.

## Fix

Hand the matrix's build outputs to coexist via the **private S3 cache** (already available to floxenvs — no new secrets):

- **Build matrix** (all 4 systems): the `Configure Nix` step now also passes `substituter` / `substituter-key` / AWS creds (`MANAGED_CACHE_PRIVATE_S3_BUCKET` + `MANAGED_CACHE_PRIVATE_SECRET_KEY` + `MANAGED_CACHE_PRIVATE_AWS_*`), so each build output is pushed to `flox-cache-private`.
- **coexist**: gains the same Tailscale + `Configure Nix` setup, so its per-package `flox build` **substitutes** those exact artifacts from the cache instead of recompiling. coexist already `needs:` the whole matrix, so the cache is warm.

Result: ~1h serial rebuild → minutes of cache substitution. Tests exactly what the matrix built this run.

## Secrets

None added. Uses floxenvs's existing `MANAGED_CACHE_PRIVATE_*` (S3) vars/secrets synced via deltaops `sync-secrets-to-github.nix`.

## Validation

`actionlint` clean. Note: coexist only runs on publish (`is_publish == 'true'` — main push / `workflow_dispatch`), so this PR's CI exercises the **matrix cache upload** but not coexist itself. To validate the coexist speedup end-to-end, run this workflow via **workflow_dispatch** on the branch (dispatch sets `is_publish=true`) before merge.