### PR TITLE
ci: fix + extend coexist-check (catalog flox-ai, python3, nodejs)

### DIFF
--- a/scripts/coexist-check.sh
+++ b/scripts/coexist-check.sh
@@ -49,19 +49,30 @@ mapfile -t SKILLS < <(
 # built here: the CLI now lives in its own repo (flox/flox-ai) with no
 # local .flox/pkgs entry, so it can't be `flox build`-ed. It is still
 # checked for coexistence — installed from the catalog into the same env
-# below (see CATALOG_PKGS).
+# below (see EXTERNAL_PKGS).
 TOOLS=(
   claude-code codex opencode pi
   skill-tools skill-validator skillcheck skillspector claudelint
 )
-# Catalog packages to also install into the single env: built and published
-# elsewhere, consumed from FloxHub (needs FLOX_FLOXHUB_TOKEN). flox-ai lives
-# in its own repo but must still coexist with every skill in one env.
-CATALOG_PKGS=(flox/flox-ai)
+# Extra packages to install into the single env (NOT built from source),
+# each installed by pkg-path after the source-built artifacts:
+#
+#   - flox/flox-ai: our CLI, now in its own repo (no local .flox/pkgs
+#     entry), consumed from FloxHub — needs FLOX_FLOXHUB_TOKEN. Must still
+#     coexist with every skill in one env.
+#   - python3, nodejs: the runtimes skills bundle most (33 ship bin/python3,
+#     26 ship bin/node), deliberately UNDER their plugin dir so they don't
+#     land on $FLOX_ENV/bin. Real user envs almost always already have these
+#     at the env level, so installing them here guards that invariant: a
+#     skill that regresses and leaks bin/python3 (or bin/node) onto
+#     $FLOX_ENV/bin would collide with these and fail the check.
+#
+# Extend with uv/bun/ruby/go if those become common env-level runtimes.
+EXTERNAL_PKGS=(flox/flox-ai python3 nodejs)
 PACKAGES=("${SKILLS[@]}" "${TOOLS[@]}")
-TOTAL=$(( ${#PACKAGES[@]} + ${#CATALOG_PKGS[@]} ))
+TOTAL=$(( ${#PACKAGES[@]} + ${#EXTERNAL_PKGS[@]} ))
 echo "Target: ${#SKILLS[@]} skills + ${#TOOLS[@]} agents/audit tools" \
-     "+ ${#CATALOG_PKGS[@]} catalog pkgs = $TOTAL packages"
+     "+ ${#EXTERNAL_PKGS[@]} external pkgs = $TOTAL packages"
 
 # ── Build every package from source; collect the result symlink paths ──
 # `flox build <pkg>` writes ./result-<pkg> (and ./result-<pkg>-log) into the
@@ -125,19 +136,19 @@ for i in "${!BUILT[@]}"; do
 done
 rm -f "$inst_log"
 
-# ── Also install catalog packages (not built from source) into the SAME
+# ── Also install external packages (not built from source) into the SAME
 # env, proving they coexist with every locally-built skill/agent/tool. ──
-cat_log="$(mktemp)"
-for pkg in "${CATALOG_PKGS[@]}"; do
-  if flox install "$pkg" >"$cat_log" 2>&1; then
-    echo "  installed: $pkg (catalog)"
+ext_log="$(mktemp)"
+for pkg in "${EXTERNAL_PKGS[@]}"; do
+  if flox install "$pkg" >"$ext_log" 2>&1; then
+    echo "  installed: $pkg (external)"
   else
-    echo "  INSTALL FAILED: $pkg (catalog)" >&2
-    sed 's/^/      | /' "$cat_log" >&2
+    echo "  INSTALL FAILED: $pkg (external)" >&2
+    sed 's/^/      | /' "$ext_log" >&2
     INSTALL_FAILED+=("$pkg")
   fi
 done
-rm -f "$cat_log"
+rm -f "$ext_log"
 
 # ── List everything installed into the single environment ──
 echo ""
@@ -152,7 +163,7 @@ if [ "${#BUILD_FAILED[@]}" -gt 0 ]; then
   status=1
 fi
 if [ "${#INSTALL_FAILED[@]}" -gt 0 ]; then
-  attempted=$(( ${#BUILT[@]} + ${#CATALOG_PKGS[@]} ))
+  attempted=$(( ${#BUILT[@]} + ${#EXTERNAL_PKGS[@]} ))
   echo "coexist FAILED: ${#INSTALL_FAILED[@]}/${attempted} packages could" \
        "not be installed into one environment:"
   printf '  - %s\n' "${INSTALL_FAILED[@]}"

--- a/scripts/coexist-check.sh
+++ b/scripts/coexist-check.sh
@@ -45,13 +45,23 @@ mapfile -t SKILLS < <(
   grep -rl 'flox_agent_layout' "$REPO_ROOT"/.flox/pkgs/*/default.nix \
     | xargs -n1 dirname | xargs -n1 basename | sort -u
 )
-# The 4 agent runtimes + the 6 audit tools.
+# The 4 agent runtimes + the 5 source-built audit tools. flox-ai is NOT
+# built here: the CLI now lives in its own repo (flox/flox-ai) with no
+# local .flox/pkgs entry, so it can't be `flox build`-ed. It is still
+# checked for coexistence — installed from the catalog into the same env
+# below (see CATALOG_PKGS).
 TOOLS=(
   claude-code codex opencode pi
-  flox-ai skill-tools skill-validator skillcheck skillspector claudelint
+  skill-tools skill-validator skillcheck skillspector claudelint
 )
+# Catalog packages to also install into the single env: built and published
+# elsewhere, consumed from FloxHub (needs FLOX_FLOXHUB_TOKEN). flox-ai lives
+# in its own repo but must still coexist with every skill in one env.
+CATALOG_PKGS=(flox/flox-ai)
 PACKAGES=("${SKILLS[@]}" "${TOOLS[@]}")
-echo "Target: ${#SKILLS[@]} skills + ${#TOOLS[@]} agents/audit tools = ${#PACKAGES[@]} packages"
+TOTAL=$(( ${#PACKAGES[@]} + ${#CATALOG_PKGS[@]} ))
+echo "Target: ${#SKILLS[@]} skills + ${#TOOLS[@]} agents/audit tools" \
+     "+ ${#CATALOG_PKGS[@]} catalog pkgs = $TOTAL packages"
 
 # ── Build every package from source; collect the result symlink paths ──
 # `flox build <pkg>` writes ./result-<pkg> (and ./result-<pkg>-log) into the
@@ -115,6 +125,20 @@ for i in "${!BUILT[@]}"; do
 done
 rm -f "$inst_log"
 
+# ── Also install catalog packages (not built from source) into the SAME
+# env, proving they coexist with every locally-built skill/agent/tool. ──
+cat_log="$(mktemp)"
+for pkg in "${CATALOG_PKGS[@]}"; do
+  if flox install "$pkg" >"$cat_log" 2>&1; then
+    echo "  installed: $pkg (catalog)"
+  else
+    echo "  INSTALL FAILED: $pkg (catalog)" >&2
+    sed 's/^/      | /' "$cat_log" >&2
+    INSTALL_FAILED+=("$pkg")
+  fi
+done
+rm -f "$cat_log"
+
 # ── List everything installed into the single environment ──
 echo ""
 echo "Packages in the coexistence environment:"
@@ -128,12 +152,13 @@ if [ "${#BUILD_FAILED[@]}" -gt 0 ]; then
   status=1
 fi
 if [ "${#INSTALL_FAILED[@]}" -gt 0 ]; then
-  echo "coexist FAILED: ${#INSTALL_FAILED[@]}/${#BUILT[@]} built packages could" \
+  attempted=$(( ${#BUILT[@]} + ${#CATALOG_PKGS[@]} ))
+  echo "coexist FAILED: ${#INSTALL_FAILED[@]}/${attempted} packages could" \
        "not be installed into one environment:"
   printf '  - %s\n' "${INSTALL_FAILED[@]}"
   status=1
 fi
 [ "$status" -ne 0 ] && exit 1
 
-echo "coexist OK: all ${#PACKAGES[@]} packages built and installed into one Flox environment"
+echo "coexist OK: all $TOTAL packages built/installed into one Flox environment"
 exit 0


### PR DESCRIPTION
## Problem

CI Packages → *"All skills + agents + audit tools coexist in one Flox
env"* fails:

```
BUILD FAILED: flox-ai
    | ✘ ERROR: Target 'flox-ai' not found.
coexist FAILED: 1/71 packages did not build:
  - flox-ai
```

The flox-ai CLI moved to its own repo (`flox/flox-ai`) and the local
`.flox/pkgs/flox-ai` package was removed, but `scripts/coexist-check.sh`
still listed `flox-ai` in its source-built `TOOLS` array and tried to
`flox build flox-ai`.

## Fix + extension

Source-built `TOOLS` no longer lists `flox-ai`. Instead, a new
`EXTERNAL_PKGS` list is installed by pkg-path into the same throwaway env
after the source-built `./result-<pkg>` artifacts. An install failure
counts as a coexist failure, same as the built packages.

`EXTERNAL_PKGS=(flox/flox-ai python3 nodejs)`:

- **`flox/flox-ai`** — our CLI, now shipped from its own repo / the
  catalog. Still proven to coexist with every skill.
- **`python3`, `nodejs`** — the runtimes skills bundle most (33 ship
  `bin/python3`, 26 ship `bin/node`), deliberately UNDER their plugin dir
  so they never land on `$FLOX_ENV/bin`. Real user envs almost always
  already have these at the env level. Installing them here guards that
  invariant: a skill that regresses and leaks `bin/python3`/`bin/node`
  onto `$FLOX_ENV/bin` would collide with these and fail the check — the
  same class of bug as the original `bin/python3` clash this script exists
  to catch.

Easy to extend with `uv`/`bun`/`ruby`/`go` if those become common
env-level runtimes.

The coexist CI step already exports `FLOX_FLOXHUB_TOKEN`, so the
`flox/flox-ai` install authenticates.

Failing run: https://github.com/flox/floxenvs/actions/runs/29812639120/job/88577681240