### PR TITLE
ci: pre-warm .website env closure for fragment audits

### DIFF
--- a/.github/workflows/ci_pkgs.yml
+++ b/.github/workflows/ci_pkgs.yml
@@ -377,8 +377,45 @@ jobs:
       # Audit only skills-* packages (the Claude Code skill/plugin
       # fragments) — gated here at the step level since matrix.package is
       # known. Everything else is built/published, not audited.
+      #
+      # The audit shell activates the .website env; during the nightly
+      # floxbot PR wave dozens of runs used to do that activation against
+      # the catalog/R2 cache simultaneously, some stalled on substitution
+      # and nix silently fell back to building the env from source on the
+      # 2-core runner until the 90-minute job timeout. Restore the
+      # pre-warmed closure (warm_website_env.yml, nightly on main) into a
+      # local file:// binary cache and substitute from it instead.
+      - name: "Restore pre-warmed .website env cache"
+        id: "website-cache"
+        if: ${{ startsWith(matrix.package, 'skills-') }}
+        uses: "actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.1.0
+        with:
+          path: "_website_nix_cache"
+          key: "website-env-x86_64-linux-${{ hashFiles('.website/.flox/env/manifest.lock') }}"
+      - name: "Seed empty .website env cache on restore miss"
+        if: ${{ startsWith(matrix.package, 'skills-') && steps.website-cache.outputs.cache-hit != 'true' }}
+        # A valid-but-empty local binary cache keeps the
+        # extra-substituters entry harmless when the warm cache is
+        # missing (first run after a lockfile bump): nix just finds no
+        # paths there and falls through to the normal substituters.
+        run: |
+          set -euo pipefail
+          mkdir -p _website_nix_cache
+          echo "StoreDir: /nix/store" > _website_nix_cache/nix-cache-info
       - name: "Audit fragment content"
         if: ${{ startsWith(matrix.package, 'skills-') }}
+        # Fail fast instead of stalling to the 90-minute job timeout when
+        # the env still cannot be substituted — reruns are cheap, silent
+        # 90-minute hangs are not.
+        timeout-minutes: 20
+        env:
+          # Overrides the workflow-level NIX_CONFIG for this step, so
+          # repeat `fallback = true` here. The file:// cache is signed
+          # with the same key as the private R2 cache, which
+          # configure-nix-action already trusts.
+          NIX_CONFIG: |
+            fallback = true
+            extra-substituters = file://${{ github.workspace }}/_website_nix_cache
         # Fragments are content-audited from the build above; run-audit.sh
         # reuses result-<pkg> and runs the flox-ai audit engine. The
         # flox-ai + skill-audit tools live in the .website env (NOT the

