### PR TITLE
fix(upgrade): authenticate GitHub API calls in 3 more upgrade scripts

### DIFF
--- a/.flox/pkgs/opencode/upgrade.sh
+++ b/.flox/pkgs/opencode/upgrade.sh
@@ -6,7 +6,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HASHES_FILE="$SCRIPT_DIR/hashes.json"
 
 current_version=$(jq -r '.version' "$HASHES_FILE")
-latest_version=$(curl -sfL "https://api.github.com/repos/anomalyco/opencode/releases/latest" | jq -r '.tag_name' | sed 's/^v//')
+
+# Authenticate when a token is available: the shared unauthenticated
+# 60/hr GitHub API quota per egress IP gets exhausted by parallel
+# runners, surfacing as `curl exit 22`.
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
+latest_version=$(curl -sfL --retry 3 --retry-delay 5 \
+  -H "Accept: application/vnd.github+json" \
+  "${auth_header[@]}" \
+  "https://api.github.com/repos/anomalyco/opencode/releases/latest" \
+  | jq -r '.tag_name' | sed 's/^v//')
 
 echo "Current: $current_version, Latest: $latest_version"
 

--- a/.flox/pkgs/skillcheck/upgrade.sh
+++ b/.flox/pkgs/skillcheck/upgrade.sh
@@ -12,12 +12,21 @@ FAKE_HASH="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
 
 current_rev=$(jq -r '.rev' "$HASHES_FILE")
 
+# Authenticate when a token is available: the shared unauthenticated
+# 60/hr GitHub API quota per egress IP gets exhausted by parallel
+# runners, surfacing as `curl exit 22`.
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
 # Upstream ships no tags/releases, so track the latest commit on the
 # default branch and read the version from its package.json.
-latest_rev=$(curl -sfL \
+latest_rev=$(curl -sfL --retry 3 --retry-delay 5 \
+  -H "Accept: application/vnd.github+json" \
+  "${auth_header[@]}" \
   "https://api.github.com/repos/${OWNER}/${REPO}/commits/${BRANCH}" \
   | jq -r '.sha')
-latest_version=$(curl -sfL \
+latest_version=$(curl -sfL --retry 3 --retry-delay 5 \
   "https://raw.githubusercontent.com/${OWNER}/${REPO}/${latest_rev}/package.json" \
   | jq -r '.version')
 

--- a/.flox/pkgs/skills-anthropic-claude-code-setup/upgrade.sh
+++ b/.flox/pkgs/skills-anthropic-claude-code-setup/upgrade.sh
@@ -21,8 +21,16 @@ fi
 
 short_sha="${rev:0:7}"
 
-commit_json=$(curl -sfL \
+# Authenticate when a token is available: the shared unauthenticated
+# 60/hr GitHub API quota per egress IP gets exhausted by parallel
+# runners, surfacing as `curl exit 22`.
+auth_header=()
+[ -n "${GITHUB_TOKEN:-}" ] \
+  && auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+
+commit_json=$(curl -sfL --retry 3 --retry-delay 5 \
   -H "Accept: application/vnd.github+json" \
+  "${auth_header[@]}" \
   "https://api.github.com/repos/$OWNER/$REPO/commits/$rev")
 commit_date=$(echo "$commit_json" \
   | jq -r '.commit.committer.date' \


### PR DESCRIPTION
opencode, skillcheck, and skills-anthropic-claude-code-setup failed in the
scheduled Upgrade Packages run (32072532886) with bare `curl exit 22` —
the shared unauthenticated 60/hr GitHub API quota per egress IP gets
exhausted by parallel runners.

Adds the `GITHUB_TOKEN` auth_header + retry pattern from #9718 to all
three scripts. Verified locally: all resolve versions correctly.