### PR TITLE
feat(skills-okf): package okf-skills plugin

### DIFF
--- a/.flox/pkgs/skills-okf/default.nix
+++ b/.flox/pkgs/skills-okf/default.nix
@@ -96,14 +96,27 @@ stdenv.mkDerivation {
         'uv run "''${CLAUDE_SKILL_DIR}/../validate/scripts/okf_validate.py"' \
         "$PY $out/libexec/okf/validate/okf_validate.py"
 
+    # The upstream "If uv is unavailable, fall back to: <duplicate uv-free
+    # command>" paragraph loses all meaning once the primary command above
+    # is already rewritten to the bundled interpreter — there is no
+    # fallback path left to describe, and leaving the sentence in place
+    # would ship two byte-identical command blocks with a connective
+    # sentence that no longer makes sense. Delete the sentence and its
+    # code block outright rather than rewrite it into a second copy.
     substituteInPlace "$PLUGIN_DIR/skills/validate/SKILL.md" \
       --replace-fail \
         'uv run "''${CLAUDE_SKILL_DIR}/scripts/okf_validate.py"' \
         "$PY $out/libexec/okf/validate/okf_validate.py" \
       --replace-fail \
-        'python3 -m pip install --quiet pyyaml && \
-python3 "''${CLAUDE_SKILL_DIR}/scripts/okf_validate.py"' \
-        "$PY $out/libexec/okf/validate/okf_validate.py" \
+        'If `uv` is unavailable, fall back to:
+
+```bash
+python3 -m pip install --quiet pyyaml && \
+python3 "''${CLAUDE_SKILL_DIR}/scripts/okf_validate.py" $ARGUMENTS
+```
+
+' \
+        "" \
       --replace-fail \
         '`''${CLAUDE_SKILL_DIR}` resolves whether this skill runs as part of the `okf`
 plugin or is installed standalone (e.g. via `npx skills add`), so the checker is
@@ -116,9 +129,15 @@ always found at that location regardless of how the skill is installed.'
         'uv run "''${CLAUDE_SKILL_DIR}/scripts/okf_visualize.py"' \
         "$PY $out/libexec/okf/visualize/okf_visualize.py" \
       --replace-fail \
-        'python3 -m pip install --quiet pyyaml && \
-python3 "''${CLAUDE_SKILL_DIR}/scripts/okf_visualize.py"' \
-        "$PY $out/libexec/okf/visualize/okf_visualize.py" \
+        'If `uv` is unavailable:
+
+```bash
+python3 -m pip install --quiet pyyaml && \
+python3 "''${CLAUDE_SKILL_DIR}/scripts/okf_visualize.py" $ARGUMENTS
+```
+
+' \
+        "" \
       --replace-fail \
         'Open it in any browser; `''${CLAUDE_SKILL_DIR}` resolves whether this runs as part
 of the `okf` plugin or as a standalone skills.sh skill.' \

--- a/.flox/pkgs/skills-okf/default.nix
+++ b/.flox/pkgs/skills-okf/default.nix
@@ -1,0 +1,87 @@
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  python3,
+}:
+
+let
+  versionData = builtins.fromJSON (builtins.readFile ./hashes.json);
+  inherit (versionData) version rev srcHash;
+
+  # The three shipped scripts are PEP-723 single-file scripts whose only
+  # third-party dependency is pyyaml. They import no subprocess module and
+  # shell out to nothing, so a plain interpreter (no makeBinaryWrapper, no
+  # PATH prefix) is enough — script shebangs and the SKILL.md invocations
+  # point at this store path.
+  pythonEnv = python3.withPackages (ps: [ ps.pyyaml ]);
+in
+stdenv.mkDerivation {
+  pname = "skills-okf";
+  inherit version;
+
+  src = fetchFromGitHub {
+    owner = "scaccogatto";
+    repo = "okf-skills";
+    inherit rev;
+    hash = srcHash;
+  };
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    PLUGIN_DIR="$out/share/claude-code/plugins/okf"
+    mkdir -p "$PLUGIN_DIR"
+
+    # Upstream ships the Claude Code plugin at the repo root:
+    # `.claude-plugin/plugin.json` names the plugin `okf` and
+    # `.claude-plugin/marketplace.json` points its source at `./`. Copy the
+    # whole tree, then strip everything that is not plugin content.
+    cp -r "$src"/. "$PLUGIN_DIR/"
+    chmod -R u+w "$PLUGIN_DIR"
+
+    rm -rf "$PLUGIN_DIR/.okf" \
+           "$PLUGIN_DIR/.github" \
+           "$PLUGIN_DIR/.gitignore" \
+           "$PLUGIN_DIR/benchmark" \
+           "$PLUGIN_DIR/docs" \
+           "$PLUGIN_DIR/examples" \
+           "$PLUGIN_DIR/templates" \
+           "$PLUGIN_DIR/tests" \
+           "$PLUGIN_DIR/Makefile" \
+           "$PLUGIN_DIR/action.yml" \
+           "$PLUGIN_DIR/CHANGELOG.md" \
+           "$PLUGIN_DIR/README.md"
+
+    runHook postInstall
+  '';
+
+  # Emit the per-agent launch layout (share/flox/<agent>/okf) from the
+  # share/claude-code staging, then hard-gate packaging hygiene. Both
+  # helpers are sourced inline (no build-input derivation) so postInstall
+  # runs on the native builder and cross-system publish works.
+  postInstall = ''
+    ${builtins.readFile ../../nix/flox-agent-layout.sh}
+    flox_agent_layout "okf" "$out/share"
+    ${builtins.readFile ../../nix/flox-skill-check.sh}
+    flox_skill_check "$out"
+  '';
+
+  meta = {
+    description =
+      "Open Knowledge Format (OKF) skills for Claude Code — author, "
+      + "maintain, validate, and visualize portable markdown knowledge "
+      + "bundles, with Python and pyyaml bundled for the skill scripts.";
+    homepage = "https://github.com/scaccogatto/okf-skills";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-darwin"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "x86_64-linux"
+    ];
+  };
+}