--- a/.github/workflows/warm_website_env.yml
+++ b/.github/workflows/warm_website_env.yml
@@ -1,0 +1,85 @@
+name: "Warm .website env cache"
+
+# Pre-warms the x86_64-linux closure of the .website flox env into a
+# local file:// binary cache stored in the Actions cache. The per-PR
+# "Audit fragment content" step in ci_pkgs.yml restores this cache and
+# substitutes from it, so the nightly floxbot PR wave (~40 parallel
+# runs) no longer hammers the catalog/R2 cache with simultaneous
+# `flox activate -d .website` activations — the exact overload that
+# made activations stall silently until the 90-minute job timeout.
+#
+# Runs on main so the produced Actions cache entry is visible to every
+# PR branch (caches created on PR branches are branch-scoped, caches
+# created on the default branch are shared).
+
+on:
+  schedule:
+    # 01:00 UTC — before the nightly floxbot upgrade wave (~01:45 UTC).
+    - cron: "0 1 * * *"
+  push:
+    branches: ["main"]
+    paths:
+      - ".website/.flox/**"
+      - ".github/workflows/warm_website_env.yml"
+  workflow_dispatch: {}
+
+permissions:
+  contents: "read"
+
+env:
+  FLOX_DISABLE_METRICS: "true"
+  NIX_CONFIG: "fallback = true"
+
+jobs:
+  warm:
+    name: "Warm .website env (x86_64-linux)"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 45
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
+      - name: "Look up existing cache"
+        id: "cache"
+        uses: "actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.1.0
+        with:
+          path: "_website_nix_cache"
+          key: "website-env-x86_64-linux-${{ hashFiles('.website/.flox/env/manifest.lock') }}"
+      - name: "Install flox"
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        uses: "flox/install-flox-action@3b80351ae97bbe063f264dc88fbd505507054963" # v2.5.3
+      - name: "Setup Tailscale"
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        uses: "tailscale/github-action@780049a30b6ff5c378a9e7b389d15ece7a204888" # v4.1.3
+        with:
+          oauth-secret: "${{ secrets.MANAGED_TAILSCALE_AUTH_KEY }}"
+          tags: "tag:ci"
+          timeout: "30s"
+          use-cache: true
+      - name: "Configure Nix remote builders + private cache"
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        uses: "flox/configure-nix-action@28a4eb7f63bf54c91670b4a698f0a9ebfb95384f" # main
+        with:
+          ssh-key: "${{ secrets.MANAGED_FLOXBOT_SSH_KEY }}"
+          remote-builders: "${{ vars.MANAGED_REMOTE_BUILDERS }}"
+          substituter: "${{ vars.MANAGED_CACHE_PRIVATE_R2_BUCKET }}"
+          substituter-key: "${{ secrets.MANAGED_CACHE_PRIVATE_SECRET_KEY }}"
+          aws-access-key-id: "${{ secrets.MANAGED_CACHE_PRIVATE_R2_ACCESS_KEY_ID }}"
+          aws-secret-access-key: "${{ secrets.MANAGED_CACHE_PRIVATE_R2_SECRET_ACCESS_KEY }}"
+      - name: "Realize and export the .website env closure"
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+        run: |
+          set -euo pipefail
+          # Activation realizes every store path of the env for this
+          # system (locked manifest — no resolution, only substitution).
+          flox activate -d .website -- true
+          # The rendered env lives behind .flox/run/<system>.<name>.<mode>;
+          # `nix copy` exports its full closure into a local file://
+          # binary cache, signed with the same key as the private R2
+          # cache so consumer jobs (which already trust that key via
+          # configure-nix-action) accept the paths.
+          run_link="$(readlink -f .website/.flox/run/x86_64-linux.*)"
+          echo "env store path: $run_link"
+          nix --extra-experimental-features nix-command \
+            copy --to "file://$PWD/_website_nix_cache?secret-key=/tmp/secret-key&compression=zstd" \
+            "$run_link"
+          du -sh _website_nix_cache


### PR DESCRIPTION
## Problem

During the nightly floxbot upgrade wave (~01:45 UTC) dozens of `CI Packages` runs execute `Audit fragment content` (x86_64-linux) at the same time. Each one activates the `.website` env against the catalog/R2 cache; under that load some substitutions stall, nix silently falls back to **building the env from source** on the 2-core runner, and the step hangs with zero output until the 90-minute job timeout cancels the run — which fails the `Summary` gate. An off-peak rerun always passes (healthy activation: ~17s).

## Fix

- **`warm_website_env.yml` (new):** nightly at 01:00 UTC (before the wave), on `.website` lockfile changes, and on dispatch — realizes the env once on `main` and exports its closure via `nix copy` into a `file://` binary cache stored in the Actions cache, signed with the same key as the private R2 cache. Running on `main` makes the cache entry restorable from every PR branch.
- **`ci_pkgs.yml`:** the audit step restores that cache and adds it as `extra-substituters`, so the wave's activations substitute locally instead of 40 parallel catalog hits. On restore miss a valid-empty cache is seeded so the substituter entry is harmless. `timeout-minutes: 20` on the step turns any remaining stall into a fast, rerunnable failure instead of a silent 90-minute hang.

## Notes

- Non-`skills-*` packages and other platform legs untouched.
- First run after a `.website` lockfile bump misses the cache until the next warm run; the step then behaves exactly as today, just bounded by the 20-minute timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)