### PR TITLE
ci: bound .website env activation in fragment audit with 60s retries

### DIFF
--- a/.github/workflows/ci_pkgs.yml
+++ b/.github/workflows/ci_pkgs.yml
@@ -379,15 +379,35 @@ jobs:
       # known. Everything else is built/published, not audited.
       - name: "Audit fragment content"
         if: ${{ startsWith(matrix.package, 'skills-') }}
+        # Backstop for the audit run itself once the env is realized.
+        timeout-minutes: 20
         # Fragments are content-audited from the build above; run-audit.sh
         # reuses result-<pkg> and runs the flox-ai audit engine. The
         # flox-ai + skill-audit tools live in the .website env (NOT the
         # root env — they're floxenvs-flake-sourced and would poison
         # `flox build`'s nixpkgs resolution).
-        shell: "flox activate -d .website -- bash -e {0}"
         run: |
           set -euo pipefail
-          REPO_ROOT="$PWD" bash scripts/run-audit.sh skill "${{ matrix.package }}"
+          # Realizing the .website env normally takes ~17s, but under
+          # load (the nightly bot PR wave) substitution sometimes stalls
+          # with zero output until the 90-minute job timeout. Health-check
+          # the activation with a hard 60s bound, three attempts — a
+          # stall now costs 3 minutes and a clear error, not 90 silent
+          # ones.
+          ok=""
+          for attempt in 1 2 3; do
+            if timeout 60 flox activate -d .website -- true; then
+              ok=1
+              break
+            fi
+            echo "::warning::.website env activation attempt $attempt did not finish within 60s"
+          done
+          if [ -z "$ok" ]; then
+            echo "::error::.website env activation failed 3 times (60s each) — substitution stalled; rerun the job"
+            exit 1
+          fi
+          flox activate -d .website -- bash -e -c \
+            'REPO_ROOT="$PWD" bash scripts/run-audit.sh skill "${{ matrix.package }}"'
       - name: "Upload fragment metrics"
         if: ${{ startsWith(matrix.package, 'skills-') }}
         uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7


### PR DESCRIPTION
## Problem

`Audit fragment content` (x86_64-linux) starts with `flox activate -d .website`. A healthy activation takes ~17s, but under load (nightly floxbot PR wave) substitution sometimes stalls with zero output until the 90-minute job timeout cancels the run — failing the `Summary` gate. A manual rerun always passes.

## Fix

Health-check the activation before running the audit:

- hard **60-second bound** per attempt (`timeout 60 flox activate -d .website -- true`)
- **3 attempts**, warning annotation per timeout
- clear `::error::` + fail after the third — worst case is **3 minutes** and a rerunnable red check instead of a silent 90-minute hang

The audit itself then runs in the already-realized env (store paths cached locally, second activation is instant), with `timeout-minutes: 20` on the step as backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)