### PR TITLE
ci: move CI to Blacksmith runners with persistent /nix sticky disks

### DIFF
--- a/.flox/pkgs/cclint/default.nix
+++ b/.flox/pkgs/cclint/default.nix
@@ -44,3 +44,5 @@ buildNpmPackage {
     platforms = lib.platforms.unix;
   };
 }
+
+# CI touch: exercise Blacksmith stickydisk build path (PR #10818).

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  # Blacksmith (https://docs.blacksmith.sh/blacksmith-runners/overview)
+  labels:
+    - "blacksmith-2vcpu-ubuntu-2404"
+    - "blacksmith-4vcpu-ubuntu-2404"
+    - "blacksmith-4vcpu-ubuntu-2404-arm"
+    - "blacksmith-6vcpu-macos-latest"

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   add-label:
-    runs-on: ubuntu-latest
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     permissions:
       pull-requests: write
       issues: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   wait-for-environments:
     name: "Wait Envs"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 120
 
     outputs:
@@ -275,7 +275,7 @@ jobs:
 
   wait-for-packages:
     name: "Wait Pkgs"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 120
 
     outputs:
@@ -449,7 +449,7 @@ jobs:
 
   result:
     name: "Summary"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 5
     needs: ["wait-for-environments", "wait-for-packages"]
     if: always()
@@ -506,7 +506,7 @@ jobs:
 
   auto-merge:
     name: "Auto Merge"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 5
     needs: ["wait-for-environments", "wait-for-packages", "result"]
     if: >-
@@ -529,7 +529,7 @@ jobs:
 
   report-failure:
     name: "Report Failure"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 5
     needs: ["wait-for-environments", "wait-for-packages"]
     if: >-
@@ -561,7 +561,7 @@ jobs:
 
   containerize:
     name: "Containerize '${{ matrix.env }}'"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     timeout-minutes: 30
     needs: ["wait-for-environments", "result"]
     if: >-
@@ -593,7 +593,7 @@ jobs:
           ENV="${{ matrix.env }}"
           LOCK="$ENV/.flox/env/manifest.lock"
 
