### PR TITLE
fix(skillspector): expose only bin/skillspector, not the venv

### DIFF
--- a/.flox/pkgs/skillspector/default.nix
+++ b/.flox/pkgs/skillspector/default.nix
@@ -3,6 +3,8 @@
   python313,
   callPackage,
   yara,
+  runCommand,
+  makeBinaryWrapper,
 }:
 
 let
@@ -79,24 +81,36 @@ let
 
   venv = pythonSet.mkVirtualEnv "skillspector-env" workspace.deps.default;
 
-in
-venv.overrideAttrs (old: {
-  pname = "skillspector";
   version = (lib.importJSON ./hashes.json).version;
 
-  passthru = (old.passthru or { }) // {
-    python = python313;
-  };
+in
+# Expose ONLY bin/skillspector. Installing the venv itself would put its
+# bin/python{,3,3.13} symlinks on $FLOX_ENV/bin and collide with an
+# env-level python3 (the coexist check guards exactly this).
+runCommand "skillspector-${version}"
+  {
+    pname = "skillspector";
+    inherit version;
+    nativeBuildInputs = [ makeBinaryWrapper ];
 
-  meta = {
-    description = "Security scanner for AI agent skills";
-    homepage = "https://github.com/NVIDIA/SkillSpector";
-    license = lib.licenses.asl20;
-    mainProgram = "skillspector";
-    platforms = [
-      "aarch64-darwin"
-      "aarch64-linux"
-      "x86_64-linux"
-    ];
-  };
-})
+    passthru = {
+      inherit venv;
+      python = python313;
+    };
+
+    meta = {
+      description = "Security scanner for AI agent skills";
+      homepage = "https://github.com/NVIDIA/SkillSpector";
+      license = lib.licenses.asl20;
+      mainProgram = "skillspector";
+      platforms = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+    };
+  }
+  ''
+    mkdir -p $out/bin
+    makeBinaryWrapper ${venv}/bin/skillspector $out/bin/skillspector
+  ''


### PR DESCRIPTION
Fixes the coexist-check failure on main ([run](https://github.com/flox/floxenvs/actions/runs/31499327176/job/93806039498)):

```
'skillspector-env' conflicts with 'python3'. Both packages provide the file 'bin/python'
```

The package output was the whole uv2nix virtualenv, so its `bin/python{,3,3.13}` symlinks landed on `$FLOX_ENV/bin` and collided with the env-level `python3` that the coexist check installs.

Now the output is a `makeBinaryWrapper` around the venv's `bin/skillspector` — the venv stays in the store as a dependency, and only `bin/skillspector` is exposed.

Verified locally (aarch64-darwin): `flox build skillspector` → `result-skillspector/bin/` contains only `skillspector`, and `skillspector --version` prints `SkillSpector v2.9.2`.