### PR TITLE
ci: bump `configure-nix-action` pin to the `node24` runtime

### DIFF
--- a/.github/workflows/ci_pkgs.yml
+++ b/.github/workflows/ci_pkgs.yml
@@ -193,7 +193,7 @@ jobs:
           timeout: "30s"
           use-cache: true
       - name: "Configure Nix remote builders + private cache"
-        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
+        uses: "flox/configure-nix-action@28a4eb7f63bf54c91670b4a698f0a9ebfb95384f" # main
         with:
           ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
           remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
@@ -245,7 +245,7 @@ jobs:
           timeout: "30s"
           use-cache: true
       - name: "Configure Nix remote builders + private cache"
-        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
+        uses: "flox/configure-nix-action@28a4eb7f63bf54c91670b4a698f0a9ebfb95384f" # main
         with:
           ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
           remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
@@ -297,7 +297,7 @@ jobs:
           timeout: "30s"
           use-cache: true
       - name: "Configure Nix remote builders + private cache"
-        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
+        uses: "flox/configure-nix-action@28a4eb7f63bf54c91670b4a698f0a9ebfb95384f" # main
         with:
           ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
           remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
@@ -349,7 +349,7 @@ jobs:
           timeout: "30s"
           use-cache: true
       - name: "Configure Nix remote builders + private cache"
-        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
+        uses: "flox/configure-nix-action@28a4eb7f63bf54c91670b4a698f0a9ebfb95384f" # main
         with:
           ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
           remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
@@ -555,7 +555,7 @@ jobs:
           timeout: "30s"
           use-cache: true
       - name: "Configure Nix remote builders + private cache"
-        uses: "flox/configure-nix-action@1ee58d63463cb1870ab73d9df0acfd9d8ba671f8" # main
+        uses: "flox/configure-nix-action@28a4eb7f63bf54c91670b4a698f0a9ebfb95384f" # main
         with:
           ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
           remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"


### PR DESCRIPTION
## Summary

`flox/configure-nix-action` now declares the Node 24 action runtime (flox/configure-nix-action#45): Node 20 reached end-of-life in April 2026 and GitHub removes it from Actions runners in fall 2026, so workflows consuming the action at an older pin emit a deprecation warning on every run. This advances the pin to the current head of the action's `main` (flox/configure-nix-action@28a4eb7f63bf54c91670b4a698f0a9ebfb95384f), silencing the warning and picking up the action's routine maintenance along the way. No workflow changes are needed beyond the pin; the action's bundled behavior is unchanged.

Part of [ECO-191](https://linear.app/floxdotdev/issue/ECO-191/migrate-configure-nix-action-to-the-node24-runtime).

### Test plan

- [ ] CI passes on this PR (the updated action runs in this repo's own workflows)