### PR TITLE
fix(codewhale): keep x86_64-darwin build alive under Rosetta (1800s silence timeout)

### DIFF
--- a/.flox/pkgs/codewhale/default.nix
+++ b/.flox/pkgs/codewhale/default.nix
@@ -50,6 +50,19 @@ rustPlatform.buildRustPackage {
 
   doCheck = false;
 
+  # The final link of this multi-crate workspace can run silently for well
+  # over 30 minutes on slower builders (x86_64-darwin via Rosetta on
+  # aarch64 hardware), tripping Nix's max-silent-time default of 1800s.
+  # Emit a heartbeat every 60s during the build so it stays alive (same
+  # approach as pkgs/openclaw).
+  preBuild = ''
+    ( while true; do echo "[heartbeat] still building codewhale..."; sleep 60; done ) &
+    _codewhale_heartbeat_pid=$!
+  '';
+  postBuild = ''
+    kill "$_codewhale_heartbeat_pid" 2>/dev/null || true
+  '';
+
   postInstall = ''
     installShellCompletion --cmd codewhale \
       --bash <($out/bin/codewhale completion bash) \
@@ -57,7 +70,10 @@ rustPlatform.buildRustPackage {
       --zsh <($out/bin/codewhale completion zsh)
   '';
 
-  doInstallCheck = true;
+  # Skip the emulated `codewhale --version` check on x86_64-darwin: under
+  # Rosetta the emulated binary can hang past the 1800s builder timeout
+  # (same reason claude-code gates its install check on this platform).
+  doInstallCheck = stdenv.hostPlatform.system != "x86_64-darwin";
   nativeInstallCheckInputs = [ versionCheckHook ];
 
   meta = {


### PR DESCRIPTION
## Problem

`Publish 'codewhale' (x86_64-darwin)` fails: the build goes silent for ~30 min after the last `Compiling` line, then:

```
error: building of codewhale-0.8.67.drv on ssh-ng://nixbld@lhr-aarch64-darwin-02
  failed: ... timed out after 1800 seconds of silence
```

The multi-crate workspace's final link is very slow under Rosetta (x86_64-darwin emulated on aarch64 builders) and emits no output, tripping Nix's 1800s `max-silent-time`.

## Fix

Two precedented, minimal changes:

1. **Build heartbeat** — emit a line every 60s during the build so it never goes silent past 1800s. Exactly what `pkgs/openclaw` already does for this same Rosetta case.
2. **Skip the install check on x86_64-darwin** — `doInstallCheck = stdenv.hostPlatform.system != "x86_64-darwin"`. The emulated `codewhale --version` can hang the same way (same reason `claude-code` gates its check on this platform).

Other 3 systems unchanged. Validated locally: aarch64-darwin builds fine with the change.

Follows the darwin-publish investigation; agent-browser (pnpm offline on darwin) tracked separately.