### PR TITLE
fix(codex): build codex-code-mode-host so Code Mode works

### DIFF
--- a/.flox/pkgs/codex/default.nix
+++ b/.flox/pkgs/codex/default.nix
@@ -19,13 +19,38 @@ let
     builtins.fromJSON (builtins.readFile ./hashes.json);
   inherit (versionData) version hash cargoHash;
 
-  # The v8 crate downloads a prebuilt static library at build time.
-  # Fetch it as a fixed-output derivation so the build stays sandboxed.
+  # The v8 crate downloads a prebuilt static library and a matching generated
+  # bindings file at build time. Fetch both as fixed-output derivations so the
+  # build stays sandboxed.
+  #
+  # It must be the POINTER-COMPRESSION + SANDBOX variant: codex-code-mode-host
+  # depends on codex-code-mode-runtime, which takes `v8` with the
+  # `v8_enable_sandbox` feature, and cargo's feature resolution then builds the
+  # whole v8 crate that way. denoland/rusty_v8 publishes no prebuilt artifacts
+  # for that combination (its releases carry only the plain, ptrcomp and
+  # simdutf variants), so upstream builds its own pair from source and
+  # publishes it on the openai/codex release `rusty-v8-v<v8 crate version>`.
+  # Upstream's own builds consume exactly these two files via
+  # RUSTY_V8_ARCHIVE / RUSTY_V8_SRC_BINDING_PATH — see
+  # .github/actions/setup-rusty-v8 in openai/codex.
+  #
+  # `v8_version` is the v8 crate version pinned by codex-rs/Cargo.toml, NOT the
+  # codex version; re-check it on every version bump (see upgrade.sh).
+  rustyV8 = versionData.rusty_v8;
+  rustyV8BaseUrl = "https://github.com/openai/codex/releases/download/rusty-v8-v${rustyV8.v8_version}";
+  rustyV8Target = stdenv.hostPlatform.rust.rustcTarget;
+
   librusty_v8 = fetchurl {
-    name = "librusty_v8-${versionData.librusty_v8.version}";
-    url = "https://github.com/denoland/rusty_v8/releases/download/v${versionData.librusty_v8.version}/librusty_v8_release_${stdenv.hostPlatform.rust.rustcTarget}.a.gz";
-    hash = versionData.librusty_v8.hashes.${stdenv.hostPlatform.system};
+    name = "librusty_v8-${rustyV8.profile}-${rustyV8.v8_version}.a.gz";
+    url = "${rustyV8BaseUrl}/librusty_v8_${rustyV8.profile}_${rustyV8Target}.a.gz";
+    hash = rustyV8.archive_hashes.${stdenv.hostPlatform.system};
     meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+
+  rustyV8SrcBinding = fetchurl {
+    name = "src_binding-${rustyV8.profile}-${rustyV8.v8_version}.rs";
+    url = "${rustyV8BaseUrl}/src_binding_${rustyV8.profile}_${rustyV8Target}.rs";
+    hash = rustyV8.binding_hashes.${stdenv.hostPlatform.system};
   };
 
   # codex-realtime-webrtc pulls in livekit's webrtc-sys on macOS,
@@ -73,9 +98,16 @@ rustPlatform.buildRustPackage {
   # core/agents_md.rs. Paths are relative to codex-rs (the sourceRoot).
   patches = [ ./flox-fragments.patch ];
 
+  # codex-cli alone leaves out the Code Mode host binary. Codex's Code Mode
+  # spawns `codex-code-mode-host` (workspace member code-mode-host) as a child
+  # process for tool execution, so omitting it makes every Code Mode tool call
+  # fail with "failed to spawn code-mode host ...: No such file or directory".
+  # Upstream ships it as its own release asset; build it as a package too.
   cargoBuildFlags = [
     "--package"
     "codex-cli"
+    "--package"
+    "codex-code-mode-host"
   ];
 
   nativeBuildInputs = [
@@ -90,6 +122,7 @@ rustPlatform.buildRustPackage {
 
   env = {
     RUSTY_V8_ARCHIVE = librusty_v8;
+    RUSTY_V8_SRC_BINDING_PATH = rustyV8SrcBinding;
   }
   // lib.optionalAttrs (livekitWebrtc != null) {
     LK_CUSTOM_WEBRTC = livekitWebrtc;

--- a/.flox/pkgs/codex/default.nix
+++ b/.flox/pkgs/codex/default.nix
@@ -34,23 +34,38 @@ let
   # RUSTY_V8_ARCHIVE / RUSTY_V8_SRC_BINDING_PATH — see
   # .github/actions/setup-rusty-v8 in openai/codex.
   #
-  # `v8_version` is the v8 crate version pinned by codex-rs/Cargo.toml, NOT the
-  # codex version; re-check it on every version bump (see upgrade.sh).
-  rustyV8 = versionData.rusty_v8;
-  rustyV8BaseUrl = "https://github.com/openai/codex/releases/download/rusty-v8-v${rustyV8.v8_version}";
+  # Do NOT "simplify" this back to denoland's plain `release` assets. Both
+  # RUSTY_V8_* vars override rusty_v8's own feature-derived asset choice
+  # (build.rs `static_lib_url`), so a plain archive + plain bindings still
+  # link and still build — but the v8 crate's Rust half is compiled with
+  # `v8_enable_sandbox` either way, and that feature gates real API surface
+  # (`array_buffer.rs`, `shared_array_buffer.rs`) as well as V8's heap
+  # layout. nixpkgs' codex derivation does exactly that; it silently ships a
+  # V8 without the sandbox codex asked for. numtide/llm-agents.nix uses these
+  # same openai-published artifacts, with pins identical to ours.
+  #
+  # `librusty_v8.version` is the v8 CRATE version pinned by codex-rs/Cargo.toml,
+  # NOT the codex version; re-check it on every version bump (see upgrade.sh).
+  # The block's key names match numtide's, and are a superset of the
+  # `librusty_v8` block goose-cli keeps in this repo. The base URL is derived
+  # from `version` rather than stored beside it (numtide stores one, but their
+  # update.py regenerates the whole block, while our upgrade.sh preserves it
+  # verbatim — a stored URL with the version inlined would silently desync).
+  rustyV8 = versionData.librusty_v8;
+  rustyV8BaseUrl = "https://github.com/openai/codex/releases/download/rusty-v8-v${rustyV8.version}";
   rustyV8Target = stdenv.hostPlatform.rust.rustcTarget;
 
   librusty_v8 = fetchurl {
-    name = "librusty_v8-${rustyV8.profile}-${rustyV8.v8_version}.a.gz";
+    name = "librusty_v8-${rustyV8.profile}-${rustyV8.version}.a.gz";
     url = "${rustyV8BaseUrl}/librusty_v8_${rustyV8.profile}_${rustyV8Target}.a.gz";
-    hash = rustyV8.archive_hashes.${stdenv.hostPlatform.system};
+    hash = rustyV8.hashes.${stdenv.hostPlatform.system};
     meta.sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
   };
 
   rustyV8SrcBinding = fetchurl {
-    name = "src_binding-${rustyV8.profile}-${rustyV8.v8_version}.rs";
+    name = "src_binding-${rustyV8.profile}-${rustyV8.version}.rs";
     url = "${rustyV8BaseUrl}/src_binding_${rustyV8.profile}_${rustyV8Target}.rs";
-    hash = rustyV8.binding_hashes.${stdenv.hostPlatform.system};
+    hash = rustyV8.srcBindingHashes.${stdenv.hostPlatform.system};
   };
 
   # codex-realtime-webrtc pulls in livekit's webrtc-sys on macOS,
@@ -103,6 +118,8 @@ rustPlatform.buildRustPackage {
   # process for tool execution, so omitting it makes every Code Mode tool call
   # fail with "failed to spawn code-mode host ...: No such file or directory".
   # Upstream ships it as its own release asset; build it as a package too.
+  # nixpkgs (pkgs/by-name/co/codex) and numtide/llm-agents.nix both pass
+  # exactly these two --package flags.
   cargoBuildFlags = [
     "--package"
     "codex-cli"

--- a/.flox/pkgs/codex/hashes.json
+++ b/.flox/pkgs/codex/hashes.json
@@ -2,13 +2,20 @@
   "version": "0.151.0",
   "hash": "sha256-snrzA4W+vLqpPk3MS4xw9SszK1byCKo6ERz3JDgRZdA=",
   "cargoHash": "sha256-r6ox0dUH1OBkD8sQApfANrGbWxKXLv2UNLJZzciJc3I=",
-  "librusty_v8": {
-    "version": "146.4.0",
-    "hashes": {
-      "x86_64-linux": "sha256-5ktNmeSuKTouhGJEqJuAF4uhA4LBP7WRwfppaPUpEVM=",
-      "aarch64-linux": "sha256-2/FlsHyBvbBUvARrQ9I+afz3vMGkwbW0d2mDpxBi7Ng=",
-      "x86_64-darwin": "sha256-YwzSQPG77NsHFBfcGDh6uBz2fFScHFFaC0/Pnrpke7c=",
-      "aarch64-darwin": "sha256-v+LJvjKlbChUbw+WWCXuaPv2BkBfMQzE4XtEilaM+Yo="
+  "rusty_v8": {
+    "v8_version": "150.4.0",
+    "profile": "ptrcomp_sandbox_release",
+    "archive_hashes": {
+      "x86_64-linux": "sha256-o1x10fJuapg4haRbM0kKTr5U8FBQVosyuJz7QhswtYM=",
+      "aarch64-linux": "sha256-0VF+7UBUaFNwKbAF1f6ZfsdNXI01H5FrOm3yC30oEbo=",
+      "x86_64-darwin": "sha256-4Nm7ZOizoDTCkwyDly8/NXYCERSDQvoEB7OCUO8zCFY=",
+      "aarch64-darwin": "sha256-AK27SHmISMd1UEQcaGc6XoUpuOG3PqvN7iMss5tA9KE="
+    },
+    "binding_hashes": {
+      "x86_64-linux": "sha256-dyeCauR5vbZF6Acjn7EtH44uI956bPFvXuWSaQ0dhQY=",
+      "aarch64-linux": "sha256-dyeCauR5vbZF6Acjn7EtH44uI956bPFvXuWSaQ0dhQY=",
+      "x86_64-darwin": "sha256-ylrfDPicmnCtRgrnNkiy/om3SqETs8t/dXtqArdYOU8=",
+      "aarch64-darwin": "sha256-ylrfDPicmnCtRgrnNkiy/om3SqETs8t/dXtqArdYOU8="
     }
   },
   "livekit_webrtc": {

--- a/.flox/pkgs/codex/hashes.json
+++ b/.flox/pkgs/codex/hashes.json
@@ -2,16 +2,16 @@
   "version": "0.151.0",
   "hash": "sha256-snrzA4W+vLqpPk3MS4xw9SszK1byCKo6ERz3JDgRZdA=",
   "cargoHash": "sha256-r6ox0dUH1OBkD8sQApfANrGbWxKXLv2UNLJZzciJc3I=",
-  "rusty_v8": {
-    "v8_version": "150.4.0",
+  "librusty_v8": {
+    "version": "150.4.0",
     "profile": "ptrcomp_sandbox_release",
-    "archive_hashes": {
+    "hashes": {
       "x86_64-linux": "sha256-o1x10fJuapg4haRbM0kKTr5U8FBQVosyuJz7QhswtYM=",
       "aarch64-linux": "sha256-0VF+7UBUaFNwKbAF1f6ZfsdNXI01H5FrOm3yC30oEbo=",
       "x86_64-darwin": "sha256-4Nm7ZOizoDTCkwyDly8/NXYCERSDQvoEB7OCUO8zCFY=",
       "aarch64-darwin": "sha256-AK27SHmISMd1UEQcaGc6XoUpuOG3PqvN7iMss5tA9KE="
     },
-    "binding_hashes": {
+    "srcBindingHashes": {
       "x86_64-linux": "sha256-dyeCauR5vbZF6Acjn7EtH44uI956bPFvXuWSaQ0dhQY=",
       "aarch64-linux": "sha256-dyeCauR5vbZF6Acjn7EtH44uI956bPFvXuWSaQ0dhQY=",
       "x86_64-darwin": "sha256-ylrfDPicmnCtRgrnNkiy/om3SqETs8t/dXtqArdYOU8=",

--- a/.flox/pkgs/codex/upgrade.sh
+++ b/.flox/pkgs/codex/upgrade.sh
@@ -41,8 +41,7 @@ echo "  hash: $src_hash"
 #
 # Read the v8 and livekit hashes (rarely change) so we can rewrite
 # the file with a fake cargoHash without losing them.
-v8_version=$(jq -r '.librusty_v8.version' "$HASHES_FILE")
-v8_hashes=$(jq '.librusty_v8.hashes' "$HASHES_FILE")
+v8_block=$(jq '.rusty_v8' "$HASHES_FILE")
 lk_tag=$(jq -r '.livekit_webrtc.tag' "$HASHES_FILE")
 lk_hashes=$(jq '.livekit_webrtc.hashes' "$HASHES_FILE")
 
@@ -56,15 +55,14 @@ write_hashes() {
     --arg v "$latest_version" \
     --arg h "$src_hash" \
     --arg c "$cargo_hash" \
-    --arg v8v "$v8_version" \
-    --argjson v8h "$v8_hashes" \
+    --argjson v8 "$v8_block" \
     --arg lkt "$lk_tag" \
     --argjson lkh "$lk_hashes" \
     '{
       version: $v,
       hash: $h,
       cargoHash: $c,
-      librusty_v8: { version: $v8v, hashes: $v8h },
+      rusty_v8: $v8,
       livekit_webrtc: { tag: $lkt, hashes: $lkh }
     }' > "$HASHES_FILE"
 }
@@ -95,8 +93,13 @@ rm -f "$tmp_hashes"
 trap - EXIT
 
 echo "Updated to $latest_version"
-echo "NOTE: librusty_v8 and livekit_webrtc hashes were kept as-is."
+echo "NOTE: rusty_v8 and livekit_webrtc hashes were kept as-is."
 echo "      If the build fails, check if those deps changed upstream."
+echo "      rusty_v8.v8_version must match the \`v8\` pin in"
+echo "      codex-rs/Cargo.toml. When it moves, refresh the block from"
+echo "      https://github.com/openai/codex/releases/tag/rusty-v8-v<ver>"
+echo "      — the .sha256 asset for each target lists both files' digests"
+echo "      (nix hash convert --hash-algo sha256 --from base16 --to sri)."
 echo "WARNING: flox-fragments.patch must be re-verified against the new"
 echo "         version. It targets core-skills/src/loader.rs and"
 echo "         core/src/agents_md.rs. If 'flox build codex' fails on the"

--- a/.flox/pkgs/codex/upgrade.sh
+++ b/.flox/pkgs/codex/upgrade.sh
@@ -41,7 +41,7 @@ echo "  hash: $src_hash"
 #
 # Read the v8 and livekit hashes (rarely change) so we can rewrite
 # the file with a fake cargoHash without losing them.
-v8_block=$(jq '.rusty_v8' "$HASHES_FILE")
+v8_block=$(jq '.librusty_v8' "$HASHES_FILE")
 lk_tag=$(jq -r '.livekit_webrtc.tag' "$HASHES_FILE")
 lk_hashes=$(jq '.livekit_webrtc.hashes' "$HASHES_FILE")
 
@@ -62,7 +62,7 @@ write_hashes() {
       version: $v,
       hash: $h,
       cargoHash: $c,
-      rusty_v8: $v8,
+      librusty_v8: $v8,
       livekit_webrtc: { tag: $lkt, hashes: $lkh }
     }' > "$HASHES_FILE"
 }
@@ -93,9 +93,9 @@ rm -f "$tmp_hashes"
 trap - EXIT
 
 echo "Updated to $latest_version"
-echo "NOTE: rusty_v8 and livekit_webrtc hashes were kept as-is."
+echo "NOTE: librusty_v8 and livekit_webrtc hashes were kept as-is."
 echo "      If the build fails, check if those deps changed upstream."
-echo "      rusty_v8.v8_version must match the \`v8\` pin in"
+echo "      librusty_v8.version must match the \`v8\` pin in"
 echo "      codex-rs/Cargo.toml. When it moves, refresh the block from"
 echo "      https://github.com/openai/codex/releases/tag/rusty-v8-v<ver>"
 echo "      — the .sha256 asset for each target lists both files' digests"


### PR DESCRIPTION
## Symptom

Every `flox/codex` install ships without `codex-code-mode-host`, so codex's
**Code Mode** tool-execution feature fails closed on every real tool call:

```
ERROR codex_core::tools::router: error=failed to spawn code-mode host
  /nix/store/…-codex-0.151.0/bin/codex-code-mode-host: No such file or directory (os error 2)
```

What the user sees is the agent declining to do the work:

> I couldn't read `greeting.txt` because the local command host failed to start
> (`codex-code-mode-host` is missing). No file contents were returned.

Reproduced against the currently published build with
`echo "cat greeting.txt and tell me its contents" | codex exec --json --dangerously-bypass-approvals-and-sandbox -C <git repo> -`.
The published store path's `bin/` holds only `codex` and `logs_client`.

## Root cause

`.flox/pkgs/codex/default.nix` asked cargo for one workspace member:

```nix
cargoBuildFlags = [ "--package" "codex-cli" ];
```

Upstream's `codex-rs` keeps the Code Mode host in a separate member,
`codex-rs/code-mode-host` (binary `codex-code-mode-host`), which codex spawns as
a child process for tool execution. Upstream ships it as a first-class release
asset on every platform — `rust-v0.151.0` publishes
`codex-code-mode-host-x86_64-unknown-linux-musl.tar.gz` — and `rust-release.yml`
lists it in the binary set for every bundle. We were simply never building it.

## The fix

Two parts. The first is the one-liner:

```nix
cargoBuildFlags = [ "--package" "codex-cli" "--package" "codex-code-mode-host" ];
```

The second is why that alone does not build. `codex-code-mode-host` depends on
`codex-code-mode-runtime`, which takes `v8` with the `v8_enable_sandbox`
feature, so cargo resolves the `v8` crate to its pointer-compression + sandbox
variant and the build stops at:

```
error: couldn't read …/v8-150.4.0/gen/src_binding_ptrcomp_sandbox_release_x86_64-unknown-linux-gnu.rs
```

denoland/rusty_v8 publishes **no** prebuilt artifacts for that feature
combination — its releases carry only the plain, `ptrcomp` and `simdutf`
variants. Upstream handles this by building the pair from source itself
(`.github/workflows/rusty-v8-release.yml`) and publishing it on the
`openai/codex` release `rusty-v8-v<v8 crate version>`. So the recipe now fetches
those two assets as fixed-output derivations and hands them to the crate's build
script through `RUSTY_V8_ARCHIVE` and `RUSTY_V8_SRC_BINDING_PATH` — exactly what
upstream's own `.github/actions/setup-rusty-v8` does. Hashes are recorded for all
four systems, derived from the `.sha256` manifest upstream publishes per target.

### A stale pin retired along the way

`codex-cli` does not depend on `v8` at all — only `code-mode-runtime` and
`v8-poc` do — so V8 was never compiled here and the existing `librusty_v8` entry
was inert. It had drifted to denoland **146.4.0** while the workspace pins
`v8 = "=150.4.0"`, and would have broken the moment anything actually linked it.
The `librusty_v8` block in `hashes.json` keeps its name and gains a `profile`
plus a second hash set (`srcBindingHashes`) for the bindings file. `upgrade.sh`
now preserves that block as one unit, and its closing note says how to refresh it
when the v8 pin moves.

### Deliberately unchanged

- **`cargoHash`** — it hashes the vendored workspace `Cargo.lock`, which does not
  depend on `cargoBuildFlags`. Confirmed by rebuilding without touching it.
- **`nativeBuildInputs`** — `code-mode-protocol`'s build script uses vendored
  `protoc` and already ran, since `codex-core` depends on `codex-code-mode`
  transitively.
- **`postFixup`** — it wraps `$out/bin/codex` to put bubblewrap on `PATH`; the
  host is spawned as a child process and inherits it.

## Reconciled against the two open-source packagings

Second commit. Both places codex is packaged in the open were read in full
before concluding anything.

**[nixpkgs `pkgs/by-name/co/codex`](https://github.com/NixOS/nixpkgs/tree/master/pkgs/by-name/co/codex)**
(currently 0.149.0) passes *exactly* these two `--package` flags — independent
corroboration that the core fix is right and not a local theory.

It resolves the V8 half differently, and I don't think we should copy it. It
points `RUSTY_V8_ARCHIVE` / `RUSTY_V8_SRC_BINDING_PATH` at denoland's plain
`release` assets, even though `code-mode-runtime` takes `v8` with
`v8_enable_sandbox` — true in 0.149.0 as well, so this isn't a version
difference. Both env vars override rusty_v8's own feature-derived asset choice
(`build.rs` `static_lib_url`), so a plain archive + plain bindings is internally
consistent and *does* link. But the crate's Rust half is still compiled with the
feature, and that feature gates real API surface (`array_buffer.rs`,
`shared_array_buffer.rs` are full of `#[cfg(not(feature = "v8_enable_sandbox"))]`)
on top of changing V8's heap layout. Net effect: a codex that silently ships
without the V8 sandbox it asked for. `default.nix` now carries a note saying so,
so nobody "simplifies" this recipe in that direction later.

**[numtide/llm-agents.nix `packages/codex`](https://github.com/numtide/llm-agents.nix/tree/main/packages/codex)**
is the real sibling — same codex 0.151.0, same `hash`, same `cargoHash`, same
`hashes.json`-driven shape — and it got here first: `codex: also build the
codex-code-mode-host binary` (2026-07-09) and `codex: use openai's rusty_v8
sandbox prebuilts` (2026-08-07). Their pins are **byte-identical** to the ones
this PR landed. Their `update.py` comment states the same reason in almost the
same words.

So the approach needed no change. What did:

### Naming, brought back in line

The first commit renamed the `hashes.json` block to `rusty_v8` with
`v8_version` / `archive_hashes` / `binding_hashes`. That diverges from numtide's
`librusty_v8` with `version` / `profile` / `hashes` / `srcBindingHashes` — *and*
from the `librusty_v8` block `goose-cli` keeps in this repo. Since codex and
goose-cli previously shared one shape, the rename made codex the odd one out
locally while also drifting from upstream. Reverted to the shared names; the
codex block stays a superset, adding `profile` and `srcBindingHashes` that
goose-cli doesn't need.

numtide also stores the fetch `baseUrl` in data. **Not adopted**, deliberately:
their `update.py` regenerates the whole block, while our `upgrade.sh` preserves
it verbatim, so a stored URL with the version inlined would silently desync from
`version` on a hand-edited bump. It stays derived in `default.nix`.

### Pins re-derived from upstream

All eight hashes (archive + bindings x four systems) were re-derived from the
`.sha256` manifests openai publishes per target on `rusty-v8-v150.4.0`. All eight
match what's committed.

### No functional change, and that's verified not asserted

`flox build codex` before and after the second commit both produce
`/nix/store/2ihfwl7jd4zzsw6ycn2w1s5rwa0y1lx7-codex-0.151.0` — the same store
path, so the artifact verified below is bit-for-bit the one this PR ships. The
repro was re-run against it: the tool call completes, `greeting.txt`'s contents
come back, and the JSON stream carries no code-mode error.

## Verification

Build-verified locally on `x86_64-linux` with `flox build codex` (a full Rust +
V8 workspace build), not just reasoned about.

**Output contents** — before, `bin/` held `codex` and `logs_client`. After:

```
codex                    411       (wrapper)
codex-code-mode-host     88029648  (V8 linked)
logs_client              40337032
```

`codex --version` → `codex-cli 0.151.0`; `codex-code-mode-host --help` runs.

**Functional** — the same prompt that reproduced the failure, run against the new
build in the same throwaway git repo: zero code-mode errors anywhere in the JSON
stream, and the tool call actually completes:

> The file contains:
> `hello from the repro file`

<details>
<summary>Asset URLs checked for all four systems</summary>

All eight `rusty-v8-v150.4.0` assets (archive + bindings ×
`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-apple-darwin`,
`aarch64-apple-darwin`) return HTTP 200. Only `x86_64-linux` was actually built;
the other three systems are covered by recorded hashes and CI.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JoVCHYJTJadUNAAPeySwww

