### PR TITLE
fix(upgrade): authenticate GitHub API calls in uv2nix-family upgrade scripts

### DIFF
--- a/.flox/pkgs/pyproject-build-systems/upgrade.sh
+++ b/.flox/pkgs/pyproject-build-systems/upgrade.sh
@@ -6,7 +6,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HASHES_FILE="$SCRIPT_DIR/hashes.json"
 
 current_rev=$(jq -r '.rev // empty' "$HASHES_FILE")
-latest_rev=$(curl -sfL "https://api.github.com/repos/pyproject-nix/build-system-pkgs/commits/HEAD" \
+
+# Authenticate when a token is available — unauthenticated api.github.com
+# calls share the runner IP's 60/h budget and get rate-limited (curl -f
+# exits 22 before any error output under set -e).
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
+latest_rev=$(curl -sfL "${auth_header[@]}" \
+  "https://api.github.com/repos/pyproject-nix/build-system-pkgs/commits/HEAD" \
   | jq -r '.sha')
 
 if [ -z "$latest_rev" ] || [ "$latest_rev" = "null" ]; then

--- a/.flox/pkgs/pyproject-nix/upgrade.sh
+++ b/.flox/pkgs/pyproject-nix/upgrade.sh
@@ -6,7 +6,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HASHES_FILE="$SCRIPT_DIR/hashes.json"
 
 current_rev=$(jq -r '.rev // empty' "$HASHES_FILE")
-latest_rev=$(curl -sfL "https://api.github.com/repos/pyproject-nix/pyproject.nix/commits/HEAD" \
+# Authenticate when a token is available — unauthenticated api.github.com
+# calls share the runner IP's 60/h budget and get rate-limited (curl -f
+# exits 22 before any error output under set -e).
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
+latest_rev=$(curl -sfL "${auth_header[@]}" \
+  "https://api.github.com/repos/pyproject-nix/pyproject.nix/commits/HEAD" \
   | jq -r '.sha')
 
 if [ -z "$latest_rev" ] || [ "$latest_rev" = "null" ]; then

--- a/.flox/pkgs/uv2nix/upgrade.sh
+++ b/.flox/pkgs/uv2nix/upgrade.sh
@@ -6,7 +6,15 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HASHES_FILE="$SCRIPT_DIR/hashes.json"
 
 current_rev=$(jq -r '.rev // empty' "$HASHES_FILE")
-latest_rev=$(curl -sfL "https://api.github.com/repos/pyproject-nix/uv2nix/commits/HEAD" \
+# Authenticate when a token is available — unauthenticated api.github.com
+# calls share the runner IP's 60/h budget and get rate-limited (curl -f
+# exits 22 before any error output under set -e).
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
+latest_rev=$(curl -sfL "${auth_header[@]}" \
+  "https://api.github.com/repos/pyproject-nix/uv2nix/commits/HEAD" \
   | jq -r '.sha')
 
 if [ -z "$latest_rev" ] || [ "$latest_rev" = "null" ]; then


### PR DESCRIPTION
Fixes the [Upgrade Packages failure](https://github.com/flox/floxenvs/actions/runs/31674043033): the `pyproject-build-systems` job exited with bare code 22.

## Root cause

`upgrade.sh` fetches `api.github.com/repos/.../commits/HEAD` with unauthenticated curl. All jobs on a runner IP share GitHub's 60/h unauthenticated budget, so the scheduled wave gets rate-limited (HTTP 403 → `curl -f` exit 22), and `set -euo pipefail` kills the script before its own error message prints.

## Fix

Send `Authorization: Bearer $GITHUB_TOKEN` (already exported by the workflow) when the token is present — the same pattern the 14 token-aware upgrade scripts already use. Applied to the failing script and its two identical siblings `pyproject-nix` and `uv2nix`.

All three verified locally with a token: exit 0 (uv2nix's run confirmed it also detects a pending upstream bump; the bump itself is left to the bot).

## Note on the Upgrade Environments failures

The [hermes/symphony env-upgrade failures](https://github.com/flox/floxenvs/actions/runs/31345460656) (`no substituter that can build .../hermes-agent-env`) are the known missing-catalog-artifact pattern, resolved by yesterday's full-fleet republish — no code change needed. Validation dispatches: [hermes](https://github.com/flox/floxenvs/actions/runs/31690815443), [symphony](https://github.com/flox/floxenvs/actions/runs/31690818290).

Remaining exposure (follow-up, not this PR): 86 of 100 upgrade scripts hitting api.github.com still run unauthenticated.