-          # Containers are built on ubuntu-latest (x86_64-linux). If the
+          # Containers are built on x86_64-linux runners. If the
           # env doesn't support x86_64-linux, skip the containerize job.
           # Empty `systems` in the manifest means "all systems" (default).
           ENV_LINUX=$(jq -r '
@@ -619,6 +619,19 @@ jobs:
 
           echo "env x86_64-linux supported: $ENV_LINUX"
           echo "demo x86_64-linux supported: $DEMO_LINUX"
+
+      - name: "Create Nix store mount point"
+        if: steps.linux_support.outputs.env_linux == 'true' || steps.linux_support.outputs.demo_linux == 'true'
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+
+      - name: "Mount Nix store"
+        if: steps.linux_support.outputs.env_linux == 'true' || steps.linux_support.outputs.demo_linux == 'true'
+        uses: "useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151" # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
 
       - name: "Install flox"
         if: steps.linux_support.outputs.env_linux == 'true' || steps.linux_support.outputs.demo_linux == 'true'

--- a/.github/workflows/ci_devcontainers.yml
+++ b/.github/workflows/ci_devcontainers.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   freshness:
     name: "Check devcontainers are up to date"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     timeout-minutes: 10
     steps:
       - name: "Checkout"

--- a/.github/workflows/ci_envs.yml
+++ b/.github/workflows/ci_envs.yml
@@ -34,7 +34,7 @@ jobs:
 
   discover:
     name: "Discover changed environments"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 5
     outputs:
       environments: "${{ steps.discover.outputs.environments }}"

--- a/.github/workflows/ci_pkgs.yml
+++ b/.github/workflows/ci_pkgs.yml
@@ -57,7 +57,7 @@ jobs:
 
   discover:
     name: "Discover changed packages"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 10
 
     outputs:
@@ -208,7 +208,7 @@ jobs:
 
   aarch64-darwin:
     name: "${{ needs.discover.outputs.is_publish == 'true' && 'Publish' || 'Build' }} '${{ matrix.chunk.id }}' (aarch64-darwin)"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     timeout-minutes: 90
     needs: ["discover"]
     if: needs.discover.outputs.aarch64-darwin != '[]'
@@ -223,6 +223,15 @@ jobs:
         with:
           fetch-depth: 0
           filter: "blob:none"
+      - name: "Create Nix store mount point"
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+      - name: "Mount Nix store"
+        uses: "useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151" # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
       - name: "Install flox"
         uses: "flox/install-flox-action@1128abd73431089ab9d871c893b4e72a729354e1" # v2.6.0
       - name: "Setup Tailscale"
@@ -272,7 +281,7 @@ jobs:
 
   aarch64-linux:
     name: "${{ needs.discover.outputs.is_publish == 'true' && 'Publish' || 'Build' }} '${{ matrix.chunk.id }}' (aarch64-linux)"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     timeout-minutes: 90
     needs: ["discover"]
     if: needs.discover.outputs.aarch64-linux != '[]'
@@ -287,6 +296,15 @@ jobs:
         with:
           fetch-depth: 0
           filter: "blob:none"
+      - name: "Create Nix store mount point"
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+      - name: "Mount Nix store"
+        uses: "useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151" # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
       - name: "Install flox"
         uses: "flox/install-flox-action@1128abd73431089ab9d871c893b4e72a729354e1" # v2.6.0
       - name: "Setup Tailscale"
@@ -336,7 +354,7 @@ jobs:
 
   x86_64-darwin:
     name: "${{ needs.discover.outputs.is_publish == 'true' && 'Publish' || 'Build' }} '${{ matrix.chunk.id }}' (x86_64-darwin)"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     timeout-minutes: 90
     needs: ["discover"]
     if: needs.discover.outputs.x86_64-darwin != '[]'
@@ -351,6 +369,15 @@ jobs:
         with:
           fetch-depth: 0
           filter: "blob:none"
+      - name: "Create Nix store mount point"
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+      - name: "Mount Nix store"
+        uses: "useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151" # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
       - name: "Install flox"
         uses: "flox/install-flox-action@1128abd73431089ab9d871c893b4e72a729354e1" # v2.6.0
       - name: "Setup Tailscale"
@@ -400,7 +427,7 @@ jobs:
 
   x86_64-linux:
     name: "${{ needs.discover.outputs.is_publish == 'true' && 'Publish' || 'Build' }} '${{ matrix.chunk.id }}' (x86_64-linux)"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     timeout-minutes: 90
     needs: ["discover"]
     if: needs.discover.outputs.x86_64-linux != '[]'
@@ -415,6 +442,15 @@ jobs:
         with:
           fetch-depth: 0
           filter: "blob:none"
+      - name: "Create Nix store mount point"
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+      - name: "Mount Nix store"
+        uses: "useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151" # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
       - name: "Install flox"
         uses: "flox/install-flox-action@1128abd73431089ab9d871c893b4e72a729354e1" # v2.6.0
       - name: "Setup Tailscale"
@@ -522,7 +558,7 @@ jobs:
     # even if a leg fails — data.json falls back to prior metrics.
     needs: ["discover", "aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]
     if: always() && needs.discover.result == 'success'
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     timeout-minutes: 30
     # Serialize the site/deploy half (gh-pages) per ref. A single global
     # group means every PR's site job lands in the same queue; GitHub keeps
@@ -544,6 +580,15 @@ jobs:
         uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           fetch-depth: 0
+      - name: "Create Nix store mount point"
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+      - name: "Mount Nix store"
+        uses: "useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151" # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
       - name: "Install flox"
         # Required so the run steps' `flox activate -d .website` works.
         uses: "flox/install-flox-action@1128abd73431089ab9d871c893b4e72a729354e1" # v2.6.0
@@ -661,11 +706,20 @@ jobs:
     name: "All skills + agents + audit tools coexist in one Flox env"
     needs: ["discover", "aarch64-darwin", "aarch64-linux", "x86_64-darwin", "x86_64-linux"]
     if: always() && needs.discover.result == 'success' && needs.discover.outputs.is_publish == 'true'
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     timeout-minutes: 60
     steps:
       - name: "Checkout"
         uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
+      - name: "Create Nix store mount point"
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+      - name: "Mount Nix store"
+        uses: "useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151" # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
       - name: "Install flox"
         uses: "flox/install-flox-action@1128abd73431089ab9d871c893b4e72a729354e1" # v2.6.0
       - name: "Setup Tailscale"

--- a/.github/workflows/ci_pkgs.yml
+++ b/.github/workflows/ci_pkgs.yml
@@ -581,6 +581,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: "Create Nix store mount point"
+        # Explicit plain shell: the job's default shell is
+        # `flox activate`, but flox isn't installed yet here.
+        shell: "bash -e {0}"
         run: |
           sudo mkdir -p /nix/store
           sudo chmod -R 777 /nix

--- a/.github/workflows/environment.yml
+++ b/.github/workflows/environment.yml
@@ -15,7 +15,7 @@ jobs:
 
   discover:
     name: "Discover '${{ inputs.environment }}'"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 5
 
     outputs:
@@ -142,11 +142,11 @@ jobs:
             {
               echo "bootstrap=true"
               echo "matrix={\"system\":[]}"
-              echo "runs_on=ubuntu-latest"
+              echo "runs_on=blacksmith-4vcpu-ubuntu-2404"
               echo "start_services=false"
               echo "has_demo=false"
               echo "demo_matrix={\"system\":[]}"
-              echo "demo_runs_on=ubuntu-latest"
+              echo "demo_runs_on=blacksmith-4vcpu-ubuntu-2404"
               echo "demo_start_services=false"
             } >> "$GITHUB_OUTPUT"
             exit 0
@@ -166,9 +166,9 @@ jobs:
           # Pick a runner whose system is in the lockfile. Prefer Linux
           # (cheaper minutes), fall back to macOS for darwin-only envs.
           RUNS_ON=$(echo "$SYSTEMS" | jq -r '
-            if   index("x86_64-linux")   then "ubuntu-latest"
-            elif index("aarch64-linux")  then "ubuntu-24.04-arm"
-            elif index("aarch64-darwin") then "macos-latest"
+            if   index("x86_64-linux")   then "blacksmith-4vcpu-ubuntu-2404"
+            elif index("aarch64-linux")  then "blacksmith-4vcpu-ubuntu-2404-arm"
+            elif index("aarch64-darwin") then "blacksmith-6vcpu-macos-latest"
             else error("no supported runner for systems: \(.)")
             end
           ')
@@ -200,9 +200,9 @@ jobs:
             DEMO_MATRIX=$(echo "$DEMO_SYSTEMS" | jq -c '{system: .}')
 
             DEMO_RUNS_ON=$(echo "$DEMO_SYSTEMS" | jq -r '
-              if   index("x86_64-linux")   then "ubuntu-latest"
-              elif index("aarch64-linux")  then "ubuntu-24.04-arm"
-              elif index("aarch64-darwin") then "macos-latest"
+              if   index("x86_64-linux")   then "blacksmith-4vcpu-ubuntu-2404"
+              elif index("aarch64-linux")  then "blacksmith-4vcpu-ubuntu-2404-arm"
+              elif index("aarch64-darwin") then "blacksmith-6vcpu-macos-latest"
               else error("no supported runner for systems: \(.)")
               end
             ')
@@ -221,14 +221,14 @@ jobs:
             {
               echo "has_demo=false"
               echo "demo_matrix={\"system\":[]}"
-              echo "demo_runs_on=ubuntu-latest"
+              echo "demo_runs_on=blacksmith-4vcpu-ubuntu-2404"
               echo "demo_start_services=false"
             } >> "$GITHUB_OUTPUT"
           fi
 
   test:
     name: "Test '${{ inputs.environment }}' on '${{ matrix.system }}'"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 60
 
     needs:
@@ -299,7 +299,7 @@ jobs:
 
   test-demo:
     name: "Test '${{ inputs.environment }}-demo' on '${{ matrix.system }}'"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 60
 
     needs:
@@ -387,6 +387,19 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
+
+      - name: "Create Nix store mount point"
+        if: runner.os == 'Linux'
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+
+      - name: "Mount Nix store"
+        if: runner.os == 'Linux'
+        uses: "useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151" # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
 
       - name: "Install flox"
         uses: "flox/install-flox-action@1128abd73431089ab9d871c893b4e72a729354e1" # v2.6.0
@@ -481,6 +494,19 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
+
+      - name: "Create Nix store mount point"
+        if: runner.os == 'Linux'
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+
+      - name: "Mount Nix store"
+        if: runner.os == 'Linux'
+        uses: "useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151" # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
 
       - name: "Install flox"
         uses: "flox/install-flox-action@1128abd73431089ab9d871c893b4e72a729354e1" # v2.6.0

--- a/.github/workflows/invariants.yml
+++ b/.github/workflows/invariants.yml
@@ -16,7 +16,7 @@ jobs:
 
   lockfile-present:
     name: "Every env has manifest.lock"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/upgrade_envs.yml
+++ b/.github/workflows/upgrade_envs.yml
@@ -20,7 +20,7 @@ jobs:
 
   envs:
     name: "Find environments"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 30
 
     outputs:
@@ -60,9 +60,9 @@ jobs:
               | .[]
             ' "$LOCK")"
             runs_on="$(
-              if   echo "$systems" | grep -qx 'x86_64-linux';   then echo "ubuntu-latest"
-              elif echo "$systems" | grep -qx 'aarch64-linux';  then echo "ubuntu-24.04-arm"
-              elif echo "$systems" | grep -qx 'aarch64-darwin'; then echo "macos-latest"
+              if   echo "$systems" | grep -qx 'x86_64-linux';   then echo "blacksmith-4vcpu-ubuntu-2404"
+              elif echo "$systems" | grep -qx 'aarch64-linux';  then echo "blacksmith-4vcpu-ubuntu-2404-arm"
+              elif echo "$systems" | grep -qx 'aarch64-darwin'; then echo "blacksmith-6vcpu-macos-latest"
               else echo "ERROR"; fi
             )"
             if [ "$runs_on" = "ERROR" ]; then
@@ -101,6 +101,19 @@ jobs:
         uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
         with:
           ref: "main"
+
+      - name: "Create Nix store mount point"
+        if: runner.os == 'Linux'
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+
+      - name: "Mount Nix store"
+        if: runner.os == 'Linux'
+        uses: "useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151" # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
 
       - name: "Install flox"
         uses: "flox/install-flox-action@1128abd73431089ab9d871c893b4e72a729354e1" # v2.6.0

--- a/.github/workflows/upgrade_pkgs.yml
+++ b/.github/workflows/upgrade_pkgs.yml
@@ -21,7 +21,7 @@ jobs:
 
   discover:
     name: "Find packages"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-2vcpu-ubuntu-2404"
     timeout-minutes: 10
 
     outputs:
@@ -59,7 +59,7 @@ jobs:
 
   upgrade:
     name: "Upgrade '${{ matrix.package }}'"
-    runs-on: "ubuntu-latest"
+    runs-on: "blacksmith-4vcpu-ubuntu-2404"
     timeout-minutes: 30
     needs: ["discover"]
     if: needs.discover.outputs.packages != '[]'
@@ -73,6 +73,17 @@ jobs:
     steps:
       - name: "Checkout"
         uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
+
+      - name: "Create Nix store mount point"
+        run: |
+          sudo mkdir -p /nix/store
+          sudo chmod -R 777 /nix
+
+      - name: "Mount Nix store"
+        uses: "useblacksmith/stickydisk@74f3f01ab1392726dd6ee06904f0452b0ec1e151" # v1
+        with:
+          key: "${{ github.repository }}-nix-${{ runner.arch }}"
+          path: "/nix"
 
       - name: "Install flox"
         uses: "flox/install-flox-action@1128abd73431089ab9d871c893b4e72a729354e1" # v2.6.0

--- a/scripts/discover-envs.sh
+++ b/scripts/discover-envs.sh
@@ -53,9 +53,9 @@ get_systems() {
 # darwin-only envs. Mirrors environment.yml.
 runner_for_systems() {
   local systems="$1"
-  if   echo "$systems" | grep -qx 'x86_64-linux';   then echo "ubuntu-latest"
-  elif echo "$systems" | grep -qx 'aarch64-linux';  then echo "ubuntu-24.04-arm"
-  elif echo "$systems" | grep -qx 'aarch64-darwin'; then echo "macos-latest"
+  if   echo "$systems" | grep -qx 'x86_64-linux';   then echo "blacksmith-4vcpu-ubuntu-2404"
+  elif echo "$systems" | grep -qx 'aarch64-linux';  then echo "blacksmith-4vcpu-ubuntu-2404-arm"
+  elif echo "$systems" | grep -qx 'aarch64-darwin'; then echo "blacksmith-6vcpu-macos-latest"
   else
     echo "no supported runner for systems: $systems" >&2
     return 1


### PR DESCRIPTION
## What

Moves all CI off GitHub-hosted runners onto [Blacksmith](https://blacksmith.sh) and mounts a persistent `/nix` store via [stickydisk](https://github.com/useblacksmith/stickydisk).

### Runner mapping

| Before | After | Used by |
| ------ | ----- | ------- |
| `ubuntu-latest` (orchestration) | `blacksmith-2vcpu-ubuntu-2404` | waits, discovers, summary, auto-merge, labels, remote-SSH env tests |
| `ubuntu-latest` (build/flox) | `blacksmith-4vcpu-ubuntu-2404` | pkg build legs, site, coexist, containerize, upgrades, devcontainers |
| `ubuntu-24.04-arm` | `blacksmith-4vcpu-ubuntu-2404-arm` | aarch64-linux env jobs |
| `macos-latest` | `blacksmith-6vcpu-macos-latest` | darwin-only env jobs (M4) |

Dynamic selection (`environment.yml` discover, `upgrade_envs.yml`, `scripts/discover-envs.sh`) emits the new labels.

### Nix integration

Jobs doing local Nix work mount a Blacksmith sticky disk (block-level snapshot volume) at `/nix` before `install-flox-action`, so the store survives across runs instead of cold-starting every job. Key: `flox/floxenvs-nix-<arch>` — one warm store per arch. Guarded with `if: runner.os == 'Linux'` where the runner can be macOS (sticky disks are Linux-only).

Skipped for `ci_devcontainers` and the `environment.yml` discover job: they use the DetSys nix-installer, which writes `/nix/receipt.json`; a persisted receipt makes the next install refuse.

### Notes

- stickydisk pinned by commit SHA (v1).
- Added `.github/actionlint.yaml` declaring the Blacksmith labels.
- Sticky disk storage: $0.50/GB/month, auto-evicted after 7 idle days (acts as store GC).
- First run per arch is cold; second run should show a warm `/nix`.