### PR TITLE
fix(agent-browser,openclaw): migrate pnpm deps to fetcherVersion 4

### DIFF
--- a/.flox/pkgs/agent-browser/default.nix
+++ b/.flox/pkgs/agent-browser/default.nix
@@ -56,7 +56,7 @@ let
       inherit version src;
       pnpm = pnpm_11;
       hash = pnpmDepsHash;
-      fetcherVersion = 3;
+      fetcherVersion = 4;
     };
 
     # next/font/google fetches Geist from fonts.googleapis.com at build

--- a/.flox/pkgs/agent-browser/hashes.json
+++ b/.flox/pkgs/agent-browser/hashes.json
@@ -2,5 +2,5 @@
   "version": "0.35.0",
   "srcHash": "sha256-JwFswQgXziHoTXpF/fw3RgiRJdLuSnf+L6XbRoTq7k0=",
   "cargoHash": "sha256-EkcIHRCXVB/BAIKLg7G9Fpmi4dFa9EKKZxv7rMqc1Fk=",
-  "pnpmDepsHash": "sha256-fLhx9/xb8TihIlEQtvZD9YNTOA5pPRFmQ7O28hpOTFA="
+  "pnpmDepsHash": "sha256-uY+Zm/LtNn3+qf4B/p3/nzn5Emj6C7+S8X4q8wr+Ow0="
 }

--- a/.flox/pkgs/openclaw/default.nix
+++ b/.flox/pkgs/openclaw/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation (finalAttrs: {
   pnpmDeps = (fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_11;
-    fetcherVersion = 3;
+    fetcherVersion = 4;
     hash = pnpmDepsHash;
     prePnpmInstall = ''
       export pnpm_config_side_effects_cache=false

--- a/.flox/pkgs/openclaw/hashes.json
+++ b/.flox/pkgs/openclaw/hashes.json
@@ -1,5 +1,5 @@
 {
   "version": "2026.7.1-2",
   "hash": "sha256-kpiKCTjXX4l525IJDNsnI7j2IT6ZYdqvFTyRlKGgomg=",
-  "pnpmDepsHash": "sha256-208RwaPxRckbe6nUzEO1fOXqGIJE9JkAvuMwbo7+xpw="
+  "pnpmDepsHash": "sha256-/ou2Hoix9m/be6kq4Osg4gTTQQRTkL5uLOuERmevuQ0="
 }


### PR DESCRIPTION
## Problem

The nightly **Upgrade Packages** workflow fails for `agent-browser` and
`openclaw` ([run 33476664780](https://github.com/flox/floxenvs/actions/runs/33476664780)):

```
error: fetchPnpmDeps `fetcherVersion = 3` is no longer supported for
`pnpm_11`. Please upgrade to the latest, see
https://nixos.org/manual/nixpkgs/stable/#javascript-pnpm-fetcherVersion.
```

Nixpkgs added an assertion rejecting `fetcherVersion = 3` whenever the
pnpm derivation is 11.0.0 or newer. Both packages build their pnpm store
with `pnpm_11`, so evaluation aborts before the upgrade script can even
extract a hash — the job dies in `Run update script`.

## Fix

Move both packages to `fetcherVersion = 4` (dumps the pnpm SQLite state
to an SQL file instead of building a reproducible tarball) and regenerate
`pnpmDepsHash` for the new fetcher output.

`mcporter` also pins `fetcherVersion = 3`, but it uses `pnpm_10`, which
the assertion does not cover — left unchanged.

## Verification

Both packages build locally on `aarch64-darwin`:

- `flox build agent-browser` → `agent-browser-0.35.0`
- `flox build openclaw` → `openclaw-2026.7.1-2`