--- a/.flox/pkgs/skills-okf/default.nix
+++ b/.flox/pkgs/skills-okf/default.nix
@@ -30,6 +30,41 @@ stdenv.mkDerivation {
   dontConfigure = true;
   dontBuild = true;
 
+  # The upstream unittest suite plus three smoke runs, all under the
+  # bundled interpreter — this is what proves the shipped scripts execute
+  # with the bundled pyyaml and nothing else.
+  #
+  # Skipped on x86_64-darwin: those builds run under Rosetta on the
+  # aarch64 CI runners, where emulated check phases have hung past the
+  # 1800s silence timeout in this repo. The other three systems cover it.
+  doCheck = stdenv.hostPlatform.system != "x86_64-darwin";
+
+  checkPhase = ''
+    runHook preCheck
+
+    ${pythonEnv}/bin/python3 tests/test_okf_validate.py
+
+    # validate: the vendored sample bundle must pass --strict.
+    ${pythonEnv}/bin/python3 skills/validate/scripts/okf_validate.py \
+      examples/sample-bundle --strict
+
+    # init + validate round trip: a freshly scaffolded bundle must be
+    # strict-conformant, which is upstream's own stated invariant.
+    scaffold="$TMPDIR/okf-scaffold"
+    ${pythonEnv}/bin/python3 skills/okf/scripts/okf_init.py "$scaffold" \
+      --title "check"
+    ${pythonEnv}/bin/python3 skills/validate/scripts/okf_validate.py \
+      "$scaffold" --strict
+
+    # visualize: must emit a non-empty self-contained HTML file.
+    # The flag is `-o/--out` (argparse, okf_visualize.py:409).
+    ${pythonEnv}/bin/python3 skills/visualize/scripts/okf_visualize.py \
+      examples/sample-bundle --out "$TMPDIR/viz.html"
+    test -s "$TMPDIR/viz.html"
+
+    runHook postCheck
+  '';
+
   installPhase = ''
     runHook preInstall
 

--- a/.flox/pkgs/skills-okf/default.nix
+++ b/.flox/pkgs/skills-okf/default.nix
@@ -79,6 +79,52 @@ stdenv.mkDerivation {
       chmod +x "$f"
     done < <(find "$out/libexec/okf" -type f -name '*.py')
 
+    # Point every invocation at the bundled interpreter and the libexec
+    # copy, by absolute store path. Upstream offers `uv run` with a
+    # `pip install pyyaml` fallback; under flox neither uv nor a
+    # system python3 is guaranteed, and a runtime pip install into an
+    # immutable store is meaningless. --replace-fail so an upstream
+    # rewording breaks the build instead of silently shipping a
+    # uv-dependent skill.
+    PY="${pythonEnv}/bin/python3"
+
+    substituteInPlace "$PLUGIN_DIR/skills/okf/SKILL.md" \
+      --replace-fail \
+        'uv run "''${CLAUDE_SKILL_DIR}/scripts/okf_init.py"' \
+        "$PY $out/libexec/okf/okf/okf_init.py" \
+      --replace-fail \
+        'uv run "''${CLAUDE_SKILL_DIR}/../validate/scripts/okf_validate.py"' \
+        "$PY $out/libexec/okf/validate/okf_validate.py"
+
+    substituteInPlace "$PLUGIN_DIR/skills/validate/SKILL.md" \
+      --replace-fail \
+        'uv run "''${CLAUDE_SKILL_DIR}/scripts/okf_validate.py"' \
+        "$PY $out/libexec/okf/validate/okf_validate.py" \
+      --replace-fail \
+        'python3 -m pip install --quiet pyyaml && \
+python3 "''${CLAUDE_SKILL_DIR}/scripts/okf_validate.py"' \
+        "$PY $out/libexec/okf/validate/okf_validate.py" \
+      --replace-fail \
+        '`''${CLAUDE_SKILL_DIR}` resolves whether this skill runs as part of the `okf`
+plugin or is installed standalone (e.g. via `npx skills add`), so the checker is
+always found alongside the skill.' \
+        'The path above is fixed by this flox package build, so the checker is
+always found at that location regardless of how the skill is installed.'
+
+    substituteInPlace "$PLUGIN_DIR/skills/visualize/SKILL.md" \
+      --replace-fail \
+        'uv run "''${CLAUDE_SKILL_DIR}/scripts/okf_visualize.py"' \
+        "$PY $out/libexec/okf/visualize/okf_visualize.py" \
+      --replace-fail \
+        'python3 -m pip install --quiet pyyaml && \
+python3 "''${CLAUDE_SKILL_DIR}/scripts/okf_visualize.py"' \
+        "$PY $out/libexec/okf/visualize/okf_visualize.py" \
+      --replace-fail \
+        'Open it in any browser; `''${CLAUDE_SKILL_DIR}` resolves whether this runs as part
+of the `okf` plugin or as a standalone skills.sh skill.' \
+        'Open it in any browser; the path above is fixed by this flox package build
+regardless of how the skill is installed.'
+
     runHook postInstall
   '';
 
@@ -89,6 +135,15 @@ stdenv.mkDerivation {
   postInstall = ''
     ${builtins.readFile ../../nix/flox-agent-layout.sh}
     flox_agent_layout "okf" "$out/share"
+
+    # Gate the FINAL per-agent trees: every SKILL.md that ships must be
+    # free of PATH-dependent invocations.
+    while IFS= read -r f; do
+      if grep -nE 'uv run|pip install|CLAUDE_SKILL_DIR' "$f"; then
+        echo "skills-okf: $f still has a PATH-dependent invocation" >&2
+        exit 1
+      fi
+    done < <(find "$out/share/flox" -name 'SKILL.md' -type f)
     ${builtins.readFile ../../nix/flox-skill-check.sh}
     flox_skill_check "$out"
   '';

--- a/.flox/pkgs/skills-okf/default.nix
+++ b/.flox/pkgs/skills-okf/default.nix
@@ -114,6 +114,39 @@ stdenv.mkDerivation {
       chmod +x "$f"
     done < <(find "$out/libexec/okf" -type f -name '*.py')
 
+    # okf_init.py computes its own "how to validate this" hint from
+    # `parents[2]`, a path that only resolves correctly in upstream's
+    # scripts/<skill>/scripts/ layout. Under libexec the scripts are one
+    # level shallower, so the hint pointed at a nonexistent path and
+    # still told the user to run `uv run`. Repoint it at the real
+    # libexec path and the bundled interpreter.
+    substituteInPlace "$out/libexec/okf/okf/okf_init.py" \
+      --replace-fail \
+        'validator = Path(__file__).resolve().parents[2] / "validate" / "scripts" / "okf_validate.py"' \
+        'validator = Path("'"$out"'/libexec/okf/validate/okf_validate.py")' \
+      --replace-fail \
+        'print(f"hint: validate it — uv run {validator} {args.target} --strict (or the validate skill)")' \
+        'print(f"hint: validate it — ${pythonEnv}/bin/python3 {validator} {args.target} --strict (or the validate skill)")'
+
+    # Each script also carries an inert `Run: uv run scripts/...` line in
+    # its module docstring. It is never executed, but it would trip the
+    # widened PATH-dependent-invocation gate below, and a literal `uv
+    # run` hint is wrong regardless — these scripts run under the
+    # bundled interpreter, not uv. Rewrite each to describe how the
+    # script actually runs post-install (flat, no scripts/ subdir).
+    substituteInPlace "$out/libexec/okf/okf/okf_init.py" \
+      --replace-fail \
+        'Run:  uv run scripts/okf_init.py <target-dir> [--title "..."] [--force]' \
+        'Run:  python3 okf_init.py <target-dir> [--title "..."] [--force]'
+    substituteInPlace "$out/libexec/okf/validate/okf_validate.py" \
+      --replace-fail \
+        'Run:  uv run scripts/okf_validate.py <bundle-dir>' \
+        'Run:  python3 okf_validate.py <bundle-dir>'
+    substituteInPlace "$out/libexec/okf/visualize/okf_visualize.py" \
+      --replace-fail \
+        'Run:  uv run okf_visualize.py <bundle-dir> [-o viz.html]' \
+        'Run:  python3 okf_visualize.py <bundle-dir> [-o viz.html]'
+
     # Point every invocation at the bundled interpreter and the libexec
     # copy, by absolute store path. Upstream offers `uv run` with a
     # `pip install pyyaml` fallback; under flox neither uv nor a
@@ -198,6 +231,17 @@ regardless of how the skill is installed.'
         exit 1
       fi
     done < <(find "$out/share/flox" -name 'SKILL.md' -type f)
+
+    # Also gate the shipped scripts themselves, so a future upstream
+    # sync that reintroduces a uv/pip/CLAUDE_SKILL_DIR reference (in a
+    # docstring, a hint string, anything) fails the build instead of
+    # shipping quietly.
+    for f in "$out"/libexec/okf/*/*.py; do
+      if grep -nE 'uv run|pip install|CLAUDE_SKILL_DIR' "$f"; then
+        echo "skills-okf: $f still has a PATH-dependent invocation" >&2
+        exit 1
+      fi
+    done
     ${builtins.readFile ../../nix/flox-skill-check.sh}
     flox_skill_check "$out"
   '';
@@ -208,7 +252,10 @@ regardless of how the skill is installed.'
       + "maintain, validate, and visualize portable markdown knowledge "
       + "bundles, with Python and pyyaml bundled for the skill scripts.";
     homepage = "https://github.com/scaccogatto/okf-skills";
-    license = lib.licenses.mit;
+    license = [
+      lib.licenses.mit
+      lib.licenses.asl20
+    ];
     platforms = [
       "aarch64-darwin"
       "aarch64-linux"

--- a/.flox/pkgs/skills-okf/default.nix
+++ b/.flox/pkgs/skills-okf/default.nix
@@ -56,6 +56,29 @@ stdenv.mkDerivation {
            "$PLUGIN_DIR/CHANGELOG.md" \
            "$PLUGIN_DIR/README.md"
 
+    # The scripts live ONCE at $out/libexec, outside $out/share, so
+    # flox_agent_layout never copies them: all four per-agent trees
+    # reference the same absolute path. Keeping them under skills/<s>/
+    # would produce four duplicates and force SKILL.md to name one
+    # arbitrary copy.
+    for skill in okf validate visualize; do
+      src_dir="$PLUGIN_DIR/skills/$skill/scripts"
+      [ -d "$src_dir" ] || { echo "missing $src_dir" >&2; exit 1; }
+      mkdir -p "$out/libexec/okf/$skill"
+      mv "$src_dir"/*.py "$out/libexec/okf/$skill/"
+      rmdir "$src_dir"
+    done
+
+    # Repoint the #!/usr/bin/env python3 shebangs at the bundled
+    # interpreter and mark the scripts executable, so direct invocation
+    # works without python3 on the caller's PATH.
+    while IFS= read -r f; do
+      head -1 "$f" | grep -q '/usr/bin/env python3' || continue
+      substituteInPlace "$f" --replace-fail \
+        '#!/usr/bin/env python3' "#!${pythonEnv}/bin/python3"
+      chmod +x "$f"
+    done < <(find "$out/libexec/okf" -type f -name '*.py')
+
     runHook postInstall
   '';
 

--- a/.flox/pkgs/skills-okf/hashes.json
+++ b/.flox/pkgs/skills-okf/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.6.0",
+  "rev": "4477dd420cdb33a20983a4f86ea0fd2263aaf47f",
+  "srcHash": "sha256-o/H5vDngyrmIsMLDgaquynMtaAl0WBaXReDm3HHKj1s="
+}

--- a/.flox/pkgs/skills-okf/hashes.json
+++ b/.flox/pkgs/skills-okf/hashes.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.6.0",
+  "version": "0.6.0+unstable-2026-07-27.4477dd4",
   "rev": "4477dd420cdb33a20983a4f86ea0fd2263aaf47f",
   "srcHash": "sha256-o/H5vDngyrmIsMLDgaquynMtaAl0WBaXReDm3HHKj1s="
 }

--- a/.flox/pkgs/skills-okf/meta.yaml
+++ b/.flox/pkgs/skills-okf/meta.yaml
@@ -1,0 +1,25 @@
+kind: pkg
+subkind: plugin
+name: skills-okf
+title: OKF Skills
+plugin_for: claude-code
+publisher: flox
+tagline: >
+  Author, validate, and visualize Open Knowledge Format
+  bundles — portable markdown knowledge for agents.
+category: ai
+ai_role: tooling
+tags: [claude-code, plugin, knowledge, markdown, documentation]
+status: beta
+license: MIT
+featured: false
+install:
+  pkg: |
+    [install]
+    claude-code.pkg-path = "flox/claude-code"
+    claude-code.publisher = "flox"
+    skills-okf.pkg-path = "flox/skills-okf"
+    skills-okf.publisher = "flox"
+links:
+  source: https://github.com/flox/floxenvs/tree/main/.flox/pkgs/skills-okf
+  floxhub: https://hub.flox.dev/flox/skills-okf

--- a/.flox/pkgs/skills-okf/meta.yaml
+++ b/.flox/pkgs/skills-okf/meta.yaml
@@ -11,7 +11,7 @@ category: ai
 ai_role: tooling
 tags: [claude-code, plugin, knowledge, markdown, documentation]
 status: beta
-license: MIT
+license: MIT AND Apache-2.0
 featured: false
 install:
   pkg: |

--- a/.flox/pkgs/skills-okf/publish.json
+++ b/.flox/pkgs/skills-okf/publish.json
@@ -1,0 +1,9 @@
+{
+  "org": "flox",
+  "systems": [
+    "aarch64-darwin",
+    "aarch64-linux",
+    "x86_64-darwin",
+    "x86_64-linux"
+  ]
+}

--- a/.flox/pkgs/skills-okf/upgrade.sh
+++ b/.flox/pkgs/skills-okf/upgrade.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HASHES_FILE="$SCRIPT_DIR/hashes.json"
+
+REPO="scaccogatto/okf-skills"
+
+current_rev=$(jq -r '.rev' "$HASHES_FILE")
+current_version=$(jq -r '.version' "$HASHES_FILE")
+
+# Upstream's release tags (`okf--vX.Y.Z`) lag the plugin: `main` carried
+# 0.6.0 while the newest tag was okf--v0.4.0. Track the branch head and
+# take the version from the plugin manifest at that commit.
+latest_rev=$(curl -sf \
+  "https://api.github.com/repos/${REPO}/commits/main" | jq -r '.sha')
+
+if [ -z "$latest_rev" ] || [ "$latest_rev" = "null" ]; then
+  echo "Failed to resolve main" >&2
+  exit 1
+fi
+
+latest_version=$(curl -sf \
+  "https://raw.githubusercontent.com/${REPO}/${latest_rev}/.claude-plugin/plugin.json" \
+  | jq -r '.version')
+
+echo "Current: $current_version ($current_rev)"
+echo "Latest:  $latest_version ($latest_rev)"
+
+if [ "$current_rev" = "$latest_rev" ]; then
+  echo "Already up to date"
+  exit 0
+fi
+
+echo "Updating skills-okf to $latest_version ($latest_rev)"
+
+src_url="https://github.com/${REPO}/archive/${latest_rev}.tar.gz"
+echo "Fetching source from $src_url ..."
+src_hash=$(nix-prefetch-url --unpack "$src_url" 2>/dev/null)
+src_sri=$(nix --extra-experimental-features nix-command \
+  hash convert --hash-algo sha256 --to sri "$src_hash")
+echo "  srcHash: $src_sri"
+
+jq -n \
+  --arg v "$latest_version" \
+  --arg r "$latest_rev" \
+  --arg s "$src_sri" \
+  '{version: $v, rev: $r, srcHash: $s}' > "$HASHES_FILE"
+
+echo "Updated to $latest_version"

--- a/.flox/pkgs/skills-okf/upgrade.sh
+++ b/.flox/pkgs/skills-okf/upgrade.sh
@@ -10,25 +10,49 @@ REPO="scaccogatto/okf-skills"
 current_rev=$(jq -r '.rev' "$HASHES_FILE")
 current_version=$(jq -r '.version' "$HASHES_FILE")
 
+# Authenticated API calls use Actions' 5000/hr quota. The
+# unauthenticated 60/hr is shared per egress IP and gets exhausted
+# by parallel runners, surfacing as `curl exit 22`.
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
 # Upstream's release tags (`okf--vX.Y.Z`) lag the plugin: `main` carried
 # 0.6.0 while the newest tag was okf--v0.4.0. Track the branch head and
 # take the version from the plugin manifest at that commit.
-latest_rev=$(curl -sf \
-  "https://api.github.com/repos/${REPO}/commits/main" | jq -r '.sha')
+commit_json=$(curl -sfL --retry 3 --retry-delay 5 \
+  -H "Accept: application/vnd.github+json" \
+  "${auth_header[@]}" \
+  "https://api.github.com/repos/${REPO}/commits/main")
+latest_rev=$(echo "$commit_json" | jq -r '.sha')
 
 if [ -z "$latest_rev" ] || [ "$latest_rev" = "null" ]; then
   echo "Failed to resolve main" >&2
   exit 1
 fi
 
-latest_version=$(curl -sf \
+short_sha="${latest_rev:0:7}"
+
+# Committer date (YYYY-MM-DD), taken from the commits/main response
+# already fetched above rather than spending a second API call on it.
+commit_date=$(echo "$commit_json" \
+  | jq -r '.commit.committer.date' | cut -c1-10)
+
+plugin_version=$(curl -sfL --retry 3 --retry-delay 5 \
+  "${auth_header[@]}" \
   "https://raw.githubusercontent.com/${REPO}/${latest_rev}/.claude-plugin/plugin.json" \
   | jq -r '.version')
 
-if [ -z "$latest_version" ] || [ "$latest_version" = "null" ]; then
+if [ -z "$plugin_version" ] || [ "$plugin_version" = "null" ]; then
   echo "Failed to resolve version" >&2
   exit 1
 fi
+
+# Upstream lands commits on main without always bumping plugin.json, so
+# a bare semver would let the unattended workflow republish the same
+# version tag over different content. Compose the recorded version with
+# the commit date and short SHA so every rev gets a distinct version.
+latest_version="${plugin_version}+unstable-${commit_date}.${short_sha}"
 
 echo "Current: $current_version ($current_rev)"
 echo "Latest:  $latest_version ($latest_rev)"

--- a/.flox/pkgs/skills-okf/upgrade.sh
+++ b/.flox/pkgs/skills-okf/upgrade.sh
@@ -25,6 +25,11 @@ latest_version=$(curl -sf \
   "https://raw.githubusercontent.com/${REPO}/${latest_rev}/.claude-plugin/plugin.json" \
   | jq -r '.version')
 
+if [ -z "$latest_version" ] || [ "$latest_version" = "null" ]; then
+  echo "Failed to resolve version" >&2
+  exit 1
+fi
+
 echo "Current: $current_version ($current_rev)"
 echo "Latest:  $latest_version ($latest_rev)"
 


### PR DESCRIPTION
Packages [scaccogatto/okf-skills](https://github.com/scaccogatto/okf-skills)
as the custom package `skills-okf` — the Open Knowledge Format plugin
(`okf`, `validate`, `visualize` skills) for Claude Code, Codex, pi, and
opencode.

## Why it needed more than a copy

Upstream drives its three Python skills through `uv run "${CLAUDE_SKILL_DIR}/scripts/…"`,
with a `python3 -m pip install --quiet pyyaml` fallback. Neither works under
Flox: `uv` may not be installed, a system `python3` is not guaranteed, and a
runtime `pip install` into an immutable store is meaningless.

So every interpreter and script reference in shipped content is now an
absolute `/nix/store/…` path:

- **Scripts live once**, at `$out/libexec/okf/<skill>/`, outside `$out/share`.
  `flox_agent_layout` fans the plugin out into four per-agent trees; keeping
  `scripts/` inside the skill dirs would have produced four duplicates and
  forced `SKILL.md` to name one arbitrary copy. Shebangs point at a
  `python3.withPackages [ pyyaml ]` interpreter — no wrapper needed, the
  scripts shell out to nothing.
- **`SKILL.md` invocations are rewritten** to `<store python3> <store script>`
  via `substituteInPlace --replace-fail`, so an upstream rewording fails the
  build instead of silently shipping a `uv`-dependent skill. The dead
  "if `uv` is unavailable, fall back to" blocks are collapsed.
- **`okf_init.py`'s success hint** was resolving its validator with
  `parents[2]`, correct only in upstream's layout — in ours it printed a
  `uv run` command at a path that does not exist. Now rewritten to the real
  libexec path and the bundled interpreter.
- **A build-time gate** fails the build if `uv run`, `pip install`, or
  `CLAUDE_SKILL_DIR` survives in any shipped `SKILL.md` or script.

## Verification

`checkPhase` runs upstream's own 52-test suite plus three smoke runs under
the bundled interpreter: `validate --strict` on the sample bundle, an
init→validate round trip, and a `visualize` render asserting non-empty HTML.
Skipped on `x86_64-darwin`, where emulated check phases have hung past the
1800s silence timeout on the aarch64 runners.

Verified locally: builds clean, all three scripts run under `env -i PATH=`,
no `$out/bin`, and `$out/share` holds only `flox/`.

## Version tracking

Upstream's release tags lag its plugin (newest tag `okf--v0.4.0`, while `main`
carries `0.6.0`), so `upgrade.sh` pins the branch head and composes
`0.6.0+unstable-<date>.<sha>` — the house pattern for branch-head packages —
so an upstream push without a manifest bump can't republish the same version
with different content. It uses `GITHUB_TOKEN` with retries and guards both
API fields against null.

License is declared `MIT AND Apache-2.0`: upstream vendors Google's
Apache-2.0 OKF spec as `skills/okf/reference/SPEC.md`.
